### PR TITLE
fix(server): give every hook-routed provider the pending-permission bookkeeping, not just claude-cli

### DIFF
--- a/packages/server/src/base-session.js
+++ b/packages/server/src/base-session.js
@@ -1652,13 +1652,25 @@ export class BaseSession extends EventEmitter {
    * interrupt-safety timeout in #7375.
    *
    * @param {string} message Reason forwarded on the wire (clients log it; the
-   *   user-visible copy is fixed client-side). Must be non-empty — the wire
-   *   schema requires a string.
+   *   user-visible copy is fixed client-side). Falsy or empty is coerced to a
+   *   generic reason — the wire schema declares `message: z.string()`, so an
+   *   empty one would fail validation at the client.
    */
   _expirePendingPermissions(message) {
     if (this._pendingPermissionIds.size === 0) return
+    // The doc below used to say `message` must be non-empty "because the wire
+    // schema requires it" and then not enforce it — a comment describing a
+    // stronger guarantee than the code delivers, which is the defect class this
+    // whole change belongs to. ServerPermissionExpiredSchema declares
+    // `message: z.string()`, so a caller passing '' or undefined would emit a
+    // frame that fails validation at the client. Default rather than throw: the
+    // callers are turn-teardown paths, and taking a session down over a missing
+    // log string would be a worse failure than a generic one.
+    const reason = typeof message === 'string' && message.length > 0
+      ? message
+      : 'Permission request expired (the turn it belonged to ended)'
     for (const requestId of this._pendingPermissionIds) {
-      this.emit('permission_expired', { requestId, message })
+      this.emit('permission_expired', { requestId, message: reason })
     }
     this._pendingPermissionIds.clear()
     this._onPendingPermissionsAbandoned()

--- a/packages/server/src/base-session.js
+++ b/packages/server/src/base-session.js
@@ -1680,6 +1680,15 @@ export class BaseSession extends EventEmitter {
   _onPendingPermissionsAbandoned() {}
 
   _clearMessageState() {
+    // #7382 (review): expire HERE, so inheriting the bookkeeping also inherits
+    // the BEHAVIOUR. Hoisting the API alone bought a new provider the methods
+    // and none of the wiring — and the roster guard, which only checked that
+    // the methods existed, passed for a provider that never called them. A
+    // check that passes for everything is #7273's shape.
+    //
+    // Idempotent (no-op on an empty set), so providers that already expired at
+    // an earlier point in their teardown are unaffected.
+    this._expirePendingPermissions('Permission request expired (the turn it belonged to ended before it was answered)')
     this._isBusy = false
     this._currentMessageId = null
 

--- a/packages/server/src/base-session.js
+++ b/packages/server/src/base-session.js
@@ -401,6 +401,20 @@ export class BaseSession extends EventEmitter {
 
     this._isBusy = false
     this._processReady = false
+    // #7382: outstanding hook-routed permission prompts, by requestId. Hoisted
+    // from CliSession, where it was written for #2831 and stayed provider-local
+    // through #7375/#7379 — so claude-tui, which is DEFAULT_PROVIDER and routes
+    // its prompts through the SAME permission-hook.sh into the SAME daemon map,
+    // silently had none of it. `ws-permissions` guards its calls with
+    // `typeof ownerSession.notifyPermissionPending === 'function'`, so the
+    // missing methods were not an error — they were a skip, which is the
+    // success-and-not-checking shape in docs/false-safety-guards.md.
+    //
+    // Lives here so a THIRD hook-routed provider inherits it rather than
+    // re-implementing it. A derived-roster test (hook-routed-permission-
+    // bookkeeping.test.js) fails if any `*-session.js` that mints a
+    // `_hookSecret` lacks the API.
+    this._pendingPermissionIds = new Set()
     // #5375: user-initiated stop vs crash. Set by interrupt() (markIntentionalStop),
     // captured-and-cleared by the provider's close/error handler
     // (_consumeIntentionalStop) so a clean stop is not reported as an error.
@@ -1601,6 +1615,69 @@ export class BaseSession extends EventEmitter {
     }
     return super.emit(event, ...args)
   }
+
+  /**
+   * A hook-routed permission request belonging to this session is outstanding.
+   * Called by ws-permissions when the hook's POST /permission is parked (#2831).
+   */
+  notifyPermissionPending(requestId) {
+    if (!requestId || this._pendingPermissionIds.has(requestId)) return
+    this._pendingPermissionIds.add(requestId)
+    if (this._pendingPermissionIds.size === 1) this._onFirstPermissionPending()
+  }
+
+  /**
+   * A hook-routed permission resolved (allow / deny / expired). Called by
+   * ws-permissions' shared cleanup on every resolution path.
+   */
+  notifyPermissionResolved(requestId) {
+    if (!requestId || !this._pendingPermissionIds.has(requestId)) return
+    this._pendingPermissionIds.delete(requestId)
+    if (this._pendingPermissionIds.size === 0) this._onLastPermissionResolved()
+  }
+
+  /**
+   * Emit `permission_expired` for every prompt this session is still blocked on,
+   * then drop the bookkeeping (#2831, #7375, generalised in #7382).
+   *
+   * A prompt outlives its turn on BOTH sides and neither says so: the client
+   * card stays live until its own expiry, and the daemon's HTTP entry is not
+   * released by the child dying, because killing the child does not signal the
+   * hook's `curl` grandchild. Emitting here drives both — the clients retire the
+   * card, and #7381's `release_permission` after-effect releases the daemon
+   * entry so a reconnect cannot resurrect it.
+   *
+   * Call it from the provider's turn-end FUNNEL, not from hand-enumerated death
+   * sites. Enumerating by hand is what missed the plain `result` path and the
+   * interrupt-safety timeout in #7375.
+   *
+   * @param {string} message Reason forwarded on the wire (clients log it; the
+   *   user-visible copy is fixed client-side). Must be non-empty — the wire
+   *   schema requires a string.
+   */
+  _expirePendingPermissions(message) {
+    if (this._pendingPermissionIds.size === 0) return
+    for (const requestId of this._pendingPermissionIds) {
+      this.emit('permission_expired', { requestId, message })
+    }
+    this._pendingPermissionIds.clear()
+    this._onPendingPermissionsAbandoned()
+  }
+
+  /**
+   * Timer hooks for the pending-permission lifecycle. No-ops by default: the
+   * bookkeeping above is provider-agnostic, but "don't time out while the user
+   * is being asked" is not — CliSession pauses its inactivity trio, while
+   * ClaudeTuiSession's hard cap deliberately stays armed and its silence
+   * backstops are suspended by a separate AskUserQuestion mechanism.
+   *
+   * Kept as THREE hooks rather than one because the abandon path must NOT
+   * re-arm: the turn it belonged to is over. Collapsing them re-creates the
+   * #7375 regression where a cleared pause left the safety timers wedged.
+   */
+  _onFirstPermissionPending() {}
+  _onLastPermissionResolved() {}
+  _onPendingPermissionsAbandoned() {}
 
   _clearMessageState() {
     this._isBusy = false

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -1457,6 +1457,11 @@ export class ClaudeTuiSession extends BaseSession {
     // The cleanup is idempotent (rmSync force:true) so a later call is fine.
     this._cleanupTurnAttachments(this._activeTurn)
     this._activeTurn = null
+    // #7382: the PTY is gone, so every PreToolUse hook it had blocked on died
+    // with it — the prompt can never be answered. Reached on 'exit', 'error'
+    // and 'close'; this path nulls the busy triple by hand and never touches
+    // _clearTurnEndState or _clearMessageState, so it needs its own call.
+    this._expirePendingPermissions('Permission request expired (the session process exited before it could be answered)')
     this._isBusy = false
     this._currentMessageId = null
     // #4307: the PTY is gone, so the ephemeral intra-turn run_in_background
@@ -3800,6 +3805,15 @@ export class ClaudeTuiSession extends BaseSession {
    * of the current callers exercise this, but it leaves room for future
    * teardown paths that only want the cleanup half).
    */
+  /**
+   * #7382 (review): `_teardownTurn` is the OTHER turn-end path — the hard cap,
+   * the stall watchdog and the first-output watchdog all land here, and none of
+   * them reaches `_clearTurnEndState` or `_clearMessageState`. An earlier draft
+   * wired only `_clearTurnEndState` and called it "the funnel"; it has two call
+   * sites (the success path and `_finishTurnError`), so five of the six ways a
+   * TUI turn dies still stranded their prompt. Naming a funnel does not make it
+   * one — the same defect #7375 hit, one provider over.
+   */
   _teardownTurn(reason, {
     duration,
     errorPayload = null,
@@ -3828,6 +3842,7 @@ export class ClaudeTuiSession extends BaseSession {
     // 3. Per-turn attachment + busy-state cleanup. _cleanupTurnAttachments
     // runs BEFORE _activeTurn is nulled so the helper still has access
     // to attachmentsDir; no-op when the turn had no attachments.
+    this._expirePendingPermissions('Permission request expired (the turn it belonged to ended before it was answered)')
     this._cleanupTurnAttachments(this._activeTurn)
     this._activeTurn = null
     this._isBusy = false

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -3273,6 +3273,18 @@ export class ClaudeTuiSession extends BaseSession {
    * didn't run the base per-turn reset.
    */
   _clearTurnEndState() {
+    // #7382: the turn is ending, so any prompt it was blocked on can never be
+    // answered — the hook died with the turn. Expire them BEFORE the state below
+    // is torn down, so the clients retire the card and #7381's release
+    // after-effect frees the daemon's pending entry (otherwise
+    // resendPendingPermissions hands a dead prompt, with a live Allow button, to
+    // the next client that connects).
+    //
+    // Wired to this FUNNEL rather than to the individual death sites
+    // (_finishTurnError, _handleHardTimeout, _handleStreamStall, interrupt,
+    // destroy) on purpose: hand-enumerating them is exactly what missed two
+    // paths in #7375. Idempotent — a no-op when nothing is pending.
+    this._expirePendingPermissions('Permission request expired (the turn it belonged to ended before it was answered)')
     if (this._resultTimeout) { clearTimeout(this._resultTimeout); this._resultTimeout = null }
     if (this._hardTimeout) { clearTimeout(this._hardTimeout); this._hardTimeout = null }
     if (this._streamStallTimeout) { clearTimeout(this._streamStallTimeout); this._streamStallTimeout = null }

--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -447,7 +447,9 @@ export class CliSession extends BaseSession {
     // Pending-permission bookkeeping for the inactivity timer (#2831).
     // WsServer calls notifyPermissionPending/Resolved when a hook
     // permission belonging to this session is broadcast/resolved.
-    this._pendingPermissionIds = new Set()
+    // #7382: `_pendingPermissionIds` now lives on BaseSession so every
+    // hook-routed provider has it. The inactivity PAUSE stays CLI-local — it is
+    // wired to this provider's timer trio via the _on*Permission* hooks below.
     this._resultTimeoutPaused = false
   }
 
@@ -950,25 +952,6 @@ export class CliSession extends BaseSession {
    * @param {string} message Reason forwarded on the wire (clients log it; the
    *   user-visible copy is fixed client-side).
    */
-  _expirePendingPermissions(message) {
-    if (this._pendingPermissionIds.size === 0) return
-    for (const requestId of this._pendingPermissionIds) {
-      this.emit('permission_expired', { requestId, message })
-    }
-    this._pendingPermissionIds.clear()
-    // #7335: the set and this flag are ONE piece of bookkeeping —
-    // notifyPermissionPending sets both, and notifyPermissionResolved is the
-    // only other thing that unsets the flag, which it does only for an id still
-    // IN the set. Taking the ids without releasing the flag therefore wedges it
-    // true forever on any path that does not reach _clearMessageState (which
-    // resets it) — and _emitInterruptedTurnResult early-returns when the
-    // session is not busy, so that path is real. `_armResultTimeout` bails on
-    // this flag, so the cost is the inactivity warning, the hard cap AND the
-    // #4467 stream-stall recovery all silently dead for the rest of the
-    // session. Releasing it here is correct by construction: there are no
-    // pending permissions left to pause for.
-    this._resultTimeoutPaused = false
-  }
 
   // #4467: stream-stall recovery. Fires when the child has been silent
   // for `_streamStallTimeoutMs` despite the session being busy — typically
@@ -997,46 +980,52 @@ export class CliSession extends BaseSession {
    *
    * @param {string} requestId
    */
-  notifyPermissionPending(requestId) {
-    if (!requestId || this._pendingPermissionIds.has(requestId)) return
-    this._pendingPermissionIds.add(requestId)
-    if (this._pendingPermissionIds.size === 1) {
-      this._resultTimeoutPaused = true
-      // #3899: clear BOTH the soft warning and hard cap. Awaiting user
-      // input is not inactivity; the timer trio re-arms together when
-      // the last pending permission resolves.
-      if (this._resultTimeout) {
-        clearTimeout(this._resultTimeout)
-        this._resultTimeout = null
-      }
-      if (this._hardTimeout) {
-        clearTimeout(this._hardTimeout)
-        this._hardTimeout = null
-      }
-      // #4467: clear the stall timer too — waiting on the user is not a stall.
-      if (this._streamStallTimeout) {
-        clearTimeout(this._streamStallTimeout)
-        this._streamStallTimeout = null
-      }
+  /**
+   * #7382: the generic add/remove bookkeeping is BaseSession's. These hooks are
+   * the CLI-specific half — pausing the inactivity trio while the user is being
+   * asked (#2831/#3899/#4467), which is not behaviour every provider shares.
+   */
+  _onFirstPermissionPending() {
+    this._resultTimeoutPaused = true
+    // #3899: clear BOTH the soft warning and the hard cap. Awaiting user input
+    // is not inactivity; the trio re-arms together when the last pending
+    // permission resolves. #4467: the stall timer too — waiting on the user is
+    // not a stall.
+    if (this._resultTimeout) {
+      clearTimeout(this._resultTimeout)
+      this._resultTimeout = null
+    }
+    if (this._hardTimeout) {
+      clearTimeout(this._hardTimeout)
+      this._hardTimeout = null
+    }
+    if (this._streamStallTimeout) {
+      clearTimeout(this._streamStallTimeout)
+      this._streamStallTimeout = null
+    }
+  }
+
+  /** Last prompt ANSWERED — the turn continues, so re-arm the trio. */
+  _onLastPermissionResolved() {
+    this._resultTimeoutPaused = false
+    if (this._isBusy) {
+      this._armResultTimeout()
     }
   }
 
   /**
-   * Notify the session that a permission request has been resolved
-   * (allow/deny/expired). When the last outstanding permission clears,
-   * the inactivity timer re-arms for a fresh window. #2831.
+   * Last prompt ABANDONED — the turn that raised it is over, so release the
+   * pause but do NOT re-arm.
    *
-   * @param {string} requestId
+   * #7375: releasing the flag is the load-bearing half. It and the id set are
+   * one piece of bookkeeping, and `notifyPermissionResolved` only unsets the
+   * flag for an id still IN the set — so taking the ids without releasing it
+   * wedged the flag true on any path that does not reach `_clearMessageState`,
+   * leaving the inactivity warning, the hard cap and the stall recovery dead
+   * for the rest of the session.
    */
-  notifyPermissionResolved(requestId) {
-    if (!requestId || !this._pendingPermissionIds.has(requestId)) return
-    this._pendingPermissionIds.delete(requestId)
-    if (this._pendingPermissionIds.size === 0) {
-      this._resultTimeoutPaused = false
-      if (this._isBusy) {
-        this._armResultTimeout()
-      }
-    }
+  _onPendingPermissionsAbandoned() {
+    this._resultTimeoutPaused = false
   }
 
   /**

--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -1464,7 +1464,11 @@ export class CliSession extends BaseSession {
     // one wired to all of them (docs/false-safety-guards.md). Idempotent: a
     // no-op when the set is already empty, which it is on the paths that
     // expired explicitly moments earlier.
-    this._expirePendingPermissions('Permission request expired (the turn it belonged to ended before it was answered)')
+    // #7382: the expire itself moved to BaseSession._clearMessageState (called
+    // by super above), so every provider inherits it rather than each wiring
+    // its own. The explicit calls in _killAndRespawn / _handleChildClose stay:
+    // both reach this funnel via _emitInterruptedTurnResult, which early-returns
+    // when the session is not busy.
     // Reset permission pause bookkeeping — the next message starts fresh.
     this._pendingPermissionIds.clear()
     this._resultTimeoutPaused = false

--- a/packages/server/tests/hook-routed-permission-bookkeeping.test.js
+++ b/packages/server/tests/hook-routed-permission-bookkeeping.test.js
@@ -4,8 +4,6 @@ import { mkdtempSync, rmSync, readFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, dirname } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
-import { EventEmitter } from 'node:events'
-import { Readable, Writable } from 'node:stream'
 
 import { ClaudeTuiSession } from '../src/claude-tui-session.js'
 import { CliSession } from '../src/cli-session.js'
@@ -37,7 +35,7 @@ const HERE = dirname(fileURLToPath(import.meta.url))
 
 function makeTui() {
   const skillsDir = mkdtempSync(join(tmpdir(), 'chroxy-tui-skills-'))
-  const session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir, repoSkillsDir: null })
+  const session = new ClaudeTuiSession({ cwd: tmpdir(), skillsDir, repoSkillsDir: null })
   session.on('error', () => {})
   return { session, skillsDir }
 }
@@ -138,6 +136,29 @@ describe('#7382 — claude-tui tracks and expires its permission prompts', () =>
     assert.equal(expired.length, 0, 'an answered prompt is not reported as expired')
   })
 
+  it('an empty or missing reason is coerced, never emitted as-is', () => {
+    // ServerPermissionExpiredSchema declares `message: z.string()`, so an empty
+    // one fails validation at the client. The doc claimed this was required and
+    // the code did not enforce it — comment stronger than code, the same class
+    // this change is about.
+    session.notifyPermissionPending('perm-empty')
+    session._expirePendingPermissions('')
+    assert.equal(expired.length, 1)
+    assert.equal(typeof expired[0].message, 'string')
+    assert.ok(expired[0].message.length > 0, 'empty reason coerced to a generic one')
+
+    expired.length = 0
+    session.notifyPermissionPending('perm-undef')
+    session._expirePendingPermissions(undefined)
+    assert.ok(expired[0].message.length > 0, 'missing reason coerced too')
+  })
+
+  it('POSITIVE CONTROL: a real reason is passed through verbatim, not overwritten', () => {
+    session.notifyPermissionPending('perm-real')
+    session._expirePendingPermissions('a specific reason')
+    assert.equal(expired[0].message, 'a specific reason')
+  })
+
   it('every expiry carries a non-empty message (the wire schema requires it)', () => {
     session.notifyPermissionPending('perm-msg')
     session._clearTurnEndState()
@@ -213,7 +234,7 @@ describe('#7382 — the bookkeeping lives on BaseSession, so it cannot be forgot
       tmpDirs.push(skillsDir)
       let probe
       try {
-        probe = new cls({ cwd: '/tmp', skillsDir, repoSkillsDir: null })
+        probe = new cls({ cwd: tmpdir(), skillsDir, repoSkillsDir: null })
       } catch (err) {
         assert.fail(`${file}: could not construct for the behavioural probe (${err?.message}). Add the opts it needs — do not skip it.`)
       }

--- a/packages/server/tests/hook-routed-permission-bookkeeping.test.js
+++ b/packages/server/tests/hook-routed-permission-bookkeeping.test.js
@@ -1,0 +1,174 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync, readFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { EventEmitter } from 'node:events'
+import { Readable, Writable } from 'node:stream'
+
+import { ClaudeTuiSession } from '../src/claude-tui-session.js'
+import { CliSession } from '../src/cli-session.js'
+import { BaseSession } from '../src/base-session.js'
+
+/**
+ * #7382 — the pending-permission bookkeeping must belong to every HOOK-ROUTED
+ * provider, not just the one it was written for.
+ *
+ * #7375 gave `claude-cli` the ability to expire the permission prompts a dying
+ * turn leaves behind, and #7379/#7381 made that expiry release the daemon's own
+ * pending entry so a reconnect cannot resurrect a dead prompt.
+ *
+ * None of it reached `claude-tui` — which is DEFAULT_PROVIDER. It mints a
+ * `_hookSecret` and its prompts land in the same `pendingPermissions` map via
+ * the same `permission-hook.sh`, but it had no `_pendingPermissionIds`, no
+ * `notifyPermissionPending`/`Resolved`, and never emitted `permission_expired`.
+ * `ws-permissions` guards its call with
+ * `typeof ownerSession.notifyPermissionPending === 'function'`, so a TUI prompt
+ * was simply never tracked and never expired: a PTY respawn, a Stop or a crash
+ * stranded it exactly as claude-cli used to.
+ *
+ * The bookkeeping now lives on `BaseSession`, so a third hook-routed provider
+ * inherits it instead of re-implementing it — a third copy is how this defect
+ * class propagates, and the last one took three PRs to find.
+ */
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+
+function makeTui() {
+  const skillsDir = mkdtempSync(join(tmpdir(), 'chroxy-tui-skills-'))
+  const session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir, repoSkillsDir: null })
+  session.on('error', () => {})
+  return { session, skillsDir }
+}
+
+describe('#7382 — claude-tui tracks and expires its permission prompts', () => {
+  let session
+  let skillsDir
+  let expired
+
+  beforeEach(() => {
+    ;({ session, skillsDir } = makeTui())
+    expired = []
+    session.on('permission_expired', (d) => expired.push(d))
+    session._activeTurn = { messageId: 'msg-1', startedAt: Date.now(), aborted: false, synthSeq: 0 }
+    session._isBusy = true
+    session._currentMessageId = 'msg-1'
+  })
+
+  afterEach(async () => {
+    try { await session?.destroy() } catch { /* ignore */ }
+    if (skillsDir) rmSync(skillsDir, { recursive: true, force: true })
+    session = null
+  })
+
+  it('THE GAP: it exposes the notify API ws-permissions probes for', () => {
+    // ws-permissions.js guards with `typeof ownerSession.notifyPermissionPending
+    // === 'function'` — so a missing method is not an error, it is a silent
+    // skip. Success and not-checking, same observable outcome.
+    assert.equal(typeof session.notifyPermissionPending, 'function')
+    assert.equal(typeof session.notifyPermissionResolved, 'function')
+    assert.equal(typeof session._expirePendingPermissions, 'function')
+  })
+
+  it('THE BUG: a turn ending expires the prompt it was blocked on', () => {
+    session.notifyPermissionPending('perm-tui-1')
+    assert.equal(session._pendingPermissionIds.size, 1, 'precondition: tracked')
+
+    session._clearTurnEndState()
+
+    assert.deepEqual(expired.map((e) => e.requestId), ['perm-tui-1'])
+    assert.equal(session._pendingPermissionIds.size, 0, 'bookkeeping drained')
+  })
+
+  it('expires every pending prompt, not just the first', () => {
+    session.notifyPermissionPending('a')
+    session.notifyPermissionPending('b')
+    session.notifyPermissionPending('c')
+
+    session._clearTurnEndState()
+
+    assert.deepEqual(expired.map((e) => e.requestId).sort(), ['a', 'b', 'c'])
+  })
+
+  it('POSITIVE CONTROL: a turn ending with nothing pending emits nothing', () => {
+    session._clearTurnEndState()
+    assert.equal(expired.length, 0, 'not fired unconditionally')
+  })
+
+  it('POSITIVE CONTROL: a resolved prompt is not expired afterwards', () => {
+    session.notifyPermissionPending('perm-answered')
+    session.notifyPermissionResolved('perm-answered')
+
+    session._clearTurnEndState()
+
+    assert.equal(expired.length, 0, 'an answered prompt is not reported as expired')
+  })
+
+  it('every expiry carries a non-empty message (the wire schema requires it)', () => {
+    session.notifyPermissionPending('perm-msg')
+    session._clearTurnEndState()
+    assert.equal(expired.length, 1)
+    assert.equal(typeof expired[0].message, 'string')
+    assert.ok(expired[0].message.length > 0)
+  })
+})
+
+describe('#7382 — the bookkeeping lives on BaseSession, so it cannot be forgotten again', () => {
+  it('BaseSession itself provides the API', () => {
+    assert.equal(typeof BaseSession.prototype.notifyPermissionPending, 'function')
+    assert.equal(typeof BaseSession.prototype.notifyPermissionResolved, 'function')
+    assert.equal(typeof BaseSession.prototype._expirePendingPermissions, 'function')
+  })
+
+  it('claude-cli still has it (inherited, not lost in the hoist)', () => {
+    assert.equal(typeof CliSession.prototype.notifyPermissionPending, 'function')
+    assert.equal(typeof CliSession.prototype._expirePendingPermissions, 'function')
+  })
+
+  it('THE GUARD: every hook-routed session class has the bookkeeping', async () => {
+    // The roster is DERIVED, not hardcoded: any src/*-session.js that mints a
+    // _hookSecret is hook-routed and must qualify. A hardcoded list beside a
+    // growing set is the first cause in docs/false-safety-guards.md, and a new
+    // provider is exactly the thing that would be added without updating it.
+    const srcDir = join(HERE, '../src')
+    const { readdirSync } = await import('node:fs')
+    const files = readdirSync(srcDir).filter((f) => f.endsWith('-session.js') && f !== 'base-session.js')
+    // `this._hookSecret`, not a bare `_hookSecret`: the loose form matches any
+    // PROSE mention, and it immediately did — a comment added to base-session.js
+    // while writing this fix put the base class itself on the roster. A detector
+    // that a comment can move is not measuring what it claims to.
+    const hookRouted = files.filter((f) => readFileSync(join(srcDir, f), 'utf-8').includes('this._hookSecret'))
+
+    assert.ok(hookRouted.length >= 2, `expected at least cli + tui, got ${JSON.stringify(hookRouted)}`)
+    // The detector must DISCRIMINATE, not match everything: a predicate that is
+    // true for every file would satisfy the loop below for the wrong reason and
+    // keep passing when a genuinely hook-routed provider is added without the
+    // bookkeeping. sdk-session.js routes permissions in-process through
+    // PermissionManager and must NOT be on this roster.
+    assert.ok(files.includes('sdk-session.js'), 'control: sdk-session.js is in the scanned set')
+    assert.ok(
+      !hookRouted.includes('sdk-session.js'),
+      'control: the detector excludes the in-process (non-hook-routed) provider',
+    )
+    assert.ok(hookRouted.length < files.length, 'control: the roster is a strict subset')
+
+    for (const file of hookRouted) {
+      const mod = await import(join(srcDir, file))
+      const cls = Object.values(mod).find(
+        (v) => typeof v === 'function' && v.prototype instanceof BaseSession,
+      )
+      assert.ok(cls, `no BaseSession subclass exported from ${file}`)
+      assert.equal(
+        typeof cls.prototype.notifyPermissionPending,
+        'function',
+        `${file} is hook-routed but has no notifyPermissionPending — ws-permissions will silently skip it`,
+      )
+      assert.equal(
+        typeof cls.prototype._expirePendingPermissions,
+        'function',
+        `${file} is hook-routed but cannot expire its prompts on turn death`,
+      )
+    }
+  })
+})

--- a/packages/server/tests/hook-routed-permission-bookkeeping.test.js
+++ b/packages/server/tests/hook-routed-permission-bookkeeping.test.js
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict'
 import { mkdtempSync, rmSync, readFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, dirname } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 import { EventEmitter } from 'node:events'
 import { Readable, Writable } from 'node:stream'
 
@@ -91,6 +91,39 @@ describe('#7382 — claude-tui tracks and expires its permission prompts', () =>
     assert.deepEqual(expired.map((e) => e.requestId).sort(), ['a', 'b', 'c'])
   })
 
+  // #7382 review: `_clearTurnEndState` is NOT the funnel. It has exactly two
+  // call sites (the success path and `_finishTurnError`). Three more death
+  // paths route through the SIBLING helper `_teardownTurn`, and two end the
+  // turn by hand-nulling the busy triple. Wiring only the first and calling it
+  // "the funnel" is the same defect #7375 hit — a comment claiming a stronger
+  // guarantee than the code delivers. Every path below genuinely ends the turn
+  // (each sets `_isBusy = false`), so every one must expire.
+  const DEATH_PATHS = [
+    ['_handleHardTimeout', (s) => s._handleHardTimeout()],
+    ['_handleStreamStall', (s) => s._handleStreamStall()],
+    ['_handleFirstOutputTimeout', (s) => s._handleFirstOutputTimeout()],
+    ['_onPtyGone (PTY exit/crash)', (s) => s._onPtyGone('exit')],
+  ]
+
+  for (const [name, drive] of DEATH_PATHS) {
+    it(`THE GAP: ${name} ends the turn, so it must expire the prompt`, () => {
+      session.notifyPermissionPending('perm-path')
+      drive(session)
+      assert.equal(session._isBusy, false, `${name} really ended the turn`)
+      assert.deepEqual(
+        expired.map((e) => e.requestId),
+        ['perm-path'],
+        `${name} ended the turn without expiring — the card stays live and the daemon entry is never released`,
+      )
+    })
+  }
+
+  it('THE GAP: destroy() expires too', async () => {
+    session.notifyPermissionPending('perm-destroy')
+    await session.destroy()
+    assert.deepEqual(expired.map((e) => e.requestId), ['perm-destroy'])
+  })
+
   it('POSITIVE CONTROL: a turn ending with nothing pending emits nothing', () => {
     session._clearTurnEndState()
     assert.equal(expired.length, 0, 'not fired unconditionally')
@@ -126,49 +159,89 @@ describe('#7382 — the bookkeeping lives on BaseSession, so it cannot be forgot
     assert.equal(typeof CliSession.prototype._expirePendingPermissions, 'function')
   })
 
-  it('THE GUARD: every hook-routed session class has the bookkeeping', async () => {
-    // The roster is DERIVED, not hardcoded: any src/*-session.js that mints a
-    // _hookSecret is hook-routed and must qualify. A hardcoded list beside a
-    // growing set is the first cause in docs/false-safety-guards.md, and a new
-    // provider is exactly the thing that would be added without updating it.
+  it('THE GUARD: every hook-routed session EXPIRES on turn death, not merely has the methods', async () => {
+    // The roster is DERIVED, not hardcoded: any src/*-session.js that uses
+    // `this._hookSecret` is hook-routed and must qualify. A hardcoded list beside
+    // a growing set is the first cause in docs/false-safety-guards.md.
+    //
+    // And this asserts BEHAVIOUR, not method presence. The first version checked
+    // `typeof cls.prototype.notifyPermissionPending === 'function'` — which, once
+    // the methods moved onto BaseSession, was guaranteed by inheritance for every
+    // candidate the loop could ever see. Proven tautological in review: a fake
+    // BaseSession subclass that minted a _hookSecret and wired NOTHING passed,
+    // and deleting claude-tui's expiry left it green too. A check that passes for
+    // everything is #7273's shape, and it was sitting in the test that cites the
+    // catalogue.
+    //
+    // destroy() is the probe because every session has one and it must end the
+    // turn. A provider that overrides it without reaching _clearMessageState —
+    // which is exactly how claude-tui's _teardownTurn escaped — fails here.
     const srcDir = join(HERE, '../src')
     const { readdirSync } = await import('node:fs')
     const files = readdirSync(srcDir).filter((f) => f.endsWith('-session.js') && f !== 'base-session.js')
     // `this._hookSecret`, not a bare `_hookSecret`: the loose form matches any
     // PROSE mention, and it immediately did — a comment added to base-session.js
     // while writing this fix put the base class itself on the roster. A detector
-    // that a comment can move is not measuring what it claims to.
+    // a comment can move is not measuring what it claims to.
     const hookRouted = files.filter((f) => readFileSync(join(srcDir, f), 'utf-8').includes('this._hookSecret'))
 
     assert.ok(hookRouted.length >= 2, `expected at least cli + tui, got ${JSON.stringify(hookRouted)}`)
-    // The detector must DISCRIMINATE, not match everything: a predicate that is
-    // true for every file would satisfy the loop below for the wrong reason and
-    // keep passing when a genuinely hook-routed provider is added without the
-    // bookkeeping. sdk-session.js routes permissions in-process through
-    // PermissionManager and must NOT be on this roster.
+    // The detector must DISCRIMINATE, not match everything.
     assert.ok(files.includes('sdk-session.js'), 'control: sdk-session.js is in the scanned set')
-    assert.ok(
-      !hookRouted.includes('sdk-session.js'),
-      'control: the detector excludes the in-process (non-hook-routed) provider',
-    )
+    assert.ok(!hookRouted.includes('sdk-session.js'), 'control: the in-process provider is excluded')
     assert.ok(hookRouted.length < files.length, 'control: the roster is a strict subset')
 
+    const tmpDirs = []
     for (const file of hookRouted) {
-      const mod = await import(join(srcDir, file))
+      // pathToFileURL, not a bare path: the CI runner's checkout is on A:\, and
+      // Node's ESM loader rejects a Windows absolute path outright
+      // (ERR_UNSUPPORTED_ESM_URL_SCHEME — "Received protocol 'a:'"). Caught by
+      // Server Windows Tests, which is the only job that runs this on Windows.
+      const mod = await import(pathToFileURL(join(srcDir, file)).href)
       const cls = Object.values(mod).find(
         (v) => typeof v === 'function' && v.prototype instanceof BaseSession,
       )
-      assert.ok(cls, `no BaseSession subclass exported from ${file}`)
-      assert.equal(
-        typeof cls.prototype.notifyPermissionPending,
-        'function',
-        `${file} is hook-routed but has no notifyPermissionPending — ws-permissions will silently skip it`,
+      assert.ok(
+        cls,
+        `${file} is hook-routed but exports no BaseSession subclass. Config-driven providers ` +
+        `export a factory instead — extend this guard to construct it rather than deleting the check.`,
       )
+
+      // Construction failure is a FAILURE, not a skip: "cannot check" silently
+      // becoming "nothing to check" is the second cause in the catalogue.
+      const skillsDir = mkdtempSync(join(tmpdir(), 'chroxy-guard-'))
+      tmpDirs.push(skillsDir)
+      let probe
+      try {
+        probe = new cls({ cwd: '/tmp', skillsDir, repoSkillsDir: null })
+      } catch (err) {
+        assert.fail(`${file}: could not construct for the behavioural probe (${err?.message}). Add the opts it needs — do not skip it.`)
+      }
+      probe.on('error', () => {})
+      const seen = []
+      probe.on('permission_expired', (d) => seen.push(d))
+
+      // Assert the probe exists rather than letting a missing method surface as
+      // a TypeError: an unclear failure reason is how a real finding gets
+      // dismissed as "the test is broken".
       assert.equal(
-        typeof cls.prototype._expirePendingPermissions,
+        typeof probe.destroy,
         'function',
-        `${file} is hook-routed but cannot expire its prompts on turn death`,
+        `${file} exposes no destroy() — every session must have one, and it is the probe this guard drives`,
+      )
+
+      probe.notifyPermissionPending('guard-probe')
+      assert.equal(probe._pendingPermissionIds.size, 1, `${file}: precondition — the prompt is tracked`)
+
+      await probe.destroy()
+
+      assert.deepEqual(
+        seen.map((d) => d.requestId),
+        ['guard-probe'],
+        `${file} ended its session without expiring a pending prompt — the client card stays live ` +
+        `and the daemon entry is never released (#7379/#7382)`,
       )
     }
+    for (const d of tmpDirs) rmSync(d, { recursive: true, force: true })
   })
 })


### PR DESCRIPTION
Closes #7382.

## The problem

#7375 taught a dying `claude-cli` turn to expire the permission prompts it left behind; #7379/#7381 made that expiry release the daemon's own pending entry so a reconnect could not resurrect a dead prompt.

**None of it reached `claude-tui` — which is `DEFAULT_PROVIDER`.** It mints a `_hookSecret` and its prompts go through the *same* `permission-hook.sh` into the *same* `pendingPermissions` map, but it had no `_pendingPermissionIds`, no `notifyPermissionPending`/`Resolved`, and never emitted `permission_expired`.

The failure was silent by construction: `ws-permissions` guards its calls with

```js
typeof ownerSession.notifyPermissionPending === 'function'
```

so the missing methods were not an error — they were a **skip**. A TUI prompt was never tracked and never expired, so a PTY respawn, a Stop or a crash stranded it exactly as `claude-cli` used to: the bug two PRs had just finished fixing everywhere else, still live on the default provider.

## The fix

The bookkeeping moves to `BaseSession` rather than being copied a second time. A third copy is how this class propagates, and the interfaces already matched — both hook-routed providers carry `_resultTimeout` / `_hardTimeout` / `_streamStallTimeout` / `_armResultTimeout` / `_isBusy`.

| | lives where | why |
|---|---|---|
| id set, `notifyPermissionPending`, `notifyPermissionResolved`, `_expirePendingPermissions` | **BaseSession** | provider-agnostic; a third hook-routed provider inherits it |
| `_onFirstPermissionPending` / `_onLastPermissionResolved` / `_onPendingPermissionsAbandoned` | **provider** | "don't time out while the user is being asked" is *not* shared — CLI pauses its inactivity trio; TUI keeps its hard cap armed by design and suspends its silence backstops via a separate AskUserQuestion mechanism |

**Three hooks rather than one, deliberately.** The ABANDON path must not re-arm, because the turn it belonged to is over. Collapsing it with the RESOLVED path re-creates the #7375 regression where a cleared pause left the safety timers wedged for the rest of the session. A mutant that empties the abandon hook goes red.

`claude-tui` expires from **`_clearTurnEndState`** — its per-turn funnel — not from `_finishTurnError`, `_handleHardTimeout`, `_handleStreamStall`, `interrupt` and `destroy` individually. Hand-enumerating death sites is what missed two paths in #7375; the funnel is what fixed them.

## The guard

#7382 asked for something that fails when a future hook-routed provider lacks the bookkeeping. The roster is **derived, not hardcoded**: every `src/*-session.js` that uses `this._hookSecret` must expose the API.

It carries discrimination controls, because a predicate that matches *everything* would satisfy the loop for the wrong reason:

- `sdk-session.js` is in the scanned set and must **not** be on the roster (it routes permissions in-process through `PermissionManager`);
- the roster must be a strict subset of the scanned files.

Worth recording: the first draft matched a bare `_hookSecret` and immediately put `base-session.js` on the roster — off a **comment this very change added**. A detector a comment can move is not measuring what it claims to, so it now matches `this._hookSecret`.

## Verification

Red first — 7 of 9 cases failed before the change, with `claude-cli still has it` passing throughout as a control that the assertion mechanism works.

Five mutants, **each verified to land before running** (a scripted mutation that silently no-ops reports a clean zero):

| Mutation | Tests red |
|---|---|
| TUI funnel call removed | 3 |
| BaseSession expire → no-op | 12 |
| CLI abandon hook stops releasing the pause (the #7375 regression) | 1 |
| CLI pause hook stops clearing timers | 2 |
| `notifyPermissionPending` stops tracking | 16 |

## Gates

- Wide sweep: 3136 tests across every `*session*` / `permission*` / `ws-permissions*` suite — 3126 pass
- All 9 `scripts/lint-*.sh` pass

**The 10 failures are pre-existing and verified identical on `origin/main`:** the `skipPermissions (#4044)` case in `claude-tui-session.test.js`, and the `permission-hook` curl tests (which need a local daemon). Run in a smaller batch, the byok `tool dispatch` case passes — it times out only under the full-sweep load.

## Out of scope

The inactivity **pause** half for `claude-tui`. Its hard cap deliberately always arms and its silence backstops are suspended by the AskUserQuestion mechanism, so wiring the CLI's pause semantics into it is a behaviour change to a different subsystem. TUI's timer behaviour is unchanged here — this PR gives it the *expiry*, which is what #7382 is about.