### PR TITLE
fix(dashboard,server): warn before Auto mode kills a paused turn, and retire the prompt it strands

### DIFF
--- a/packages/dashboard/src/lib/auto-mode-confirm.test.ts
+++ b/packages/dashboard/src/lib/auto-mode-confirm.test.ts
@@ -1,29 +1,37 @@
+/**
+ * Unit tests for the pure copy-selection helper.
+ *
+ * #7335: these pin the helper only. The `isBusy` input is where the defect
+ * actually lived, so the guard that matters is the CALL-SITE suite in
+ * `store/auto-mode-confirm-busy.test.ts` — every case below passed on the
+ * broken build.
+ */
 import { describe, it, expect } from 'vitest'
 import { buildAutoModeConfirmMessage } from './auto-mode-confirm'
 
 describe('buildAutoModeConfirmMessage (#5609)', () => {
-  it('warns about interrupting the turn when the provider interrupts AND a turn is streaming', () => {
-    const msg = buildAutoModeConfirmMessage({ interruptsTurn: true, isStreaming: true })
+  it('warns about interrupting the turn when the provider interrupts AND the session is busy', () => {
+    const msg = buildAutoModeConfirmMessage({ interruptsTurn: true, isBusy: true })
     expect(msg).toMatch(/INTERRUPT/)
     expect(msg).toMatch(/restart the session/)
     // still explains the bypass consequence
     expect(msg).toMatch(/without asking for permission/)
   })
 
-  it('uses the plain copy when the provider interrupts but no turn is in flight', () => {
-    const msg = buildAutoModeConfirmMessage({ interruptsTurn: true, isStreaming: false })
+  it('uses the plain copy when the provider interrupts but there is no work at risk', () => {
+    const msg = buildAutoModeConfirmMessage({ interruptsTurn: true, isBusy: false })
     expect(msg).not.toMatch(/INTERRUPT/)
     expect(msg).toMatch(/Tools will run without asking for permission/)
   })
 
-  it('uses the plain copy for non-interrupting providers (SDK/TUI) even mid-turn', () => {
-    const msg = buildAutoModeConfirmMessage({ interruptsTurn: false, isStreaming: true })
+  it('uses the plain copy for non-interrupting providers (SDK/TUI) even when busy', () => {
+    const msg = buildAutoModeConfirmMessage({ interruptsTurn: false, isBusy: true })
     expect(msg).not.toMatch(/INTERRUPT/)
     expect(msg).toMatch(/Tools will run without asking for permission/)
   })
 
   it('treats an undefined capability flag as non-interrupting', () => {
-    const msg = buildAutoModeConfirmMessage({ interruptsTurn: undefined, isStreaming: true })
+    const msg = buildAutoModeConfirmMessage({ interruptsTurn: undefined, isBusy: true })
     expect(msg).not.toMatch(/INTERRUPT/)
     expect(msg).toMatch(/Tools will run without asking for permission/)
   })

--- a/packages/dashboard/src/lib/auto-mode-confirm.ts
+++ b/packages/dashboard/src/lib/auto-mode-confirm.ts
@@ -25,11 +25,18 @@ export interface AutoModeConfirmInput {
    */
   interruptsTurn?: boolean
   /**
-   * Whether the active session is currently streaming a response (a turn is in
-   * flight). When false, even a CLI switch has no turn to interrupt, so the
-   * destructive warning is omitted.
+   * Whether the active session has in-flight work the switch would destroy.
+   * When false, even a CLI switch has no turn to interrupt, so the destructive
+   * warning is omitted.
+   *
+   * #7335: this was named `isStreaming`, and the name was the bug — the call
+   * site dutifully fed it `!!streamingMessageId`, which the #554 stream-split
+   * clears the moment a permission prompt arrives, so a session PAUSED on a
+   * prompt looked idle and got benign copy while the CLI respawn dropped its
+   * turn. Callers must source this from `hasInterruptibleWork` (lib/session-busy),
+   * never from the streaming flag alone.
    */
-  isStreaming: boolean
+  isBusy: boolean
 }
 
 const BASE_COPY = 'Switch to Auto mode? Tools will run without asking for permission.'
@@ -48,7 +55,7 @@ const DESTRUCTIVE_COPY =
  * the standard non-destructive copy.
  */
 export function buildAutoModeConfirmMessage(input: AutoModeConfirmInput): string {
-  if (input.interruptsTurn && input.isStreaming) {
+  if (input.interruptsTurn && input.isBusy) {
     return DESTRUCTIVE_COPY
   }
   return BASE_COPY

--- a/packages/dashboard/src/lib/session-busy.test.ts
+++ b/packages/dashboard/src/lib/session-busy.test.ts
@@ -20,6 +20,9 @@ const livePrompt = {
   timestamp: NOW,
   requestId: 'req-1',
   expiresAt: NOW + 60_000,
+  // A live permission prompt always carries its options — that is what makes it
+  // answerable, and `hasInterruptibleWork` keys the "still at risk" test on it.
+  options: ['allow', 'deny'],
 } as unknown as ChatMessage
 
 const idle = { streamingMessageId: null, isIdle: true, messages: [] as ChatMessage[] }
@@ -53,9 +56,25 @@ describe('hasInterruptibleWork (#7335)', () => {
     expect(hasInterruptibleWork(idle, NOW)).toBe(false)
   })
 
-  it('false once the prompt has expired', () => {
+  it('false once the prompt has CLOCK-expired', () => {
     const expired = { ...livePrompt, expiresAt: NOW - 1 } as ChatMessage
     expect(hasInterruptibleWork({ ...idle, messages: [expired] }, NOW)).toBe(false)
+  })
+
+  it('false once the SERVER retired the prompt, even with time left on its clock', () => {
+    // `permission_expired` clears `options` but leaves `answered` unset and
+    // `expiresAt` in the future, so isLivePermissionPrompt still calls this
+    // "live". #7335's server half makes this routine — every auto-switch
+    // expires the open prompt — so without the options filter the dialog would
+    // warn about interrupting a session with nothing in flight.
+    const retired = { ...livePrompt, options: undefined } as ChatMessage
+    expect(hasInterruptibleWork({ ...idle, messages: [retired] }, NOW)).toBe(false)
+  })
+
+  it('a retired prompt does not mask a genuinely busy session', () => {
+    // The options filter must not swallow the busy signal itself.
+    const retired = { ...livePrompt, options: undefined } as ChatMessage
+    expect(hasInterruptibleWork({ streamingMessageId: null, isIdle: false, messages: [retired] }, NOW)).toBe(true)
   })
 
   it('false once the prompt is answered', () => {
@@ -81,9 +100,11 @@ describe('hasInterruptibleWork (#7335)', () => {
   })
 
   it('the two predicates DIFFER on a pending prompt — isSessionBusy must not be widened (#5952)', () => {
-    // If someone "helpfully" folds the pending-permission clause into
-    // isSessionBusy, sendInput starts badging sends "Queued" in a state where
-    // the server would not queue them. This case fails if that happens.
+    // isSessionBusy must keep mirroring the InputBar's own `isStreaming ||
+    // isBusy`. If someone "helpfully" folds the pending-permission clause into
+    // it, the input UI and the optimistic render disagree again — the gap #5952
+    // closed. (NOT because the server would decline to queue such a send: it
+    // would queue it, CliSession.sendMessage gates only on `_isBusy`.)
     const pausedButIdle = { ...idle, messages: [livePrompt] }
     expect(isSessionBusy(pausedButIdle)).toBe(false)
     expect(hasInterruptibleWork(pausedButIdle, NOW)).toBe(true)

--- a/packages/dashboard/src/lib/session-busy.test.ts
+++ b/packages/dashboard/src/lib/session-busy.test.ts
@@ -1,0 +1,91 @@
+/**
+ * #7335 — the shared busy predicates.
+ *
+ * The point of this module is that there is exactly ONE definition of each
+ * question, so these tests pin the DIFFERENCE between the two as much as the
+ * predicates themselves: `isSessionBusy` must stay narrow (it drives an
+ * InputBar-mirroring affordance) while `hasInterruptibleWork` must stay a
+ * strict superset (it drives a destructive-action warning).
+ */
+import { describe, it, expect } from 'vitest'
+import { isSessionBusy, hasInterruptibleWork } from './session-busy'
+import type { ChatMessage } from '@chroxy/store-core'
+
+const NOW = 1_700_000_000_000
+
+const livePrompt = {
+  id: 'p1',
+  type: 'prompt',
+  content: 'Bash: ls',
+  timestamp: NOW,
+  requestId: 'req-1',
+  expiresAt: NOW + 60_000,
+} as unknown as ChatMessage
+
+const idle = { streamingMessageId: null, isIdle: true, messages: [] as ChatMessage[] }
+
+describe('isSessionBusy (#5952 predicate, one copy)', () => {
+  it('is true while streaming', () => {
+    expect(isSessionBusy({ streamingMessageId: 'm1', isIdle: true })).toBe(true)
+  })
+
+  it('is true when the server says not idle, with no stream id yet', () => {
+    expect(isSessionBusy({ streamingMessageId: null, isIdle: false })).toBe(true)
+  })
+
+  it('is false when idle and not streaming', () => {
+    expect(isSessionBusy({ streamingMessageId: null, isIdle: true })).toBe(false)
+  })
+})
+
+describe('hasInterruptibleWork (#7335)', () => {
+  it('THE BUG: true when paused on a permission prompt (split cleared the stream id)', () => {
+    expect(
+      hasInterruptibleWork({ streamingMessageId: null, isIdle: false, messages: [livePrompt] }, NOW),
+    ).toBe(true)
+  })
+
+  it('true on a live prompt alone, even if isIdle is wrongly true', () => {
+    expect(hasInterruptibleWork({ ...idle, messages: [livePrompt] }, NOW)).toBe(true)
+  })
+
+  it('false on a genuinely idle session — the warning is not unconditional', () => {
+    expect(hasInterruptibleWork(idle, NOW)).toBe(false)
+  })
+
+  it('false once the prompt has expired', () => {
+    const expired = { ...livePrompt, expiresAt: NOW - 1 } as ChatMessage
+    expect(hasInterruptibleWork({ ...idle, messages: [expired] }, NOW)).toBe(false)
+  })
+
+  it('false once the prompt is answered', () => {
+    const answered = { ...livePrompt, answered: 'allow' } as ChatMessage
+    expect(hasInterruptibleWork({ ...idle, messages: [answered] }, NOW)).toBe(false)
+  })
+
+  it('ignores an AskUserQuestion prompt (no requestId/expiresAt) — questions are not permissions', () => {
+    const question = { id: 'q1', type: 'prompt', content: 'Which?', timestamp: NOW } as unknown as ChatMessage
+    expect(hasInterruptibleWork({ ...idle, messages: [question] }, NOW)).toBe(false)
+  })
+
+  it('is a STRICT SUPERSET of isSessionBusy: every busy state is also work at risk', () => {
+    const busyStates = [
+      { streamingMessageId: 'm1', isIdle: true, messages: [] as ChatMessage[] },
+      { streamingMessageId: null, isIdle: false, messages: [] as ChatMessage[] },
+      { streamingMessageId: 'm1', isIdle: false, messages: [] as ChatMessage[] },
+    ]
+    for (const s of busyStates) {
+      expect(isSessionBusy(s)).toBe(true)
+      expect(hasInterruptibleWork(s, NOW)).toBe(true)
+    }
+  })
+
+  it('the two predicates DIFFER on a pending prompt — isSessionBusy must not be widened (#5952)', () => {
+    // If someone "helpfully" folds the pending-permission clause into
+    // isSessionBusy, sendInput starts badging sends "Queued" in a state where
+    // the server would not queue them. This case fails if that happens.
+    const pausedButIdle = { ...idle, messages: [livePrompt] }
+    expect(isSessionBusy(pausedButIdle)).toBe(false)
+    expect(hasInterruptibleWork(pausedButIdle, NOW)).toBe(true)
+  })
+})

--- a/packages/dashboard/src/lib/session-busy.ts
+++ b/packages/dashboard/src/lib/session-busy.ts
@@ -1,0 +1,73 @@
+/**
+ * session-busy — the ONE definition of "this session has work that a
+ * turn-interrupting action would destroy" (#7335).
+ *
+ * Before this module the dashboard carried two hand-written copies of the
+ * question, in the same file, that disagreed:
+ *
+ *   - `sendInput` (connection.ts, #5952) used the two-part disjunction
+ *     `streamingMessageId !== null || isIdle === false`, with a comment
+ *     spelling out WHY both halves are required.
+ *   - the Auto-mode confirm (connection.ts, #5609) used only the first half,
+ *     `!!streamingMessageId`.
+ *
+ * A session paused on a permission prompt is the state where those two
+ * disagree, and it is precisely the state the Auto-mode dialog exists to guard:
+ * the #554 stream-split CLEARS `streamingMessageId` when a `permission_request`
+ * arrives, while the server-authoritative `isIdle` stays false because the turn
+ * really is still in flight (the CLI child is blocked on its PreToolUse hook).
+ * So the destructive-consequence warning was suppressed in the one state where
+ * users most reach for "skip all prompts" — being prompted is the reason you
+ * press the #3729 panic-button — and flipping to Auto silently killed the turn
+ * on `claude-cli` behind benign copy.
+ *
+ * The lesson, not the clause, is what this module encodes: two copies of a
+ * safety predicate that can drift IS the defect, so there is one exported
+ * helper and both call sites use it.
+ */
+import { countLivePermissionPrompts } from '@chroxy/store-core'
+import type { ChatMessage } from '@chroxy/store-core'
+
+/** The fields of a session state this module reads. */
+export interface SessionBusyState {
+  streamingMessageId: string | null
+  isIdle: boolean
+  messages: ChatMessage[]
+}
+
+/**
+ * #5952 — the busy signal that must match EXACTLY what the InputBar shows as
+ * busy (`isStreaming || isBusy`), because it decides whether an optimistic
+ * send renders as "Queued" or as a fresh turn.
+ *
+ * `isIdle` is the server-authoritative working flag (#4639); `streamingMessageId`
+ * additionally covers the optimistic pre-status window. Either ⇒ busy.
+ *
+ * Deliberately does NOT consider pending permissions: this predicate mirrors an
+ * INPUT-BAR affordance, and widening it would make a send optimistically claim
+ * the server queued it in a state where the server would not.
+ */
+export function isSessionBusy(
+  s: Pick<SessionBusyState, 'streamingMessageId' | 'isIdle'>,
+): boolean {
+  return s.streamingMessageId !== null || s.isIdle === false
+}
+
+/**
+ * #7335 — is there in-flight work a turn-interrupting action (the CLI's
+ * respawn-on-auto-switch) would destroy?
+ *
+ * A strict superset of {@link isSessionBusy}: busy in the InputBar sense, OR
+ * holding a live unanswered permission prompt. The third clause is defence in
+ * depth rather than the fix — a session paused on a prompt already reports
+ * `isIdle === false` — but it keeps the warning honest if that server-side
+ * signal is ever late, dropped, or reconciled out of order, and a false
+ * POSITIVE here only costs an extra sentence of confirm copy while a false
+ * negative costs the user their turn.
+ *
+ * `now` is injected (not read from the clock) so the expiry half of
+ * `isLivePermissionPrompt` is testable.
+ */
+export function hasInterruptibleWork(s: SessionBusyState, now: number): boolean {
+  return isSessionBusy(s) || countLivePermissionPrompts(s.messages, now) > 0
+}

--- a/packages/dashboard/src/lib/session-busy.ts
+++ b/packages/dashboard/src/lib/session-busy.ts
@@ -25,7 +25,7 @@
  * safety predicate that can drift IS the defect, so there is one exported
  * helper and both call sites use it.
  */
-import { countLivePermissionPrompts } from '@chroxy/store-core'
+import { isLivePermissionPrompt } from '@chroxy/store-core'
 import type { ChatMessage } from '@chroxy/store-core'
 
 /** The fields of a session state this module reads. */
@@ -40,12 +40,29 @@ export interface SessionBusyState {
  * busy (`isStreaming || isBusy`), because it decides whether an optimistic
  * send renders as "Queued" or as a fresh turn.
  *
+ * "Must match" is the CONTRACT, not yet a fact this module can enforce: the
+ * InputBar's own props are still computed inline in App.tsx as
+ * `isBusy={!isIdle}` / `isStreaming={streamingMessageId !== null}` at five call
+ * sites — a third copy, and `!isIdle` is not even equivalent to
+ * `isIdle === false` should that field ever be nullish (they invert). Routing
+ * those props through this helper is #7378. Until then, treat the sentence
+ * above as the invariant to preserve rather than one already guarded.
+ *
  * `isIdle` is the server-authoritative working flag (#4639); `streamingMessageId`
  * additionally covers the optimistic pre-status window. Either ⇒ busy.
  *
- * Deliberately does NOT consider pending permissions: this predicate mirrors an
- * INPUT-BAR affordance, and widening it would make a send optimistically claim
- * the server queued it in a state where the server would not.
+ * Deliberately does NOT consider pending permissions. The reason is the match
+ * itself, NOT anything about server behaviour: this expression mirrors the
+ * InputBar's own `isStreaming || isBusy`, and any clause added here that the
+ * InputBar does not have re-opens the window #5952 closed — where the input UI
+ * says one thing and the optimistic render assumes another.
+ *
+ * (Widening it would in fact be a no-op for the state that motivated #7335: a
+ * session paused on a prompt already reports `isIdle === false`. And note the
+ * server WOULD queue such a send — `CliSession.sendMessage` gates purely on
+ * `_isBusy`, which a pending permission never clears — so "the server would not
+ * queue it" is not a reason for anything. An earlier draft of this comment said
+ * exactly that and was wrong.)
  */
 export function isSessionBusy(
   s: Pick<SessionBusyState, 'streamingMessageId' | 'isIdle'>,
@@ -58,16 +75,32 @@ export function isSessionBusy(
  * respawn-on-auto-switch) would destroy?
  *
  * A strict superset of {@link isSessionBusy}: busy in the InputBar sense, OR
- * holding a live unanswered permission prompt. The third clause is defence in
- * depth rather than the fix — a session paused on a prompt already reports
- * `isIdle === false` — but it keeps the warning honest if that server-side
- * signal is ever late, dropped, or reconciled out of order, and a false
- * POSITIVE here only costs an extra sentence of confirm copy while a false
- * negative costs the user their turn.
+ * holding a permission prompt that is still ANSWERABLE. The second clause is
+ * defence in depth rather than the fix — a session paused on a prompt already
+ * reports `isIdle === false` — but it keeps the warning honest if that
+ * server-side signal is ever late, dropped, or reconciled out of order.
  *
- * `now` is injected (not read from the clock) so the expiry half of
- * `isLivePermissionPrompt` is testable.
+ * The `options` check is a SECOND signal, not the primary one. The primary fix
+ * is in the `permission_expired` handler (message-handler.ts), which now stamps
+ * `expiresAt` to the present so `isLivePermissionPrompt`'s `expiresAt > now`
+ * gate goes false — previously it cleared only `options`, which that predicate
+ * never reads, so a prompt the server had already killed went on counting as
+ * "live" for the rest of its five minutes and this dialog cried wolf ("this
+ * will INTERRUPT the running turn") at a session with nothing in flight.
+ * #7335's own server half made that state ROUTINE rather than rare: every
+ * auto-switch now expires the open prompt.
+ *
+ * Kept as well as the `expiresAt` fix because the two fail independently: a
+ * retired prompt is identifiable by EITHER signal, and this is a
+ * destructive-action warning where the cost of the redundancy is one extra
+ * boolean. Both are pinned by tests, so neither can rot into a lie unnoticed.
+ *
+ * Filtered here rather than inside `isLivePermissionPrompt`, which is shared
+ * cross-client (#5759) and has four other call sites.
+ *
+ * `now` is injected (not read from the clock) so the expiry gate is testable.
  */
 export function hasInterruptibleWork(s: SessionBusyState, now: number): boolean {
-  return isSessionBusy(s) || countLivePermissionPrompts(s.messages, now) > 0
+  if (isSessionBusy(s)) return true
+  return s.messages.some((m) => m.options !== undefined && isLivePermissionPrompt(m, now))
 }

--- a/packages/dashboard/src/store/auto-mode-confirm-busy.test.ts
+++ b/packages/dashboard/src/store/auto-mode-confirm-busy.test.ts
@@ -1,0 +1,168 @@
+/**
+ * #7335 — the Auto-mode confirm dialog must name the destructive consequence
+ * whenever a turn-interrupting provider has work to lose, INCLUDING the state
+ * the guard was previously blind to: a session paused on a permission prompt.
+ *
+ * These are CALL-SITE tests on purpose. `buildAutoModeConfirmMessage` was never
+ * wrong — fed `isBusy: true` it has always returned the destructive copy. The
+ * defect was `setPermissionMode` computing that boolean from
+ * `streamingMessageId` alone, which the #554 stream-split clears the moment a
+ * `permission_request` arrives. A unit test of the pure helper cannot witness
+ * that, so it would have passed on the broken build and proved nothing.
+ *
+ * Controls, per docs/false-safety-guards.md:
+ *  - NEGATIVE (the bug): paused on a prompt + interrupting provider ⇒ DESTRUCTIVE.
+ *    Fails on the pre-fix build; that was verified before the fix landed.
+ *  - POSITIVE: genuinely idle + interrupting provider ⇒ BASE copy. Keeps a fix
+ *    that just returns DESTRUCTIVE unconditionally from passing.
+ *  - PROVIDER: paused on a prompt on a NON-interrupting provider ⇒ BASE copy.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { createEmptySessionState } from './utils'
+import type { ChatMessage } from '@chroxy/store-core'
+
+const SESSION_ID = 'sess-7335'
+
+/** A live, unanswered permission prompt — `isLivePermissionPrompt` shape. */
+function livePrompt(now: number): ChatMessage {
+  return {
+    id: 'perm-1',
+    type: 'prompt',
+    content: 'Bash: rm -rf build',
+    timestamp: now,
+    requestId: 'req-1',
+    expiresAt: now + 300_000,
+    options: ['allow', 'deny'],
+  } as unknown as ChatMessage
+}
+
+/**
+ * Seed the store in the state under test and return what `window.confirm` was
+ * shown when flipping to Auto.
+ *
+ * `isIdle: false` is not a contrivance: it is what the server reports while the
+ * CLI child sits blocked on its PreToolUse hook, and `streamingMessageId: null`
+ * is what the #554 split leaves behind. Together they ARE "paused on a prompt".
+ */
+async function confirmCopyFor(opts: {
+  streamingMessageId: string | null
+  isIdle: boolean
+  messages: ChatMessage[]
+  interruptsTurnOnAutoSwitch: boolean
+}): Promise<string> {
+  const { useConnectionStore } = await import('./connection')
+  const ss = createEmptySessionState()
+  ss.permissionMode = 'approve'
+  ss.streamingMessageId = opts.streamingMessageId
+  ss.isIdle = opts.isIdle
+  ss.messages = opts.messages
+  useConnectionStore.setState({
+    activeSessionId: SESSION_ID,
+    sessionStates: { [SESSION_ID]: ss },
+    sessions: [{ sessionId: SESSION_ID, provider: 'claude-cli' } as never],
+    availableProviders: [
+      {
+        name: 'claude-cli',
+        capabilities: { interruptsTurnOnAutoSwitch: opts.interruptsTurnOnAutoSwitch },
+      } as never,
+    ],
+    socket: null,
+  })
+
+  const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
+  useConnectionStore.getState().setPermissionMode('auto')
+  expect(confirmSpy).toHaveBeenCalledOnce()
+  return String(confirmSpy.mock.calls[0]![0])
+}
+
+describe('#7335 — Auto-mode confirm copy vs the session busy predicate', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+  // Restore in afterEach, not at the end of each case body: an assertion that
+  // throws first would otherwise leak the window.confirm stub into every
+  // following case and bury the real failure.
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('NEGATIVE CONTROL: warns when paused on a permission prompt (not streaming, not idle)', async () => {
+    const now = Date.now()
+    const copy = await confirmCopyFor({
+      streamingMessageId: null,
+      isIdle: false,
+      messages: [livePrompt(now)],
+      interruptsTurnOnAutoSwitch: true,
+    })
+    expect(copy).toMatch(/INTERRUPT/)
+    expect(copy).toMatch(/restart the session/)
+  })
+
+  it('warns when paused on a prompt even if isIdle is (wrongly) true — the prompt alone is enough', async () => {
+    const now = Date.now()
+    const copy = await confirmCopyFor({
+      streamingMessageId: null,
+      isIdle: true,
+      messages: [livePrompt(now)],
+      interruptsTurnOnAutoSwitch: true,
+    })
+    expect(copy).toMatch(/INTERRUPT/)
+  })
+
+  it('still warns mid-stream (the case that already worked — no regression)', async () => {
+    const copy = await confirmCopyFor({
+      streamingMessageId: 'msg-1',
+      isIdle: false,
+      messages: [],
+      interruptsTurnOnAutoSwitch: true,
+    })
+    expect(copy).toMatch(/INTERRUPT/)
+  })
+
+  it('POSITIVE CONTROL: plain copy on a genuinely idle session — the warning is not unconditional', async () => {
+    const copy = await confirmCopyFor({
+      streamingMessageId: null,
+      isIdle: true,
+      messages: [],
+      interruptsTurnOnAutoSwitch: true,
+    })
+    expect(copy).not.toMatch(/INTERRUPT/)
+    expect(copy).toMatch(/Tools will run without asking for permission/)
+  })
+
+  it('POSITIVE CONTROL: an EXPIRED prompt is not work at risk — plain copy', async () => {
+    const now = Date.now()
+    const stale = { ...livePrompt(now), expiresAt: now - 1 } as ChatMessage
+    const copy = await confirmCopyFor({
+      streamingMessageId: null,
+      isIdle: true,
+      messages: [stale],
+      interruptsTurnOnAutoSwitch: true,
+    })
+    expect(copy).not.toMatch(/INTERRUPT/)
+  })
+
+  it('POSITIVE CONTROL: an ANSWERED prompt is not work at risk — plain copy', async () => {
+    const now = Date.now()
+    const answered = { ...livePrompt(now), answered: 'allow' } as ChatMessage
+    const copy = await confirmCopyFor({
+      streamingMessageId: null,
+      isIdle: true,
+      messages: [answered],
+      interruptsTurnOnAutoSwitch: true,
+    })
+    expect(copy).not.toMatch(/INTERRUPT/)
+  })
+
+  it('PROVIDER CONTROL: plain copy when paused on a prompt on a NON-interrupting provider', async () => {
+    const now = Date.now()
+    const copy = await confirmCopyFor({
+      streamingMessageId: null,
+      isIdle: false,
+      messages: [livePrompt(now)],
+      interruptsTurnOnAutoSwitch: false,
+    })
+    expect(copy).not.toMatch(/INTERRUPT/)
+    expect(copy).toMatch(/Tools will run without asking for permission/)
+  })
+})

--- a/packages/dashboard/src/store/auto-mode-confirm-busy.test.ts
+++ b/packages/dashboard/src/store/auto-mode-confirm-busy.test.ts
@@ -19,7 +19,8 @@
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { createEmptySessionState } from './utils'
-import type { ChatMessage } from '@chroxy/store-core'
+import type { ChatMessage, SessionInfo } from '@chroxy/store-core'
+import type { ProviderInfo } from './types'
 
 const SESSION_ID = 'sess-7335'
 
@@ -59,12 +60,12 @@ async function confirmCopyFor(opts: {
   useConnectionStore.setState({
     activeSessionId: SESSION_ID,
     sessionStates: { [SESSION_ID]: ss },
-    sessions: [{ sessionId: SESSION_ID, provider: 'claude-cli' } as never],
+    sessions: [{ sessionId: SESSION_ID, provider: 'claude-cli' } as unknown as SessionInfo],
     availableProviders: [
       {
         name: 'claude-cli',
         capabilities: { interruptsTurnOnAutoSwitch: opts.interruptsTurnOnAutoSwitch },
-      } as never,
+      } as unknown as ProviderInfo,
     ],
     socket: null,
   })
@@ -130,7 +131,7 @@ describe('#7335 — Auto-mode confirm copy vs the session busy predicate', () =>
     expect(copy).toMatch(/Tools will run without asking for permission/)
   })
 
-  it('POSITIVE CONTROL: an EXPIRED prompt is not work at risk — plain copy', async () => {
+  it('POSITIVE CONTROL: a CLOCK-expired prompt is not work at risk — plain copy', async () => {
     const now = Date.now()
     const stale = { ...livePrompt(now), expiresAt: now - 1 } as ChatMessage
     const copy = await confirmCopyFor({
@@ -140,6 +141,24 @@ describe('#7335 — Auto-mode confirm copy vs the session busy predicate', () =>
       interruptsTurnOnAutoSwitch: true,
     })
     expect(copy).not.toMatch(/INTERRUPT/)
+  })
+
+  it('POSITIVE CONTROL: a SERVER-retired prompt is not work at risk — plain copy', async () => {
+    // The case this PR's own server half makes routine: _killAndRespawn emits
+    // permission_expired, whose handler clears `options` but leaves `answered`
+    // unset and `expiresAt` in the future. Flipping to Auto again a minute later
+    // must not claim there is a turn to interrupt. Distinct from the clock case
+    // above — that one was never reachable this way.
+    const now = Date.now()
+    const retired = { ...livePrompt(now), options: undefined } as ChatMessage
+    const copy = await confirmCopyFor({
+      streamingMessageId: null,
+      isIdle: true,
+      messages: [retired],
+      interruptsTurnOnAutoSwitch: true,
+    })
+    expect(copy).not.toMatch(/INTERRUPT/)
+    expect(copy).toMatch(/Tools will run without asking for permission/)
   })
 
   it('POSITIVE CONTROL: an ANSWERED prompt is not work at risk — plain copy', async () => {

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -88,6 +88,7 @@ import { armSchedulerRequest, failAllSchedulerRequests, SCHEDULER_DISCONNECT_ERR
 import { formatQuestionAnswerSummary } from '../utils/questionAnswerSummary';
 import { getAuthToken } from '../utils/auth';
 import { buildAutoModeConfirmMessage } from '../lib/auto-mode-confirm';
+import { hasInterruptibleWork, isSessionBusy } from '../lib/session-busy';
 import {
   setStore,
   wsSend,
@@ -3463,8 +3464,13 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     // server is authoritative regardless (it queues any mid-turn input and
     // reconciles via message_queued/message_dequeued), so this only keeps the
     // optimistic render honest.
+    // #7335: the same predicate the Auto-mode confirm asks, so the two can no
+    // longer drift. `isSessionBusy` — NOT `hasInterruptibleWork` — is correct
+    // here: this mirrors an InputBar affordance, and counting a pending
+    // permission as busy would optimistically badge a send "Queued" in a state
+    // where the server would not queue it. See lib/session-busy.
     const active = get().getActiveSessionState();
-    const busy = active.streamingMessageId !== null || active.isIdle === false;
+    const busy = isSessionBusy(active);
 
     // Show user message immediately (optimistic update + thinking indicator, or
     // a queued badge when busy). #6632: carry the caller-built MessageAttachment
@@ -4136,12 +4142,18 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       const caps = state.availableProviders.find(
         (p) => p.name === activeProvider,
       )?.capabilities;
-      const isStreaming = !!get().getActiveSessionState().streamingMessageId;
+      // #7335: ask the ONE busy predicate, not `!!streamingMessageId`. The
+      // #554 stream-split CLEARS streamingMessageId when a permission prompt
+      // arrives, so the old read reported "nothing in flight" for a session
+      // PAUSED on a prompt — and being prompted is exactly why a user reaches
+      // for "skip all prompts". The benign copy was therefore shown in the one
+      // state where confirming silently kills the turn on claude-cli.
+      const isBusy = hasInterruptibleWork(get().getActiveSessionState(), Date.now());
       const ok = typeof window !== 'undefined' && typeof window.confirm === 'function'
         ? window.confirm(
             buildAutoModeConfirmMessage({
               interruptsTurn: caps?.interruptsTurnOnAutoSwitch,
-              isStreaming,
+              isBusy,
             }),
           )
         : true;

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -3464,11 +3464,11 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     // server is authoritative regardless (it queues any mid-turn input and
     // reconciles via message_queued/message_dequeued), so this only keeps the
     // optimistic render honest.
-    // #7335: the same predicate the Auto-mode confirm asks, so the two can no
-    // longer drift. `isSessionBusy` — NOT `hasInterruptibleWork` — is correct
-    // here: this mirrors an InputBar affordance, and counting a pending
-    // permission as busy would optimistically badge a send "Queued" in a state
-    // where the server would not queue it. See lib/session-busy.
+    // #7335: extracted so this and the Auto-mode confirm can no longer drift.
+    // `isSessionBusy` — NOT `hasInterruptibleWork` — is correct here: this
+    // expression must keep mirroring the InputBar's own `isStreaming || isBusy`
+    // (the #5952 invariant above), and a clause the InputBar does not have would
+    // re-open exactly the gap that invariant closed. See lib/session-busy.
     const active = get().getActiveSessionState();
     const busy = isSessionBusy(active);
 

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -5420,7 +5420,33 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
           updateSession(expTargetId, (ss) => ({
             messages: ss.messages.map((m) =>
               m.requestId === expiredRequestId && m.type === 'prompt'
-                ? { ...m, content: `${m.content}\n${expiredSystemMsg.content}`, options: undefined }
+                // #7335: `expiresAt` is what actually retires the card, and until
+                // now nothing moved it. Clearing `options` reads like it should,
+                // but #2853 records that PermissionPrompt hardcodes its own
+                // buttons and NEVER reads that array — the dashboard's
+                // interactive gate is `requestId && expiresAt && !answered`
+                // (useMessageRenderer), and the countdown is seeded from
+                // `Math.max(0, expiresAt - Date.now())`. So an expired prompt
+                // went on offering a working Allow for the rest of its five
+                // minutes, with "(Expired …)" printed next to it.
+                //
+                // Stamp it to NOW, not 0: the renderer's gate gives up on a
+                // falsy `expiresAt` and would drop the whole card, erasing the
+                // record of a tool call nobody answered (#7353). Now the card
+                // stays, reads "Timed out", and offers nothing.
+                //
+                // Setting `answered` instead would be wrong: that field is a
+                // DECISION token (#6222/#6223) and no decision was made.
+                //
+                // This also retires the tab badge and the "jump to next pending"
+                // target, both of which key off `isLivePermissionPrompt`'s
+                // `expiresAt > now`.
+                ? {
+                    ...m,
+                    content: `${m.content}\n${expiredSystemMsg.content}`,
+                    options: undefined,
+                    expiresAt: Date.now(),
+                  }
                 : m
             ),
           }));

--- a/packages/dashboard/src/store/permission-expired-retires-card.test.ts
+++ b/packages/dashboard/src/store/permission-expired-retires-card.test.ts
@@ -1,0 +1,123 @@
+/**
+ * #7335 / #2853 — `permission_expired` must actually RETIRE the prompt card.
+ *
+ * The store previously answered this by clearing `options`, which looks right
+ * and does nothing: #2853 records that the dashboard's PermissionPrompt
+ * hardcodes its own buttons and never reads that array. The interactive gate is
+ * `requestId && expiresAt && !answered` (useMessageRenderer.tsx) and the
+ * countdown is seeded from `Math.max(0, expiresAt - Date.now())`, so an expired
+ * prompt kept offering a working Allow for the rest of its five minutes with
+ * "(Expired …)" printed beside it.
+ *
+ * These assert the STORE fields the renderer actually consults, so they would
+ * have failed on the old build. `store.test.ts` only asserted that `content`
+ * matched /Expired/ — a field nothing gates on.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { createEmptySessionState } from './utils'
+import { isLivePermissionPrompt } from '@chroxy/store-core'
+import type { ChatMessage } from '@chroxy/store-core'
+
+const SESSION_ID = 'sess-exp'
+const REQ = 'req-exp'
+
+function promptMsg(now: number): ChatMessage {
+  return {
+    id: 'perm-1',
+    type: 'prompt',
+    content: 'Bash: rm -rf build',
+    timestamp: now,
+    requestId: REQ,
+    expiresAt: now + 300_000,
+    options: [{ label: 'Allow', value: 'allow' }, { label: 'Deny', value: 'deny' }],
+  } as unknown as ChatMessage
+}
+
+async function expirePrompt(seed?: (ss: ReturnType<typeof createEmptySessionState>) => void) {
+  const { useConnectionStore } = await import('./connection')
+  const { _testMessageHandler } = await import('./message-handler')
+  const now = Date.now()
+  const ss = createEmptySessionState()
+  ss.messages = [promptMsg(now)]
+  seed?.(ss)
+  useConnectionStore.setState({
+    activeSessionId: SESSION_ID,
+    sessionStates: { [SESSION_ID]: ss },
+    socket: null,
+  })
+  _testMessageHandler.setContext({
+    url: 'ws://x', token: 't', isReconnect: false, silent: false,
+    socket: { send: () => {}, readyState: 1 } as unknown as WebSocket,
+  })
+  _testMessageHandler.handle({
+    type: 'permission_expired',
+    requestId: REQ,
+    sessionId: SESSION_ID,
+    message: 'Permission request expired',
+  })
+  return useConnectionStore.getState().sessionStates[SESSION_ID]!.messages[0]!
+}
+
+describe('#7335 — permission_expired retires the prompt card', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  it('THE BUG: moves expiresAt into the past so the renderer stops offering Allow', async () => {
+    const m = await expirePrompt()
+    // useMessageRenderer seeds the countdown with max(0, expiresAt - now);
+    // <= now means remaining 0 => PermissionPrompt's isExpired => no buttons.
+    expect(m.expiresAt).toBeDefined()
+    expect(m.expiresAt!).toBeLessThanOrEqual(Date.now())
+  })
+
+  it('keeps expiresAt TRUTHY so the card is not erased entirely (#7353)', async () => {
+    // The renderer's gate is `requestId && expiresAt && !answered`. A falsy
+    // expiresAt drops the card, destroying the only record of a tool call
+    // nobody answered — the failure #7353 is about.
+    const m = await expirePrompt()
+    expect(m.expiresAt).toBeTruthy()
+    expect(m.requestId).toBe(REQ)
+  })
+
+  it('does NOT set `answered` — that field is a decision token and no decision was made', async () => {
+    const m = await expirePrompt()
+    expect(m.answered).toBeUndefined()
+  })
+
+  it('still appends the expiry note to the card content', async () => {
+    const m = await expirePrompt()
+    expect(m.content).toMatch(/Expired/)
+  })
+
+  it('stops counting as a live permission, so the tab badge clears', async () => {
+    const m = await expirePrompt()
+    expect(isLivePermissionPrompt(m, Date.now())).toBe(false)
+  })
+
+  it('POSITIVE CONTROL: an untouched prompt still counts as live and keeps its future expiry', async () => {
+    // Guards against a "fix" that expires every prompt in the session.
+    const { useConnectionStore } = await import('./connection')
+    const { _testMessageHandler } = await import('./message-handler')
+    const now = Date.now()
+    const ss = createEmptySessionState()
+    const other = { ...promptMsg(now), id: 'perm-2', requestId: 'req-other' } as ChatMessage
+    ss.messages = [promptMsg(now), other]
+    useConnectionStore.setState({
+      activeSessionId: SESSION_ID,
+      sessionStates: { [SESSION_ID]: ss },
+      socket: null,
+    })
+    _testMessageHandler.setContext({
+      url: 'ws://x', token: 't', isReconnect: false, silent: false,
+      socket: { send: () => {}, readyState: 1 } as unknown as WebSocket,
+    })
+    _testMessageHandler.handle({
+      type: 'permission_expired', requestId: REQ, sessionId: SESSION_ID, message: 'x',
+    })
+    const msgs = useConnectionStore.getState().sessionStates[SESSION_ID]!.messages
+    expect(isLivePermissionPrompt(msgs[0]!, Date.now())).toBe(false)
+    expect(isLivePermissionPrompt(msgs[1]!, Date.now())).toBe(true)
+    expect(msgs[1]!.expiresAt!).toBeGreaterThan(Date.now())
+  })
+})

--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -913,28 +913,39 @@ export class CliSession extends BaseSession {
    * clears the prompt's `options`, which is what actually retires the dead
    * Allow button — so emitting here is the whole client-side fix.
    *
-   * Extracted because it was wired to `_handleHardTimeout` alone while a turn
-   * has several ways to die — correct for every input it saw and never reached
-   * by the rest, the shape catalogued in docs/false-safety-guards.md. The
-   * callers, audited rather than assumed:
+   * Wired at three sites, and the third is the one that matters:
    *
-   *   - `_handleHardTimeout`  — the original (#2831).
-   *   - `_killAndRespawn`     — the #3729 panic-button, the auto-mode switch,
-   *                             and mid-turn setModel.
-   *   - `_handleChildClose`   — a crash, and user Stop via SIGINT.
+   *   - `_clearMessageState` — the FUNNEL. Every turn end reaches it: the
+   *     normal `result`, the hard cap, the interrupt safety timeout,
+   *     `destroy()`. It is also where the ids used to be dropped silently.
+   *   - `_killAndRespawn`    — the #3729 panic-button, the auto-mode switch,
+   *     mid-turn setModel. Needs its OWN call because it reaches the funnel via
+   *     `_emitInterruptedTurnResult`, which early-returns when the session is
+   *     not busy.
+   *   - `_handleChildClose`  — a crash, or user Stop where the child dies. Same
+   *     early-return caveat.
    *
-   * Deliberately NOT wired to the remaining three:
+   * An earlier draft wired only the two death sites and justified skipping the
+   * rest in a table. Review found the table wrong twice over: the interrupt
+   * safety timeout was excused as "the child ignored SIGINT so the prompt is
+   * still answerable", which this file contradicts eleven hundred lines below
+   * (`claude only aborts the current turn` — the hook dies with the turn), and
+   * that path then wiped the ids anyway via `_clearMessageState`, so no later
+   * close could expire them. The plain `result` path was not in the table at
+   * all. Enumerating callers by hand is what produced both errors; wiring the
+   * funnel is what fixes them.
    *
-   *   - `_handleStreamStall` cannot fire while a permission is pending —
-   *     `notifyPermissionPending` clears the stall timer and
-   *     `_armResultTimeout` bails on `_resultTimeoutPaused`, so it is
-   *     unreachable in this state rather than merely unlikely.
-   *   - the interrupt safety timeout fires when the child IGNORED SIGINT and
-   *     is still alive, so its hook is still blocked and its prompt still
-   *     genuinely answerable. Expiring there would be the lie this method
-   *     exists to prevent.
-   *   - `destroy()` tears the whole session down; the card goes with it, and
-   *     the HTTP side is already released by ws-permissions' own close path.
+   * `_handleStreamStall` is genuinely unreachable with a permission pending —
+   * `notifyPermissionPending` clears the stall timer and `_armResultTimeout`
+   * bails on `_resultTimeoutPaused` — and it routes through the funnel anyway.
+   *
+   * NOT a full solution on its own: this retires the prompt in the CLIENTS. The
+   * daemon's own `pendingPermissions` entry (ws-permissions.js) is NOT released
+   * here, because killing the CLI child does not signal the hook's `curl`
+   * grandchild (POSIX `killProcessTree` sends SIGTERM to the direct child only),
+   * so its socket stays open and `resendPendingPermissions` will re-send the
+   * request to any client that reconnects inside the five-minute window. That
+   * gap predates this change; see #7379.
    *
    * @param {string} message Reason forwarded on the wire (clients log it; the
    *   user-visible copy is fixed client-side).
@@ -945,6 +956,18 @@ export class CliSession extends BaseSession {
       this.emit('permission_expired', { requestId, message })
     }
     this._pendingPermissionIds.clear()
+    // #7335: the set and this flag are ONE piece of bookkeeping —
+    // notifyPermissionPending sets both, and notifyPermissionResolved is the
+    // only other thing that unsets the flag, which it does only for an id still
+    // IN the set. Taking the ids without releasing the flag therefore wedges it
+    // true forever on any path that does not reach _clearMessageState (which
+    // resets it) — and _emitInterruptedTurnResult early-returns when the
+    // session is not busy, so that path is real. `_armResultTimeout` bails on
+    // this flag, so the cost is the inactivity warning, the hard cap AND the
+    // #4467 stream-stall recovery all silently dead for the rest of the
+    // session. Releasing it here is correct by construction: there are no
+    // pending permissions left to pause for.
+    this._resultTimeoutPaused = false
   }
 
   // #4467: stream-stall recovery. Fires when the child has been silent
@@ -1444,6 +1467,15 @@ export class CliSession extends BaseSession {
     super._clearMessageState()
     this._waitingForAnswer = false
     this._currentCtx = null
+    // #7335: this is the ONE funnel every turn end passes through — the normal
+    // `result`, the hard cap, the interrupt safety timeout, destroy() — and it
+    // used to drop `_pendingPermissionIds` on the floor without telling anyone.
+    // Expiring here rather than only at the individual death sites is the
+    // difference between a guard wired to the callers someone remembered and
+    // one wired to all of them (docs/false-safety-guards.md). Idempotent: a
+    // no-op when the set is already empty, which it is on the paths that
+    // expired explicitly moments earlier.
+    this._expirePendingPermissions('Permission request expired (the turn it belonged to ended before it was answered)')
     // Reset permission pause bookkeeping — the next message starts fresh.
     this._pendingPermissionIds.clear()
     this._resultTimeoutPaused = false

--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -914,10 +914,27 @@ export class CliSession extends BaseSession {
    * Allow button — so emitting here is the whole client-side fix.
    *
    * Extracted because it was wired to `_handleHardTimeout` alone while a turn
-   * has two ways to die: the hard cap, and `_killAndRespawn` (the #3729
-   * panic-button, mid-turn setModel, the auto-mode switch). Correct for every
-   * input it saw and never reached by the other caller — the shape catalogued
-   * in docs/false-safety-guards.md.
+   * has several ways to die — correct for every input it saw and never reached
+   * by the rest, the shape catalogued in docs/false-safety-guards.md. The
+   * callers, audited rather than assumed:
+   *
+   *   - `_handleHardTimeout`  — the original (#2831).
+   *   - `_killAndRespawn`     — the #3729 panic-button, the auto-mode switch,
+   *                             and mid-turn setModel.
+   *   - `_handleChildClose`   — a crash, and user Stop via SIGINT.
+   *
+   * Deliberately NOT wired to the remaining three:
+   *
+   *   - `_handleStreamStall` cannot fire while a permission is pending —
+   *     `notifyPermissionPending` clears the stall timer and
+   *     `_armResultTimeout` bails on `_resultTimeoutPaused`, so it is
+   *     unreachable in this state rather than merely unlikely.
+   *   - the interrupt safety timeout fires when the child IGNORED SIGINT and
+   *     is still alive, so its hook is still blocked and its prompt still
+   *     genuinely answerable. Expiring there would be the lie this method
+   *     exists to prevent.
+   *   - `destroy()` tears the whole session down; the card goes with it, and
+   *     the HTTP side is already released by ws-permissions' own close path.
    *
    * @param {string} message Reason forwarded on the wire (clients log it; the
    *   user-visible copy is fixed client-side).
@@ -1828,6 +1845,17 @@ export class CliSession extends BaseSession {
 
     if (this._destroying) return
     if (this._respawning) return
+
+    // #7335: the child is gone, so every PreToolUse hook it had blocked on
+    // died with it and its prompt can never be answered — same stranded card
+    // as the respawn path, reached a different way. This covers a crash AND a
+    // user Stop (interrupt() → SIGINT → the child exits here, NOT through
+    // _killAndRespawn). Before _emitInterruptedTurnResult for the same reason:
+    // that call reaches _clearMessageState, which drops the ids silently.
+    //
+    // The respawn path already expired them and set `_respawning`, so the
+    // close it causes returns above — no double emit; pinned by a test.
+    this._expirePendingPermissions('Permission request expired (the session process exited before it could be answered)')
 
     this._emitInterruptedTurnResult()
 

--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -893,17 +893,41 @@ export class CliSession extends BaseSession {
     const friendly = formatIdleDuration(this._hardTimeoutMs)
     // #4828: session-scoped (hard-cap fires from active turn).
     ;(this._log || log).warn(`Hard-cap timeout (${friendly}) — force-clearing busy state`)
-    // Fire permission_expired for every pending permission we know about
-    // so the client clears the stale prompt.
-    for (const requestId of this._pendingPermissionIds) {
-      this.emit('permission_expired', {
-        requestId,
-        message: 'Permission request expired (session timeout)',
-      })
-    }
-    this._pendingPermissionIds.clear()
+    this._expirePendingPermissions('Permission request expired (session timeout)')
     this._emitInterruptedTurnResult(this._hardTimeoutMs)
     this.emit('error', { message: `Response timed out after ${friendly}` })
+  }
+
+  /**
+   * Emit `permission_expired` for every prompt this session is still blocked
+   * on, then drop the bookkeeping (#2831, extended by #7335).
+   *
+   * A prompt outlives its turn on BOTH sides and neither side says so:
+   * client-side the card stays live until its own 5-minute `expiresAt`, and
+   * server-side the daemon's HTTP handler tears the pending entry down on the
+   * hook's `req 'aborted'` / `res 'close'` without broadcasting anything. So a
+   * user who clicks Allow afterwards gets the "stale/unknown toolUseId …
+   * already resolved" path with nothing explaining which decision died.
+   *
+   * The dashboard's `permission_expired` handler appends the expiry note AND
+   * clears the prompt's `options`, which is what actually retires the dead
+   * Allow button — so emitting here is the whole client-side fix.
+   *
+   * Extracted because it was wired to `_handleHardTimeout` alone while a turn
+   * has two ways to die: the hard cap, and `_killAndRespawn` (the #3729
+   * panic-button, mid-turn setModel, the auto-mode switch). Correct for every
+   * input it saw and never reached by the other caller — the shape catalogued
+   * in docs/false-safety-guards.md.
+   *
+   * @param {string} message Reason forwarded on the wire (clients log it; the
+   *   user-visible copy is fixed client-side).
+   */
+  _expirePendingPermissions(message) {
+    if (this._pendingPermissionIds.size === 0) return
+    for (const requestId of this._pendingPermissionIds) {
+      this.emit('permission_expired', { requestId, message })
+    }
+    this._pendingPermissionIds.clear()
   }
 
   // #4467: stream-stall recovery. Fires when the child has been silent
@@ -1456,6 +1480,13 @@ export class CliSession extends BaseSession {
    * Suppresses auto-respawn during the kill, clears timers, and starts fresh.
    */
   _killAndRespawn() {
+    // #7335: retire the prompts the dying turn was blocked on BEFORE
+    // _emitInterruptedTurnResult, which reaches _clearMessageState and wipes
+    // `_pendingPermissionIds` silently. Ordering is the whole fix: after that
+    // call there is nothing left to tell the client about, which is exactly
+    // how the card ended up stranded live on screen with a dead Allow button.
+    this._expirePendingPermissions('Permission request expired (the turn it belonged to was interrupted and the session restarted)')
+
     // #4471: emit synthetic terminating events BEFORE setting _respawning,
     // otherwise the _handleChildClose guard short-circuits and the dashboard
     // never receives `agent_idle` — Stop stays stuck on panic-button +

--- a/packages/server/tests/cli-session-respawn-expires-permissions.test.js
+++ b/packages/server/tests/cli-session-respawn-expires-permissions.test.js
@@ -57,6 +57,10 @@ describe('CliSession — respawn expires pending permissions (#7335)', () => {
     session = createReadySession()
     expired = []
     session.on('permission_expired', (d) => expired.push(d))
+    // Several of these paths emit `error` by design (a child close reports
+    // "exited unexpectedly"). Sink it so node:test does not rethrow an
+    // EventEmitter unhandled-'error' and bury the assertion under test.
+    session.on('error', () => {})
   })
 
   afterEach(() => {
@@ -93,6 +97,41 @@ describe('CliSession — respawn expires pending permissions (#7335)', () => {
 
     assert.equal(expired.length, 1, 'the open prompt is expired, not abandoned')
     assert.equal(expired[0].requestId, 'perm-auto')
+  })
+
+  it('THE ADJACENT PATH: a child that exits (crash or user Stop) also expires its prompts', async () => {
+    await session.sendMessage('run a command')
+    session.notifyPermissionPending('perm-crash')
+
+    // interrupt()/Stop sends SIGINT and the child exits; a crash lands here
+    // too. Neither goes through _killAndRespawn, so this path needed wiring of
+    // its own — the hook died with the child either way.
+    session._handleChildClose(1)
+
+    assert.equal(expired.length, 1, 'the prompt the dead child was blocked on is expired')
+    assert.equal(expired[0].requestId, 'perm-crash')
+    assert.equal(session._pendingPermissionIds.size, 0, 'bookkeeping cleared')
+  })
+
+  it('POSITIVE CONTROL: a child close with NO pending permissions emits nothing', async () => {
+    await session.sendMessage('do something')
+
+    session._handleChildClose(0)
+
+    assert.equal(expired.length, 0, 'no phantom expiries on a clean exit')
+  })
+
+  it('does not expire twice when a respawn is followed by the child close it caused', async () => {
+    await session.sendMessage('do something')
+    session.notifyPermissionPending('perm-1')
+
+    session._killAndRespawn()
+    assert.equal(expired.length, 1, 'respawn expired it')
+
+    // The kill above sets _respawning, so the close it triggers short-circuits
+    // before the expire — but assert it rather than trust the ordering.
+    session._handleChildClose(0)
+    assert.equal(expired.length, 1, 'the close it caused does not re-expire')
   })
 
   it('POSITIVE CONTROL: a respawn with NO pending permissions emits nothing', async () => {

--- a/packages/server/tests/cli-session-respawn-expires-permissions.test.js
+++ b/packages/server/tests/cli-session-respawn-expires-permissions.test.js
@@ -1,0 +1,141 @@
+import { describe, it, beforeEach, afterEach, mock } from 'node:test'
+import assert from 'node:assert/strict'
+import { Readable, Writable } from 'node:stream'
+import { EventEmitter } from 'node:events'
+import { CliSession } from '../src/cli-session.js'
+
+/**
+ * #7335 — a respawn must EXPIRE the permission prompts the dropped turn left
+ * behind, instead of forgetting them silently.
+ *
+ * `_killAndRespawn` kills the `claude -p` child. Every PreToolUse hook that
+ * child had blocked on dies with it, so the daemon's HTTP handler tears the
+ * pending entry down via its `req 'aborted'` / `res 'close'` path — which
+ * broadcasts NOTHING. Meanwhile `_emitInterruptedTurnResult` →
+ * `_clearMessageState` wipes `_pendingPermissionIds` with no event either. The
+ * prompt is dead on both sides and the client is never told, so the card sits
+ * there live until its own 5-minute `expiresAt`, and clicking Allow returns the
+ * server's "stale/unknown toolUseId … already resolved" path.
+ *
+ * The fix reuses the mechanism `_handleHardTimeout` has had since #2831 — that
+ * path already emitted `permission_expired` for exactly this reason. It was
+ * simply never wired to the OTHER way a turn dies, which is the
+ * guard-wired-to-only-some-of-its-callers shape in docs/false-safety-guards.md.
+ *
+ * No client change is needed: the dashboard's `permission_expired` handler
+ * already appends the expiry note and clears the prompt's `options`, which is
+ * what makes the Allow button (and its confusing "already acknowledged"
+ * response) go away.
+ */
+
+function createMockChild() {
+  const child = new EventEmitter()
+  child.stdin = new Writable({ write(_chunk, _enc, cb) { cb() } })
+  child.stdout = new Readable({ read() {} })
+  child.stderr = new Readable({ read() {} })
+  child.pid = 12345
+  // Never emits 'close', so _killAndRespawn's respawn() (and start()) never
+  // runs — these tests are about what happens BEFORE the new child exists.
+  child.kill = mock.fn(() => true)
+  child.killed = false
+  return child
+}
+
+function createReadySession(opts = {}) {
+  const session = new CliSession({ cwd: '/tmp', ...opts })
+  session._processReady = true
+  session._child = createMockChild()
+  return session
+}
+
+describe('CliSession — respawn expires pending permissions (#7335)', () => {
+  let session
+  let expired
+
+  beforeEach(() => {
+    mock.timers.enable({ apis: ['setTimeout', 'setInterval', 'Date'] })
+    session = createReadySession()
+    expired = []
+    session.on('permission_expired', (d) => expired.push(d))
+  })
+
+  afterEach(() => {
+    mock.timers.reset()
+    session.removeAllListeners()
+  })
+
+  it('THE BUG: _killAndRespawn emits permission_expired for every pending permission', async () => {
+    await session.sendMessage('do something')
+    session.notifyPermissionPending('perm-1')
+    session.notifyPermissionPending('perm-2')
+
+    session._killAndRespawn()
+
+    assert.equal(expired.length, 2, 'one permission_expired per pending permission')
+    assert.deepEqual(
+      expired.map((e) => e.requestId).sort(),
+      ['perm-1', 'perm-2'],
+      'expired the ids that were actually pending',
+    )
+    for (const e of expired) {
+      assert.equal(typeof e.message, 'string')
+      assert.ok(e.message.length > 0, 'carries a reason string')
+    }
+    assert.equal(session._pendingPermissionIds.size, 0, 'bookkeeping cleared')
+  })
+
+  it('THE SCENARIO: flipping to auto while paused on a prompt expires that prompt', async () => {
+    await session.sendMessage('run a command')
+    session.notifyPermissionPending('perm-auto')
+
+    // The #3729 panic-button: BaseSession lets 'auto' through the busy guard.
+    session.setPermissionMode('auto')
+
+    assert.equal(expired.length, 1, 'the open prompt is expired, not abandoned')
+    assert.equal(expired[0].requestId, 'perm-auto')
+  })
+
+  it('POSITIVE CONTROL: a respawn with NO pending permissions emits nothing', async () => {
+    await session.sendMessage('do something')
+
+    session._killAndRespawn()
+
+    assert.equal(expired.length, 0, 'no phantom expiries — the event is not unconditional')
+  })
+
+  it('POSITIVE CONTROL: a resolved permission is not expired again on respawn', async () => {
+    await session.sendMessage('do something')
+    session.notifyPermissionPending('perm-1')
+    session.notifyPermissionResolved('perm-1')
+
+    session._killAndRespawn()
+
+    assert.equal(expired.length, 0, 'an already-resolved prompt is not double-reported')
+  })
+
+  it('does not emit twice when the hard-cap timeout is followed by a respawn', async () => {
+    // Own session: the hard cap is pinned inside the stall window so the
+    // hard-timeout path is what fires, not the #4467 stall recovery.
+    const s = createReadySession({
+      resultTimeoutMs: 5 * 60_000,
+      hardTimeoutMs: 5 * 60_000,
+      streamStallTimeoutMs: 0,
+    })
+    const seen = []
+    s.on('permission_expired', (d) => seen.push(d))
+    // The hard-cap path emits `error` by design; sink it so node:test does not
+    // rethrow an EventEmitter unhandled-'error'.
+    s.on('error', () => {})
+
+    await s.sendMessage('do something')
+    // Registered without the pause side effect, so the hard timer stays armed —
+    // the orphan case _handleHardTimeout was written for.
+    s._pendingPermissionIds.add('perm-orphan')
+    mock.timers.tick(5 * 60_000 + 100)
+    assert.equal(seen.length, 1, 'hard-cap expired it once')
+
+    s._killAndRespawn()
+    assert.equal(seen.length, 1, 'respawn does not re-expire an already-expired prompt')
+    s.removeAllListeners()
+  })
+})

--- a/packages/server/tests/cli-session-respawn-expires-permissions.test.js
+++ b/packages/server/tests/cli-session-respawn-expires-permissions.test.js
@@ -121,17 +121,105 @@ describe('CliSession — respawn expires pending permissions (#7335)', () => {
     assert.equal(expired.length, 0, 'no phantom expiries on a clean exit')
   })
 
-  it('does not expire twice when a respawn is followed by the child close it caused', async () => {
+  it('does not expire the SAME prompt twice across a respawn and the close it caused', async () => {
     await session.sendMessage('do something')
     session.notifyPermissionPending('perm-1')
 
     session._killAndRespawn()
     assert.equal(expired.length, 1, 'respawn expired it')
 
-    // The kill above sets _respawning, so the close it triggers short-circuits
-    // before the expire — but assert it rather than trust the ordering.
     session._handleChildClose(0)
-    assert.equal(expired.length, 1, 'the close it caused does not re-expire')
+    assert.deepEqual(expired.map((e) => e.requestId), ['perm-1'], 'not re-expired')
+  })
+
+  it('the _respawning short-circuit is REAL, not just an empty set', async () => {
+    // The previous version of this case asserted only that the count stayed at
+    // 1 — which it would with the `if (this._respawning) return` guard DELETED,
+    // because _killAndRespawn had already emptied the set. Deleting the guard
+    // left the whole suite green. Re-arm an id in the gap so the two outcomes
+    // actually differ: with the guard, the close short-circuits and this id
+    // survives to be expired later; without it, the close expires it now.
+    await session.sendMessage('do something')
+    session.notifyPermissionPending('perm-1')
+
+    session._killAndRespawn()
+    assert.equal(expired.length, 1, 'respawn expired the first prompt')
+
+    // The old child lives for up to the 10s force-kill grace and can raise a
+    // fresh PreToolUse hook in that window (the file asserts this itself).
+    session.notifyPermissionPending('perm-during-grace')
+
+    session._handleChildClose(0)
+
+    assert.deepEqual(
+      expired.map((e) => e.requestId),
+      ['perm-1'],
+      'the close short-circuited on _respawning and did NOT expire the late prompt',
+    )
+    assert.ok(
+      session._pendingPermissionIds.has('perm-during-grace'),
+      'the late prompt is still pending, owned by the respawned child',
+    )
+  })
+
+  it('C1: expiring releases the inactivity PAUSE, not just the ids', async () => {
+    // The set and _resultTimeoutPaused are one piece of bookkeeping.
+    // notifyPermissionResolved only unsets the flag for an id still in the set,
+    // so taking the ids without releasing the flag wedges it true — and
+    // _armResultTimeout bails on it, leaving the inactivity warning, the hard
+    // cap and the stream-stall recovery all dead for the rest of the session.
+    await session.sendMessage('do something')
+    // Drive _isBusy false first, so _emitInterruptedTurnResult early-returns and
+    // cannot mask the bug by resetting the flag itself.
+    session._clearMessageState()
+    session.notifyPermissionPending('perm-late')
+    assert.equal(session._resultTimeoutPaused, true, 'precondition: paused')
+    assert.equal(session._isBusy, false, 'precondition: not busy')
+
+    session._handleChildClose(1)
+
+    assert.equal(session._resultTimeoutPaused, false, 'pause released')
+
+    // The real consequence: the next turn must re-arm its safety timers.
+    session._processReady = true
+    session._child = createMockChild()
+    await session.sendMessage('next turn')
+    assert.ok(session._resultTimeout, 'inactivity warning re-armed')
+    assert.ok(session._hardTimeout, 'hard cap re-armed')
+  })
+
+  it('F3: the interrupt safety timeout expires too — it aborts the turn, killing the hook', async () => {
+    // Previously excused as "the child ignored SIGINT so the prompt is still
+    // answerable". This file says otherwise at the markIntentionalStop comment:
+    // claude only aborts the CURRENT TURN, so the in-flight hook dies with it.
+    // That path also wiped the ids via _clearMessageState, so no later close
+    // could expire them either.
+    await session.sendMessage('do something')
+    session.notifyPermissionPending('perm-int')
+
+    // The safety timeout's body, reached 5s after interrupt() when the child
+    // survived SIGINT.
+    session._emitInterruptedTurnResult()
+
+    assert.deepEqual(expired.map((e) => e.requestId), ['perm-int'], 'expired, not silently dropped')
+    assert.equal(session._pendingPermissionIds.size, 0)
+  })
+
+  it('F4: a NORMAL turn end expires a prompt left pending, rather than dropping it', async () => {
+    // The most common way a turn stops was in neither column of the original
+    // audit table. _clearMessageState wiped the set with no event.
+    await session.sendMessage('do something')
+    session.notifyPermissionPending('perm-orphaned-by-result')
+
+    session._clearMessageState()
+
+    assert.deepEqual(expired.map((e) => e.requestId), ['perm-orphaned-by-result'])
+  })
+
+  it('POSITIVE CONTROL: a normal turn end with nothing pending emits nothing', async () => {
+    await session.sendMessage('do something')
+    session._clearMessageState()
+    assert.equal(expired.length, 0, 'the funnel does not fire unconditionally')
   })
 
   it('POSITIVE CONTROL: a respawn with NO pending permissions emits nothing', async () => {


### PR DESCRIPTION
Closes #7335.

Switching to **Auto** while a permission prompt was open killed the in-flight turn on `claude-cli` behind benign confirm copy, then left the dead prompt on screen with a live Allow button. Reported from dogfooding v0.11.0.

Two independent gaps, same shape — a predicate that is correct for every state it was tested in and blind to the one that matters.

## 1. The confirm copy (dashboard)

`setPermissionMode` computed "is a turn in flight" from `streamingMessageId` alone. The #554 stream-split **clears** that field the moment a `permission_request` arrives, while the server-authoritative `isIdle` stays `false` because the turn really is still running (the CLI child is blocked on its PreToolUse hook). So a session *paused on a prompt* read as idle and got the benign copy — in the one state where users most reach for "skip all prompts", since being prompted is the whole reason you press the #3729 panic-button.

The correct two-part disjunction already existed 670 lines earlier in the same file (#5952, `sendInput`), with a comment explaining why both halves are required. Two hand-written copies of one safety predicate that can drift **is** the defect, so both call sites now use one exported helper in `lib/session-busy`:

| helper | clauses | used by |
|---|---|---|
| `isSessionBusy` | `streamingMessageId \|\| !isIdle` | `sendInput` |
| `hasInterruptibleWork` | the above **+** a live permission prompt | the Auto confirm |

`sendInput` keeps the narrow one deliberately: widening it would optimistically badge a send "Queued" in a state where the server would not queue it. A test pins that the two must continue to differ, so a future "helpful" merge of the two fails.

`AutoModeConfirmInput.isStreaming` is renamed `isBusy`. The name was the bug — the helper was always correct, the call site fed it a lying value.

## 2. The stranded prompt (server)

`_killAndRespawn` kills the child, so every PreToolUse hook it blocked on dies and the daemon tears the pending entry down via `req 'aborted'` **without broadcasting anything**; `_emitInterruptedTurnResult` → `_clearMessageState` then wipes `_pendingPermissionIds` silently. The prompt was dead on both sides and the client was never told — hence the card sitting live until its own 5-minute expiry, and the "already acknowledged" response on Allow.

`_handleHardTimeout` has emitted `permission_expired` for exactly this reason since #2831. It was simply never wired to the **other** ways a turn dies. Extracted as `_expirePendingPermissions` and called *before* the state wipe — the ordering is the whole fix.

The callers were then audited rather than assumed, because a turn dies more ways than the respawn:

| path | wired? | why |
|---|---|---|
| `_handleHardTimeout` | yes | the original (#2831) |
| `_killAndRespawn` | yes | the panic-button, the auto-mode switch, mid-turn `setModel` |
| `_handleChildClose` | yes | a crash, **and user Stop** — SIGINT exits the child without going through `_killAndRespawn`, so this needed wiring of its own |
| `_handleStreamStall` | no | **unreachable** with a permission pending, not merely unlikely: `notifyPermissionPending` clears the stall timer and `_armResultTimeout` bails on `_resultTimeoutPaused` |
| interrupt safety timeout | no | fires when the child *ignored* SIGINT and is still alive, so its hook is still blocked and the prompt still genuinely answerable — expiring there would be the lie this method exists to prevent |
| `destroy()` | no | takes the whole session down, card included; `ws-permissions` already releases the HTTP side |

The respawn path sets `_respawning`, so the close it causes short-circuits above the new call — no double emit, pinned by a test rather than left to the reader.

**No client change was needed**: the dashboard's `permission_expired` handler already appends the expiry note and clears the prompt's `options`, which is what retires the dead Allow button.

## Verification — red first

Per `docs/false-safety-guards.md`, confirmed failing before the fix and passing after:

- The guards are **call-site** tests. A unit test of `buildAutoModeConfirmMessage` passes on the broken build — the helper was never where the bug lived, so that test proves nothing. The existing unit suite now says so in its header.
- **Negative controls** (the bug): paused-on-prompt ⇒ destructive copy; respawn with pending permissions ⇒ `permission_expired` per id.
- **Positive controls**, so a fix that fires unconditionally cannot pass: genuinely idle session, *expired* prompt, *answered* prompt, AskUserQuestion prompt (not a permission), respawn with nothing pending, clean child close with nothing pending, already-resolved permission, and no double-emit either when a hard timeout precedes a respawn or when a respawn is followed by the close it caused.
- **Provider control**: paused-on-prompt on a non-interrupting provider (SDK/TUI) ⇒ benign copy.
- Both original defects were re-applied as mutants after the fix and confirmed to go red.

## Gates

- Dashboard: 299 files / 5193 tests pass · `tsc --noEmit` clean · `vite build` clean
- Server: 107 related `cli-session` tests pass · all 9 `scripts/lint-*.sh` pass
- Two failures in `tests/cli-session.test.js` (`omits CHROXY_PORT/CHROXY_HOOK_SECRET when port is not set`) were verified to fail identically on `origin/main` — a local-environment artifact, not from this change.

## Left for a follow-on

The issue's third expected outcome — tool calls of a killed turn carrying an explicit *"turn interrupted by permission-mode switch"* state rather than a bare red — is not in this PR. It needs an interrupt reason threaded from the respawn through `event-normalizer` into the tool-call render state, which is a separate change from the two predicates above. Filed separately.
