### PR TITLE
fix(server): release the daemon's pending permission when the turn that raised it dies

### DIFF
--- a/packages/server/src/event-normalizer.js
+++ b/packages/server/src/event-normalizer.js
@@ -776,6 +776,13 @@ Object.assign(EVENT_MAP, {
   }),
 
   permission_expired: (data, ctx) => ({
+    // #7379: retiring the card in the clients is only half of it — the daemon's
+    // own pending entry has to go too, or `resendPendingPermissions` hands the
+    // dead prompt to the next client that connects. Carried as a side effect
+    // rather than wired at the two event-subscription sites because those are
+    // separate code paths (multi-session and legacy-CLI) and wiring one is how
+    // this class of bug happens; `executeSideEffects` runs on both.
+    sideEffects: [{ type: 'release_permission', requestId: data.requestId }],
     messages: [{
       msg: {
         type: 'permission_expired',

--- a/packages/server/src/event-normalizer.js
+++ b/packages/server/src/event-normalizer.js
@@ -778,11 +778,22 @@ Object.assign(EVENT_MAP, {
   permission_expired: (data, ctx) => ({
     // #7379: retiring the card in the clients is only half of it — the daemon's
     // own pending entry has to go too, or `resendPendingPermissions` hands the
-    // dead prompt to the next client that connects. Carried as a side effect
-    // rather than wired at the two event-subscription sites because those are
-    // separate code paths (multi-session and legacy-CLI) and wiring one is how
-    // this class of bug happens; `executeSideEffects` runs on both.
-    sideEffects: [{ type: 'release_permission', requestId: data.requestId }],
+    // dead prompt to the next client that connects. Carried as an effect rather
+    // than wired at the two event-subscription sites because those are separate
+    // code paths (multi-session and legacy-CLI) and wiring one is how this class
+    // of bug happens; the executor runs on both.
+    //
+    // AFTER-effect, not a side effect, and the distinction is load-bearing:
+    // releasing runs ws-permissions' shared cleanup() -> tearDownRoute ->
+    // WsServer._unregisterPermissionRoute, which UNSUBSCRIBES every client whose
+    // subscription to this session was permission-induced and who is not
+    // actively viewing it (the #4798 "view A, get prompted for A, switch to B"
+    // flow). broadcastToSession's recipient filter is `active || subscribed`, so
+    // releasing first drops exactly the clients that still need to hear the
+    // prompt is dead — their card would keep a live Allow button until the
+    // client-side expiry, which is the bug this whole change exists to remove.
+    // Tell the clients first, then release.
+    afterEffects: [{ type: 'release_permission', requestId: data?.requestId }],
     messages: [{
       msg: {
         type: 'permission_expired',

--- a/packages/server/src/ws-forwarding.js
+++ b/packages/server/src/ws-forwarding.js
@@ -247,6 +247,13 @@ function setupSessionForwarding(normalizer, ctx) {
         broadcastToSession(sessionId, stamped)
       }
     }
+
+    // #7379: AFTER the broadcast, deliberately. Releasing a permission runs
+    // ws-permissions' cleanup() -> tearDownRoute, which unsubscribes the
+    // permission-induced viewers of this session — so anything released here
+    // must already have been told. Same executor as sideEffects so the two
+    // buckets can never grow divergent handling.
+    executeSideEffects(result.afterEffects, sessionId, ctx)
     } catch (err) {
       // #5313 (WP-1.3): see the try at the top of this listener.
       const message = err?.message || String(err)
@@ -405,6 +412,12 @@ function setupCliForwarding(normalizer, ctx) {
             broadcast(stamped)
           }
         }
+
+        // #7379: after the broadcast — see the multi-session path. This path
+        // broadcasts globally rather than per-session, so the unsubscribe hazard
+        // does not bite here; the ordering is mirrored anyway so the two paths
+        // cannot drift into different semantics for the same effect.
+        executeSideEffects(result.afterEffects, null, ctx)
       } catch (err) {
         const message = err?.message || String(err)
         log.error(`legacy-cli forwarding threw (event=${event}): ${message}${err?.stack ? '\n' + err.stack : ''}`)
@@ -477,7 +490,7 @@ function executeSideEffects(sideEffects, sessionId, ctx) {
         // the normal case for the SDK path and for a hook that closed cleanly.
         if (releasePermission) {
           try {
-            releasePermission(effect.requestId)
+            releasePermission(effect.requestId, sessionId)
           } catch (err) {
             log.warn(`Failed to release abandoned permission ${effect.requestId}: ${err?.message || err}`)
           }

--- a/packages/server/src/ws-forwarding.js
+++ b/packages/server/src/ws-forwarding.js
@@ -457,7 +457,7 @@ function setupCliForwarding(normalizer, ctx) {
 /** Execute side effect descriptors returned by the normalizer */
 function executeSideEffects(sideEffects, sessionId, ctx) {
   if (!sideEffects) return
-  const { normalizer, sessionManager, pushManager, broadcast, broadcastToSession, broadcastSessionList } = ctx
+  const { normalizer, sessionManager, pushManager, broadcast, broadcastToSession, broadcastSessionList, releasePermission } = ctx
   for (const effect of sideEffects) {
     switch (effect.type) {
       case 'session_list':
@@ -466,6 +466,20 @@ function executeSideEffects(sideEffects, sessionId, ctx) {
             broadcastSessionList()
           } else {
             broadcast({ type: 'session_list', sessions: sessionManager.listSessions() })
+          }
+        }
+        break
+      case 'release_permission':
+        // #7379: the session says the turn behind this prompt is dead, so the
+        // daemon must stop holding (and re-sending) its pending entry. Optional
+        // in ctx so a harness that does not wire permissions still forwards
+        // events; a no-op when the requestId was never in the HTTP map, which is
+        // the normal case for the SDK path and for a hook that closed cleanly.
+        if (releasePermission) {
+          try {
+            releasePermission(effect.requestId)
+          } catch (err) {
+            log.warn(`Failed to release abandoned permission ${effect.requestId}: ${err?.message || err}`)
           }
         }
         break

--- a/packages/server/src/ws-permissions.js
+++ b/packages/server/src/ws-permissions.js
@@ -887,10 +887,21 @@ export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAut
    * in this map at all. Returns whether it actually released something so
    * callers can log meaningfully.
    */
-  function releaseAbandonedPermission(requestId) {
+  function releaseAbandonedPermission(requestId, sessionId = null) {
     if (!requestId) return false
     const pending = pendingPermissions.get(requestId)
     if (!pending) return false
+    // Ownership guard. Not reachable today — ids are minted per-request here
+    // (`perm-${randomUUID()}`) and registered against their owner via the
+    // hook-secret lookup, and the SDK's `perm-<nonce>-<n>-<ts>` format cannot
+    // collide — but this releases a permission on behalf of a session, and
+    // "the caller passed the right id" is exactly the invariant a future
+    // emitter breaks silently. One line, checked against the route map rather
+    // than assumed.
+    if (sessionId && permissionSessionMap.has(requestId) && permissionSessionMap.get(requestId) !== sessionId) {
+      log.warn(`Refusing to release permission ${requestId}: owned by session ${permissionSessionMap.get(requestId)}, not ${sessionId}`)
+      return false
+    }
     log.info(`Releasing permission ${requestId}: the turn that raised it is gone (#7379)`)
     try {
       pending.resolve('deny')

--- a/packages/server/src/ws-permissions.js
+++ b/packages/server/src/ws-permissions.js
@@ -862,6 +862,47 @@ export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAut
     }
   }
 
+  /**
+   * #7379 — release a pending HTTP-hook permission whose asker is gone.
+   *
+   * Called when a session reports (via `permission_expired`) that the turn a
+   * prompt belonged to has died. The daemon cannot detect this itself: killing
+   * the CLI child does NOT kill the hook. POSIX `killProcessTree` is
+   * `child.kill('SIGTERM')` against the DIRECT child, while the hook is
+   * `bash permission-hook.sh` -> `curl --max-time 300` — both grandchildren,
+   * neither signalled, and on a crash nothing runs at all. So the socket stays
+   * open, `req 'aborted'` / `res 'close'` never fire, and the entry sits there
+   * with time left on its clock until `resendPendingPermissions` hands it to
+   * the next client that connects — a live Allow button for a turn that no
+   * longer exists (#7335 all over again, one reconnect later).
+   *
+   * Resolves as DENY, which is both the fail-closed default and the truth: the
+   * request can no longer be honoured by anyone. The shared `cleanup()` then
+   * deletes the map entry, tears down the permission-induced subscription, and
+   * releases the session's inactivity pause.
+   *
+   * Quiet and idempotent when the entry is already gone — that is the NORMAL
+   * case whenever the hook's socket did close on its own, and this is called on
+   * every `permission_expired`, including the SDK path whose prompts never live
+   * in this map at all. Returns whether it actually released something so
+   * callers can log meaningfully.
+   */
+  function releaseAbandonedPermission(requestId) {
+    if (!requestId) return false
+    const pending = pendingPermissions.get(requestId)
+    if (!pending) return false
+    log.info(`Releasing permission ${requestId}: the turn that raised it is gone (#7379)`)
+    try {
+      pending.resolve('deny')
+    } catch (err) {
+      // cleanup() runs BEFORE the response write inside resolve(), so the entry
+      // IS released even when writing to a torn-down socket throws. Same
+      // rationale as drainSessionPermissions — debug, not warn.
+      log.debug(`Permission ${requestId} released, but the deny response write failed (socket likely gone): ${err?.message || err}`)
+    }
+    return true
+  }
+
   /** Resolve a pending permission request */
   function resolvePermission(requestId, decision) {
     const pending = pendingPermissions.get(requestId)
@@ -942,6 +983,7 @@ export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAut
     handlePermissionResponseHttp,
     resendPendingPermissions,
     resolvePermission,
+    releaseAbandonedPermission,
     drainSessionPermissions,
     destroy,
     // #3996: expose the HTTP-permission limiter so /diagnostics can include

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -2345,6 +2345,13 @@ export class WsServer {
       // settings-handlers subscription guard naturally passes for legitimate
       // viewers (including the "view A → switch to B → respond" flow).
       registerPermissionRoute: (requestId, sessionId) => this._registerPermissionRoute(requestId, sessionId),
+      // #7379: a session reporting `permission_expired` means the turn that
+      // raised the prompt is gone, so the daemon's own pending entry must be
+      // released — otherwise resendPendingPermissions hands a dead prompt, with
+      // a live Allow button, to the next client that connects. One ctx serves
+      // both the multi-session and legacy-CLI forwarding paths, so wiring it
+      // here covers both by construction.
+      releasePermission: (requestId) => this._permissions?.releaseAbandonedPermission?.(requestId),
       broadcast: (msg, filter) => this._broadcast(msg, filter),
       broadcastToSession: (sid, msg, filter) => this._broadcastToSession(sid, msg, filter),
       broadcastSessionList: () => this._handlerCtx.transport.broadcastSessionList(),

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -2351,7 +2351,7 @@ export class WsServer {
       // a live Allow button, to the next client that connects. One ctx serves
       // both the multi-session and legacy-CLI forwarding paths, so wiring it
       // here covers both by construction.
-      releasePermission: (requestId) => this._permissions?.releaseAbandonedPermission?.(requestId),
+      releasePermission: (requestId, sessionId) => this._permissions?.releaseAbandonedPermission?.(requestId, sessionId),
       broadcast: (msg, filter) => this._broadcast(msg, filter),
       broadcastToSession: (sid, msg, filter) => this._broadcastToSession(sid, msg, filter),
       broadcastSessionList: () => this._handlerCtx.transport.broadcastSessionList(),

--- a/packages/server/tests/permission-release-on-turn-kill.test.js
+++ b/packages/server/tests/permission-release-on-turn-kill.test.js
@@ -1,0 +1,328 @@
+import { describe, it, beforeEach, afterEach, mock } from 'node:test'
+import assert from 'node:assert/strict'
+import { EventEmitter } from 'node:events'
+import { Readable, Writable } from 'node:stream'
+
+import { createPermissionHandler } from '../src/ws-permissions.js'
+import { setupForwarding } from '../src/ws-forwarding.js'
+import { EventNormalizer } from '../src/event-normalizer.js'
+import { CliSession } from '../src/cli-session.js'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+/**
+ * #7379 — a turn killed underneath a permission prompt must release the
+ * DAEMON's pending entry, not just retire the card in the clients.
+ *
+ * #7375 made a dying `claude-cli` turn emit `permission_expired`, which the
+ * clients use to retire the prompt. The daemon was left holding its own
+ * `pendingPermissions` entry, and it does not find out on its own: killing the
+ * CLI child does NOT kill the hook. `killProcessTree` on POSIX is
+ * `child.kill('SIGTERM')` against the direct child only, and the hook is
+ * `bash permission-hook.sh` -> `curl --max-time 300`, both grandchildren. So
+ * the socket stays open, the entry stays live with time on its clock, and
+ * `resendPendingPermissions` — which runs on EVERY client auth/connect —
+ * re-sends the dead prompt with a working Allow button. On a phone over a
+ * tunnel, a reconnect inside five minutes is routine, so this restored the
+ * exact #7335 symptom the previous PR set out to remove.
+ *
+ * These tests drive the REAL chain: a real POST /permission registers a real
+ * pending entry, a real CliSession kills its turn, and the real normalizer +
+ * forwarding wiring carries the release back to the real permission handler.
+ * Testing the units alone would have missed the wiring, which is the whole
+ * defect.
+ */
+
+function createMockChild() {
+  const child = new EventEmitter()
+  child.stdin = new Writable({ write(_c, _e, cb) { cb() } })
+  child.stdout = new Readable({ read() {} })
+  child.stderr = new Readable({ read() {} })
+  child.pid = 12345
+  child.kill = mock.fn(() => true)
+  child.killed = false
+  return child
+}
+
+function createReadyCliSession() {
+  // No `port`, so no hook manager is created and nothing touches the real
+  // ~/.claude/settings.json. `_hookSecret` is set unconditionally, which is all
+  // the ws-permissions lookup needs.
+  const session = new CliSession({ cwd: '/tmp' })
+  session._processReady = true
+  session._child = createMockChild()
+  return session
+}
+
+function makeReq(body, headers = {}) {
+  const emitter = new EventEmitter()
+  emitter.method = 'POST'
+  emitter.headers = headers
+  emitter.socket = { remoteAddress: '127.0.0.1' }
+  process.nextTick(() => {
+    emitter.emit('data', Buffer.from(body))
+    emitter.emit('end')
+  })
+  emitter.destroy = mock.fn()
+  emitter.setEncoding = mock.fn()
+  emitter.pause = mock.fn()
+  return emitter
+}
+
+function makeRes() {
+  const listeners = {}
+  return {
+    statusCode: null,
+    body: null,
+    writeHead(code) { this.statusCode = code },
+    end(b) { this.body = b },
+    on(event, cb) { listeners[event] = cb; return this },
+    emit(event, ...args) { if (listeners[event]) listeners[event](...args) },
+  }
+}
+
+/**
+ * Wire the pieces the way WsServer does: one permission handler over a shared
+ * `pendingPermissions` map, and one forwarding ctx whose `releasePermission`
+ * points at that handler.
+ */
+function buildRig(session, { wireRelease = true } = {}) {
+  const pendingPermissions = new Map()
+  const permissionSessionMap = new Map()
+  const sent = []
+
+  const handler = createPermissionHandler({
+    sendFn: (_ws, msg) => sent.push(msg),
+    broadcastFn: mock.fn(),
+    validateBearerAuth: mock.fn(() => true),
+    validateHookAuth: () => true,
+    pushManager: null,
+    pendingPermissions,
+    permissionSessionMap,
+    getSessionManager: () => null,
+    findSessionByHookSecret: (secret) =>
+      (secret === session._hookSecret ? { session, sessionId: 'test-session' } : null),
+  })
+
+  const normalizer = new EventNormalizer()
+  // setupCliForwarding subscribes to these; minimal emitters keep the wiring
+  // real without dragging in the dev-preview / checkpoint subsystems.
+  const devPreview = new EventEmitter()
+  devPreview.handleToolResult = () => {}
+  const checkpointManager = new EventEmitter()
+  const ctx = {
+    normalizer,
+    sessionManager: null,
+    cliSession: session,
+    devPreview,
+    checkpointManager,
+    pushManager: null,
+    permissionSessionMap,
+    questionSessionMap: new Map(),
+    registerQuestionRoute: () => {},
+    registerPermissionRoute: () => {},
+    broadcast: () => {},
+    broadcastToSession: () => {},
+    broadcastSessionList: () => {},
+  }
+  if (wireRelease) {
+    ctx.releasePermission = (requestId) => handler.releaseAbandonedPermission?.(requestId)
+  }
+  setupForwarding(ctx)
+
+  return { handler, pendingPermissions, sent, normalizer }
+}
+
+/** Drive a real hook request through POST /permission and return its requestId. */
+async function raisePermission(handler, session) {
+  const body = JSON.stringify({
+    tool_name: 'Bash',
+    tool_input: { command: 'rm -rf build' },
+    session_id: 'claude-sess-1',
+  })
+  const req = makeReq(body, { authorization: `Bearer ${session._hookSecret}` })
+  const res = makeRes()
+  handler.handlePermissionRequest(req, res)
+  // The 'end' handler runs on a later tick.
+  await new Promise((r) => setImmediate(r))
+  await new Promise((r) => setImmediate(r))
+  return res
+}
+
+describe('#7379 — a killed turn releases the daemon-side pending permission', () => {
+  let session
+  let rig
+
+  beforeEach(() => {
+    session = createReadyCliSession()
+    session.on('error', () => {})
+    rig = buildRig(session)
+  })
+
+  afterEach(() => {
+    rig?.handler?.destroy?.()
+    session?.destroy?.()
+  })
+
+  it('THE BUG: killing the turn removes the entry, so a reconnect cannot resurrect it', async () => {
+    await session.sendMessage('run a command')
+    await raisePermission(rig.handler, session)
+    assert.equal(rig.pendingPermissions.size, 1, 'precondition: the daemon holds a pending entry')
+
+    session._killAndRespawn()
+    await new Promise((r) => setImmediate(r))
+
+    assert.equal(rig.pendingPermissions.size, 0, 'daemon entry released with the turn')
+
+    // The actual user-visible consequence: a reconnecting client is not handed
+    // a live prompt for a turn that no longer exists.
+    rig.sent.length = 0
+    rig.handler.resendPendingPermissions({}, {})
+    const resent = rig.sent.filter((m) => m?.type === 'permission_request')
+    assert.deepEqual(resent, [], 'no permission_request re-sent for the dead prompt')
+  })
+
+  it('the same holds for a child that exits (crash, or user Stop via SIGINT)', async () => {
+    await session.sendMessage('run a command')
+    await raisePermission(rig.handler, session)
+    assert.equal(rig.pendingPermissions.size, 1)
+
+    session._handleChildClose(1)
+    await new Promise((r) => setImmediate(r))
+
+    assert.equal(rig.pendingPermissions.size, 0, 'released on the child-close path too')
+  })
+
+  it('POSITIVE CONTROL: a prompt whose turn is still alive is NOT released, and IS resent', async () => {
+    // The guard that keeps this fix from becoming "drop every pending
+    // permission" — the resend path must still work for live prompts.
+    await session.sendMessage('run a command')
+    await raisePermission(rig.handler, session)
+
+    rig.sent.length = 0
+    rig.handler.resendPendingPermissions({}, {})
+    const resent = rig.sent.filter((m) => m?.type === 'permission_request')
+
+    assert.equal(rig.pendingPermissions.size, 1, 'still pending — nothing killed the turn')
+    assert.equal(resent.length, 1, 'a live prompt is still re-sent to a reconnecting client')
+  })
+
+  it('POSITIVE CONTROL: releasing is idempotent and quiet when nothing is pending', async () => {
+    await session.sendMessage('run a command')
+    // No permission raised at all.
+    session._killAndRespawn()
+    await new Promise((r) => setImmediate(r))
+    assert.equal(rig.pendingPermissions.size, 0)
+    // And a second kill must not throw.
+    session._killAndRespawn()
+    await new Promise((r) => setImmediate(r))
+  })
+})
+
+describe('#7379 — the release reaches BOTH forwarding paths, not just one', () => {
+  it('the MULTI-SESSION path releases too (the legacy-CLI test above covers the other)', () => {
+    // The two paths are separate subscriptions over the same ctx. Wiring only
+    // one is the defect class this fix is about, so both are exercised: the
+    // integration tests above drive setupCliForwarding via a real CliSession;
+    // this drives setupSessionForwarding via a SessionManager-shaped emitter.
+    const released = []
+    const sessionManager = new EventEmitter()
+    sessionManager.getSession = () => ({ provider: 'claude-cli' })
+    sessionManager.listSessions = () => []
+    const devPreview = new EventEmitter()
+    devPreview.handleToolResult = () => {}
+    const checkpointManager = new EventEmitter()
+
+    setupForwarding({
+      normalizer: new EventNormalizer(),
+      sessionManager,
+      cliSession: null,
+      devPreview,
+      checkpointManager,
+      pushManager: null,
+      permissionSessionMap: new Map(),
+      questionSessionMap: new Map(),
+      registerQuestionRoute: () => {},
+      registerPermissionRoute: () => {},
+      releasePermission: (requestId) => released.push(requestId),
+      broadcast: () => {},
+      broadcastToSession: () => {},
+      broadcastSessionList: () => {},
+    })
+
+    sessionManager.emit('session_event', {
+      sessionId: 'sess-multi',
+      event: 'permission_expired',
+      data: { requestId: 'req-multi', message: 'turn interrupted' },
+    })
+
+    assert.deepEqual(released, ['req-multi'], 'multi-session path released the daemon entry')
+  })
+
+  it('POSITIVE CONTROL: an unrelated event does not release anything', () => {
+    const released = []
+    const sessionManager = new EventEmitter()
+    sessionManager.getSession = () => ({ provider: 'claude-cli' })
+    sessionManager.listSessions = () => []
+    const devPreview = new EventEmitter()
+    devPreview.handleToolResult = () => {}
+
+    setupForwarding({
+      normalizer: new EventNormalizer(),
+      sessionManager,
+      cliSession: null,
+      devPreview,
+      checkpointManager: new EventEmitter(),
+      pushManager: null,
+      permissionSessionMap: new Map(),
+      questionSessionMap: new Map(),
+      registerQuestionRoute: () => {},
+      registerPermissionRoute: () => {},
+      releasePermission: (requestId) => released.push(requestId),
+      broadcast: () => {},
+      broadcastToSession: () => {},
+      broadcastSessionList: () => {},
+    })
+
+    sessionManager.emit('session_event', {
+      sessionId: 'sess-multi',
+      event: 'stream_end',
+      data: { messageId: 'm1' },
+    })
+
+    assert.deepEqual(released, [], 'release is not fired unconditionally')
+  })
+})
+
+describe('#7379 — the WsServer ctx actually carries releasePermission', () => {
+  // A source-level guard, ANCHORED to the setupForwarding call rather than run
+  // over the whole file: a file-wide grep for "releasePermission" would be
+  // satisfied by the comment above it, or by any unrelated later use, and would
+  // keep passing with the wiring deleted.
+  const here = dirname(fileURLToPath(import.meta.url))
+  const src = readFileSync(join(here, '../src/ws-server.js'), 'utf-8')
+
+  function setupForwardingCallSlice() {
+    const start = src.indexOf('setupForwarding({')
+    if (start === -1) return ''
+    const end = src.indexOf('\n    })', start)
+    if (end === -1) return ''
+    return src.slice(start, end)
+  }
+
+  it('POSITIVE CONTROL: the slice is found and non-empty', () => {
+    const slice = setupForwardingCallSlice()
+    assert.ok(slice.length > 200, 'anchor located the setupForwarding ctx literal')
+    assert.match(slice, /broadcastToSession:/, 'slice really is the ctx object')
+  })
+
+  it('the ctx passes releasePermission through to the forwarding layer', () => {
+    const slice = setupForwardingCallSlice()
+    assert.match(
+      slice,
+      /releasePermission:\s*\(requestId\)\s*=>/,
+      'releasePermission is wired in the ctx that serves BOTH forwarding paths',
+    )
+  })
+})

--- a/packages/server/tests/permission-release-on-turn-kill.test.js
+++ b/packages/server/tests/permission-release-on-turn-kill.test.js
@@ -52,6 +52,10 @@ function createReadyCliSession() {
   const session = new CliSession({ cwd: '/tmp' })
   session._processReady = true
   session._child = createMockChild()
+  // _killAndRespawn / _handleChildClose reach start(), which really spawns the
+  // provider binary. Nothing here tests the respawn, so stub it: shelling out to
+  // the developer's real `claude` is a side effect the suite should not have.
+  session.start = mock.fn(async () => {})
   return session
 }
 
@@ -194,6 +198,25 @@ describe('#7379 — a killed turn releases the daemon-side pending permission', 
     assert.equal(rig.pendingPermissions.size, 0, 'released on the child-close path too')
   })
 
+  it('releases ALL of several pending prompts, despite re-entrancy into the iterated Set', async () => {
+    // Post-fix the emit inside _expirePendingPermissions reaches ws-permissions'
+    // cleanup() -> ownerSession.notifyPermissionResolved(), which DELETES from
+    // the very Set being iterated. Parallel prompts are real (the SDK raises
+    // several tool calls at once), so pin that none are skipped.
+    await session.sendMessage('run several commands')
+    await raisePermission(rig.handler, session)
+    await raisePermission(rig.handler, session)
+    await raisePermission(rig.handler, session)
+    assert.equal(rig.pendingPermissions.size, 3, 'precondition: three pending')
+
+    session._killAndRespawn()
+    await new Promise((r) => setImmediate(r))
+
+    assert.equal(rig.pendingPermissions.size, 0, 'all three released, none skipped')
+    assert.equal(session._pendingPermissionIds.size, 0, 'session bookkeeping drained')
+    assert.equal(session._resultTimeoutPaused, false, 'inactivity pause released')
+  })
+
   it('POSITIVE CONTROL: a prompt whose turn is still alive is NOT released, and IS resent', async () => {
     // The guard that keeps this fix from becoming "drop every pending
     // permission" — the resend path must still work for live prompts.
@@ -295,6 +318,79 @@ describe('#7379 — the release reaches BOTH forwarding paths, not just one', ()
   })
 })
 
+describe('#7379 C1 — the release must happen AFTER the expiry is broadcast', () => {
+  /**
+   * Releasing the daemon entry runs the shared `cleanup()`, which calls
+   * `tearDownRoute` -> `WsServer._unregisterPermissionRoute` -> `_decPermissionSub`
+   * -> `clientManager.unsubscribe`. That drops every client whose subscription
+   * to the session was PERMISSION-INDUCED and who is not actively viewing it —
+   * the #4798 "view A, get a prompt for A, switch to B" flow.
+   *
+   * `broadcastToSession`'s default recipient filter is `active || subscribed`.
+   * So releasing BEFORE the broadcast unsubscribes exactly the clients that
+   * still need to be told the prompt is dead, and their card keeps a live Allow
+   * button until the client-side expiry — reintroducing the bug this PR exists
+   * to remove, by a different route.
+   *
+   * The ordering IS the fix, so the ordering is what this pins.
+   */
+  function orderProbe() {
+    const order = []
+    const sessionManager = new EventEmitter()
+    sessionManager.getSession = () => ({ provider: 'claude-cli' })
+    sessionManager.listSessions = () => []
+    const devPreview = new EventEmitter()
+    devPreview.handleToolResult = () => {}
+
+    setupForwarding({
+      normalizer: new EventNormalizer(),
+      sessionManager,
+      cliSession: null,
+      devPreview,
+      checkpointManager: new EventEmitter(),
+      pushManager: null,
+      permissionSessionMap: new Map(),
+      questionSessionMap: new Map(),
+      registerQuestionRoute: () => {},
+      registerPermissionRoute: () => {},
+      releasePermission: () => order.push('release'),
+      broadcast: (msg) => order.push(`broadcast:${msg?.type}`),
+      broadcastToSession: (_sid, msg) => order.push(`broadcast:${msg?.type}`),
+      broadcastSessionList: () => {},
+    })
+
+    sessionManager.emit('session_event', {
+      sessionId: 'sess-1',
+      event: 'permission_expired',
+      data: { requestId: 'req-1', message: 'turn interrupted' },
+    })
+    return order
+  }
+
+  it('THE BUG: permission_expired is broadcast BEFORE the daemon entry is released', () => {
+    const order = orderProbe()
+    const b = order.indexOf('broadcast:permission_expired')
+    const r = order.indexOf('release')
+    assert.ok(b !== -1, 'the expiry was broadcast')
+    assert.ok(r !== -1, 'the entry was released')
+    assert.ok(
+      b < r,
+      `broadcast must precede release, got ${JSON.stringify(order)} — releasing first ` +
+      'unsubscribes the permission-induced viewers before they are told',
+    )
+  })
+
+  it('POSITIVE CONTROL: both still happen — deferring must not drop either', () => {
+    const order = orderProbe()
+    assert.equal(order.filter((o) => o === 'release').length, 1, 'released exactly once')
+    assert.equal(
+      order.filter((o) => o === 'broadcast:permission_expired').length,
+      1,
+      'broadcast exactly once',
+    )
+  })
+})
+
 describe('#7379 — the WsServer ctx actually carries releasePermission', () => {
   // A source-level guard, ANCHORED to the setupForwarding call rather than run
   // over the whole file: a file-wide grep for "releasePermission" would be
@@ -305,24 +401,50 @@ describe('#7379 — the WsServer ctx actually carries releasePermission', () => 
 
   function setupForwardingCallSlice() {
     const start = src.indexOf('setupForwarding({')
-    if (start === -1) return ''
-    const end = src.indexOf('\n    })', start)
-    if (end === -1) return ''
-    return src.slice(start, end)
+    assert.notEqual(start, -1, 'setupForwarding call not found')
+    assert.equal(
+      src.indexOf('setupForwarding({', start + 1),
+      -1,
+      'more than one setupForwarding call — the anchor is ambiguous',
+    )
+    // Walk to the matching close brace rather than the first `\n    })`, which
+    // lands mid-literal the moment a nested object is added. Guessing the
+    // terminator is how an anchored guard quietly starts checking the wrong
+    // region.
+    const open = src.indexOf('{', start)
+    let depth = 0
+    for (let i = open; i < src.length; i++) {
+      if (src[i] === '{') depth++
+      else if (src[i] === '}') {
+        depth--
+        if (depth === 0) return src.slice(start, i + 1)
+      }
+    }
+    return ''
   }
 
-  it('POSITIVE CONTROL: the slice is found and non-empty', () => {
+  it('POSITIVE CONTROL: the slice is the whole ctx literal, start to end', () => {
     const slice = setupForwardingCallSlice()
     assert.ok(slice.length > 200, 'anchor located the setupForwarding ctx literal')
-    assert.match(slice, /broadcastToSession:/, 'slice really is the ctx object')
+    // First and last keys of the literal — proves the slice did not stop early.
+    assert.match(slice, /normalizer:/, 'slice starts at the ctx object')
+    assert.match(slice, /broadcastSessionList:/, 'slice reaches the LAST key')
   })
 
-  it('the ctx passes releasePermission through to the forwarding layer', () => {
+  it('the ctx wires releasePermission through to releaseAbandonedPermission', () => {
     const slice = setupForwardingCallSlice()
+    // Assert the BODY, not just the key. Checking only `releasePermission:` would
+    // keep passing if the arrow were mutated to `() => undefined`, since every
+    // behavioural test in this file builds its own ctx and never imports WsServer.
     assert.match(
       slice,
-      /releasePermission:\s*\(requestId\)\s*=>/,
-      'releasePermission is wired in the ctx that serves BOTH forwarding paths',
+      /releasePermission:[^\n]*releaseAbandonedPermission/,
+      'releasePermission must actually call the handler, in the ctx that serves BOTH paths',
+    )
+    assert.match(
+      slice,
+      /releasePermission:\s*\(requestId,\s*sessionId\)/,
+      'the session id is threaded through for the ownership guard',
     )
   })
 })

--- a/packages/server/tests/permission-release-on-turn-kill.test.js
+++ b/packages/server/tests/permission-release-on-turn-kill.test.js
@@ -433,18 +433,50 @@ describe('#7379 — the WsServer ctx actually carries releasePermission', () => 
 
   it('the ctx wires releasePermission through to releaseAbandonedPermission', () => {
     const slice = setupForwardingCallSlice()
-    // Assert the BODY, not just the key. Checking only `releasePermission:` would
-    // keep passing if the arrow were mutated to `() => undefined`, since every
-    // behavioural test in this file builds its own ctx and never imports WsServer.
+    // Assert the BODY, not just the key: checking only `releasePermission:`
+    // keeps passing if the arrow is gutted to `() => undefined`, because every
+    // behavioural test here builds its own ctx and never imports WsServer.
+    //
+    // \b on BOTH sides, and it is load-bearing. A bare substring match is
+    // satisfied by `releaseAbandonedPermissionTYPO`, and the production call is
+    // OPTIONAL (`this._permissions?.releaseAbandonedPermission?.(…)`), so a
+    // misspelled callee is not a crash — it is a silent no-op. Substring guard
+    // plus optional call is precisely "success and not-checking look the same"
+    // (docs/false-safety-guards.md). Verified: the TYPO mutant passed this
+    // assertion before the word boundaries were added.
     assert.match(
       slice,
-      /releasePermission:[^\n]*releaseAbandonedPermission/,
-      'releasePermission must actually call the handler, in the ctx that serves BOTH paths',
+      /releasePermission:[^\n]*\breleaseAbandonedPermission\b/,
+      'releasePermission must call releaseAbandonedPermission exactly, in the ctx that serves BOTH paths',
     )
     assert.match(
       slice,
       /releasePermission:\s*\(requestId,\s*sessionId\)/,
       'the session id is threaded through for the ownership guard',
     )
+  })
+
+  it('and the handler really exports that method — the other half of the name match', () => {
+    // The source guard pins the CALLER's spelling. This pins the CALLEE's, so
+    // renaming the export without updating ws-server.js cannot slip through as
+    // an optional-call no-op. Together they close both directions of the seam
+    // that no behavioural test in this file can reach.
+    const probe = createPermissionHandler({
+      sendFn: () => {},
+      broadcastFn: () => {},
+      validateBearerAuth: () => true,
+      validateHookAuth: () => true,
+      pushManager: null,
+      pendingPermissions: new Map(),
+      permissionSessionMap: new Map(),
+      getSessionManager: () => null,
+      findSessionByHookSecret: () => null,
+    })
+    assert.equal(
+      typeof probe.releaseAbandonedPermission,
+      'function',
+      'ws-permissions must export releaseAbandonedPermission under exactly that name',
+    )
+    probe.destroy?.()
   })
 })


### PR DESCRIPTION
Closes #7379.

## The problem

#7375 made a dying `claude-cli` turn emit `permission_expired`, so the clients retire the prompt card. The **daemon** went on holding its own `pendingPermissions` entry — and it cannot find out on its own, because **killing the CLI child does not kill the hook**:

- POSIX `killProcessTree` is `child.kill('SIGTERM')` against the **direct child** (`platform.js:473`); the child is not spawned `detached`, so there is no process group to signal.
- The hook is `bash permission-hook.sh` → `curl --max-time 300` (`hooks/permission-hook.sh:249`) — both **grandchildren**. Neither is signalled, and on a crash no teardown runs at all.
- So the socket stays open, `req 'aborted'` / `res 'close'` never fire, and the entry sits there with time left on its clock.

`resendPendingPermissions` runs on **every** client auth/connect (`ws-history.js:737`, `:783`). So:

1. User flips to Auto while paused on a prompt → turn killed → card correctly goes dead.
2. The tunnel blips; the app reconnects inside the five-minute window.
3. The daemon re-sends the permission → **a fresh, live prompt with a working Allow button** for a turn that no longer exists.
4. Tapping Allow resolves into the orphaned `curl` whose parent `claude` is gone. Nothing runs. The user believes they approved a tool call.

That is the #7335 symptom, restored one reconnect later — on exactly the flaky-cellular path this product lives on.

## The fix

The session is the only party that knows the turn died, so it has to tell the daemon. `permission_expired` now carries a `release_permission` side effect, and `releaseAbandonedPermission` resolves the entry as **deny** — fail-closed, and simply true: nobody can honour the request any more. The shared `cleanup()` then deletes the map entry, tears down the permission-induced subscription, and releases the session's inactivity pause.

Quiet and idempotent when the entry is already gone — the normal case when the hook's socket *did* close, and for the SDK path whose prompts never live in that map.

**Why a side effect rather than an event listener.** There are **two** subscription sites — `setupSessionForwarding` (multi-session) and `setupCliForwarding` (legacy-CLI) — and wiring one is precisely how this class of bug happens. `executeSideEffects` runs on both, off a single ctx built in `ws-server.js`, so both are covered by construction rather than by remembering.

## Verification — red first, then every seam

The chain spans four files, and a break anywhere silently restores the bug. Each link was mutated independently:

| Mutation | Tests red |
|---|---|
| normalizer side effect removed | 3 |
| forwarding `case` removed | 3 |
| ws-server ctx entry removed | 1 (the anchored source guard — exactly its job) |
| release turned into a no-op | 2 |

The integration tests drive the **real** chain: a real `POST /permission` registers a real pending entry, a real `CliSession` kills its turn, and the real normalizer + forwarding wiring carries the release back to the real handler. Unit tests alone would have missed the wiring, which is the whole defect.

**Both forwarding paths are exercised** — the legacy-CLI one through a real `CliSession`, the multi-session one through a `SessionManager`-shaped emitter.

**Positive controls**, so the fix cannot degrade into "drop every pending permission":

- a prompt whose turn is still alive is neither released **nor** dropped from the resend (the resend path must keep working);
- an unrelated event (`stream_end`) releases nothing;
- the ws-server source guard is **anchored** to the `setupForwarding` ctx literal, with a control asserting the slice was actually found — a file-wide grep would be satisfied by the comment above the wiring and would keep passing with it deleted.

## Gates

- 363 tests across the permission / normalizer / cli-session suites · 443 across ws-server + forwarding · 0 failures
- All 9 `scripts/lint-*.sh` pass

## Not addressed here

Spawning the child `detached` so a process-group signal reaps hook grandchildren. That would fix the orphaned-`curl` class at the root rather than compensating for it, but it changes signal semantics for every provider that uses `killProcessTree` (acp, jsonl-subprocess, user-shell) and wants its own assessment.