### PR TITLE
fix(ci): stop restoring a 521MB npm cache onto runners that already have it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,14 @@ permissions:
 # `runner-target` and every consumer follows. The cost is one extra
 # job-scheduling hop and a `needs:` edge per consumer.
 #
+# A THIRD output, `npmcache`, rides the same predicate and feeds setup-node's
+# `cache:` input: empty on the self-hosted pool (whose ~/.npm is already warm and
+# persistent), `npm` on GitHub-hosted fork-PR runners (whose VM is fresh). See the
+# long comment on the `resolve` step for the measurements behind it (#7383). Every
+# setup-node consumer routed through this job MUST take `cache:` from `npmcache`
+# rather than hardcoding `npm` — a new job that hardcodes it silently re-adds a
+# 521 MB per-job download, so `ci-npm-cache-routing.test.js` fails the build on it.
+#
 # The macOS desktop job uses the separate self-hosted macOS runner and routes on
 # the same boolean inline in its `if:` (it has no shared `runs-on` array, so it
 # is not a `runner-target` consumer). The Windows jobs route through a second
@@ -70,19 +78,51 @@ jobs:
     outputs:
       runner: ${{ steps.resolve.outputs.runner }}
       winrunner: ${{ steps.resolve.outputs.winrunner }}
+      npmcache: ${{ steps.resolve.outputs.npmcache }}
     steps:
       - id: resolve
         # The condition is the same routing predicate the per-job ternary used:
         # push events and same-repo PRs are trusted; fork PRs are not.
         #   * runner    — Linux pool (label `chroxy-linux`) / ubuntu-24.04 for forks
         #   * winrunner — Windows pool (self-hosted chroxy-win) / windows-latest for forks
+        #   * npmcache  — setup-node's `cache:` input; EMPTY on self-hosted, `npm` on hosted (#7383)
+        #
+        # npmcache rides the SAME predicate on purpose: "which runner" and "does
+        # that runner already have a warm ~/.npm" are the same question, and
+        # giving it its own copy of the condition is how the two drift apart.
+        #
+        # Why empty for self-hosted: the pool members are LONG-LIVED (the Mac
+        # Docker members have been up for weeks; the winbox VM's
+        # /opt/actions-runner/_work persists across jobs), so `~/.npm` is already
+        # warm — measured at 2.2 GB, populated since the container was built.
+        # `cache: npm` made every job additionally DOWNLOAD a 521 MB
+        # actions/cache tarball and unpack it over that superset: pure overhead,
+        # 12 Linux jobs per run. Measured setup-node cost with it enabled:
+        # p50 55-58s, p90 98-244s, max 521s. Worse than slow, it is the step
+        # that FAILS: on chroxy-linux-winbox-01 the download stalls at
+        # `Received 0 of 521063625 (0.0%), 0.0 MBs/sec`, burns the job's whole
+        # `timeout-minutes`, and the resulting cancellation renders as `fail` in
+        # `gh pr checks` with every real step `skipped` — 9 such cancellations
+        # across 4 PRs before this was tracked down.
+        #
+        # Hosted runners are the opposite case and KEEP `npm`: a fork PR gets a
+        # fresh ubuntu-24.04 VM with an empty ~/.npm, so the restore is the only
+        # thing standing between it and a cold `npm ci` of the whole monorepo.
+        #
+        # `cache: ''` is how you tell setup-node "no cache" — its `if (cache)`
+        # guard treats the empty string as absent. `cache-dependency-path` stays
+        # on every job because it is what the hosted branch keys on; it is inert
+        # when `cache` is empty. packages/server/tests/ci-npm-cache-routing.test.js
+        # holds this whole arrangement in place.
         run: |
           if [ "${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}" = "true" ]; then
             echo 'runner=["self-hosted", "Linux", "chroxy-linux"]' >> "$GITHUB_OUTPUT"
             echo 'winrunner=["self-hosted", "Windows", "X64", "chroxy-win"]' >> "$GITHUB_OUTPUT"
+            echo 'npmcache=' >> "$GITHUB_OUTPUT"
           else
             echo 'runner="ubuntu-24.04"' >> "$GITHUB_OUTPUT"
             echo 'winrunner="windows-latest"' >> "$GITHUB_OUTPUT"
+            echo 'npmcache=npm' >> "$GITHUB_OUTPUT"
           fi
   server-tests:
     name: Server Tests
@@ -123,7 +163,7 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
-          cache: npm
+          cache: ${{ needs.runner-target.outputs.npmcache }}
           cache-dependency-path: '**/package-lock.json'
 
       - name: Install dependencies
@@ -274,7 +314,7 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
-          cache: npm
+          cache: ${{ needs.runner-target.outputs.npmcache }}
           cache-dependency-path: '**/package-lock.json'
 
       - name: Install dependencies
@@ -338,7 +378,7 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
-          cache: npm
+          cache: ${{ needs.runner-target.outputs.npmcache }}
           cache-dependency-path: '**/package-lock.json'
 
       - name: Install dependencies
@@ -598,7 +638,7 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
-          cache: npm
+          cache: ${{ needs.runner-target.outputs.npmcache }}
           cache-dependency-path: '**/package-lock.json'
 
       - name: Install dependencies
@@ -634,7 +674,7 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
-          cache: npm
+          cache: ${{ needs.runner-target.outputs.npmcache }}
           cache-dependency-path: '**/package-lock.json'
 
       - name: Install dependencies
@@ -702,7 +742,7 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
-          cache: npm
+          cache: ${{ needs.runner-target.outputs.npmcache }}
           cache-dependency-path: '**/package-lock.json'
 
       - name: Install dependencies
@@ -738,7 +778,7 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
-          cache: npm
+          cache: ${{ needs.runner-target.outputs.npmcache }}
           cache-dependency-path: '**/package-lock.json'
 
       - name: Install dependencies
@@ -767,7 +807,7 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
-          cache: npm
+          cache: ${{ needs.runner-target.outputs.npmcache }}
           cache-dependency-path: '**/package-lock.json'
 
       - name: Install dependencies
@@ -794,7 +834,7 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
-          cache: npm
+          cache: ${{ needs.runner-target.outputs.npmcache }}
           cache-dependency-path: '**/package-lock.json'
 
       - name: Install dependencies
@@ -833,7 +873,7 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
-          cache: npm
+          cache: ${{ needs.runner-target.outputs.npmcache }}
           cache-dependency-path: '**/package-lock.json'
 
       - name: Install dependencies
@@ -861,7 +901,7 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
-          cache: npm
+          cache: ${{ needs.runner-target.outputs.npmcache }}
           cache-dependency-path: '**/package-lock.json'
 
       - name: Install dependencies
@@ -952,7 +992,7 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
-          cache: npm
+          cache: ${{ needs.runner-target.outputs.npmcache }}
           cache-dependency-path: '**/package-lock.json'
 
       - name: Install dependencies
@@ -1106,7 +1146,7 @@ jobs:
           # resolves an explicit `renovate@<version>` spec regardless of what
           # is cached — the staleness that motivated pinning came from an
           # UNPINNED spec silently reusing whatever the cache held.
-          cache: npm
+          cache: ${{ needs.runner-target.outputs.npmcache }}
           # Glob, not the bare root lockfile: this monorepo has three
           # (root, packages/server, packages/server/sidecar) and the cache key
           # must cover all of them. packages/server/tests/ci-cache-key.test.js

--- a/.github/workflows/maestro-nightly.yml
+++ b/.github/workflows/maestro-nightly.yml
@@ -42,8 +42,18 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
-          cache: npm
-          cache-dependency-path: package-lock.json
+          # No `cache:` — #7383. This job is pinned to the self-hosted macOS
+          # runner and, as the comment above says, is unreachable from a fork, so
+          # there is no hosted branch to route for: it is ALWAYS on a box whose
+          # ~/.npm is already warm (4.8 GB on the current runner). `cache: npm`
+          # only restored a 1.86 GB actions/cache entry over a superset of
+          # itself. ci.yml's 13 consumers took the routed form instead because
+          # they DO have a fork-PR branch that still needs the restore.
+          #
+          # It also carried `cache-dependency-path: package-lock.json` — the bare
+          # root lockfile that ci-cache-key.test.js forbids, in a repo with three
+          # lockfiles, so a change under packages/ never busted the key. Both are
+          # gone with the cache.
 
       - name: Install dependencies
         run: npm ci

--- a/packages/server/tests/ci-npm-cache-routing.test.js
+++ b/packages/server/tests/ci-npm-cache-routing.test.js
@@ -99,9 +99,21 @@ function parseSteps(bodyLines) {
   })
 }
 
+/**
+ * Drop comment lines.
+ *
+ * ci.yml is heavily commented and several of those comments quote the very
+ * strings this file matches on — `cache: npm` in the rationale for removing it,
+ * and `npm ci` twice in `server-tests-windows`'s explanation of its 20-minute
+ * budget. A guard that reads prose as configuration is satisfiable by prose.
+ */
+function code(lines) {
+  return lines.filter(l => !/^\s*#/.test(l))
+}
+
 /** The value of a `with:` input inside a single step block, or undefined. */
 function stepInput(stepLines, key) {
-  for (const line of stepLines) {
+  for (const line of code(stepLines)) {
     const m = new RegExp(`^\\s*${key}:\\s*(.*)$`).exec(line)
     if (!m) continue
     let v = m[1].trim()
@@ -166,7 +178,9 @@ describe('CI npm cache routing (#7383)', () => {
   it('runner-target exposes an npmcache output', () => {
     const job = jobs.find(j => j.id === 'runner-target')
     assert.ok(
-      job.body.some(l => /^\s*npmcache:\s*\$\{\{\s*steps\.resolve\.outputs\.npmcache\s*\}\}\s*$/.test(l)),
+      code(job.body).some(l =>
+        /^\s*npmcache:\s*\$\{\{\s*steps\.resolve\.outputs\.npmcache\s*\}\}\s*$/.test(l)
+      ),
       "runner-target must expose 'npmcache: ${{ steps.resolve.outputs.npmcache }}' in its outputs"
     )
   })
@@ -176,8 +190,13 @@ describe('CI npm cache routing (#7383)', () => {
     // the `if` body is the trusted/self-hosted case, the `else` body is the fork
     // case. Asserting each npmcache value inside its own branch is what makes a
     // swap fail — checking only that both strings appear somewhere would not.
+    // The resolve STEP's shell, comments stripped — not the job body. The long
+    // rationale comment directly above that shell names both branch values, so a
+    // job-body scan would be reading the explanation rather than the code.
     const job = jobs.find(j => j.id === 'runner-target')
-    const text = job.body.join('\n')
+    const resolveStep = job.steps.find(s => s.some(l => /^\s*(- )?id: resolve\s*$/.test(l)))
+    assert.ok(resolveStep, "expected a step with 'id: resolve' in runner-target")
+    const text = code(resolveStep).join('\n')
 
     const ifAt = text.indexOf('echo \'runner=["self-hosted"')
     const elseAt = text.indexOf('echo \'runner="ubuntu-24.04"\'')
@@ -232,10 +251,16 @@ describe('CI npm cache routing (#7383)', () => {
     // `cache:` off entirely costs the self-hosted pool nothing (which is why it
     // would go unnoticed) while making every fork PR do a cold `npm ci` of the
     // whole monorepo on a fresh VM.
+    // Scans STEP bodies, minus comments — not the whole job. `server-tests-windows`
+    // explains its 20-minute budget in prose that mentions `npm ci` twice, so a
+    // job-body scan reads two comments as install steps. It reaches the right
+    // verdict there only because that job also genuinely installs; a job that
+    // merely *discussed* npm ci would be misclassified, and then required to
+    // declare a cache it has no use for.
     const installers = jobs.filter(
       job =>
         ROUTED_RUNNER_OUTPUTS.some(o => job.runsOn.includes(o)) &&
-        job.body.some(l => /(^|\s)npm ci(\s|$)/.test(l))
+        job.steps.some(step => code(step).some(l => /(^|\s)npm ci(\s|$)/.test(l)))
     )
     assert.ok(
       installers.length >= 12,

--- a/packages/server/tests/ci-npm-cache-routing.test.js
+++ b/packages/server/tests/ci-npm-cache-routing.test.js
@@ -1,0 +1,294 @@
+import { before, describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+
+/**
+ * #7383 — setup-node's npm cache must be routed, never hardcoded.
+ *
+ * The self-hosted pool members are long-lived and their `~/.npm` is already warm
+ * (measured 2.2 GB, persistent since the container was built), so `cache: npm`
+ * only made every job additionally download and unpack a 521 MB actions/cache
+ * tarball over a superset of itself. On `chroxy-linux-winbox-01` that download
+ * stalls outright — `Received 0 of 521063625 (0.0%), 0.0 MBs/sec` — until the job
+ * burns its entire `timeout-minutes`, and the cancellation renders as `fail` in
+ * `gh pr checks` with every real step `skipped`. Nine such cancellations across
+ * four PRs looked exactly like test failures.
+ *
+ * GitHub-hosted fork-PR runners are the opposite case: a fresh VM with an empty
+ * `~/.npm`, where the restore is the only thing standing between the job and a
+ * cold `npm ci` of the whole monorepo. So the cache is not removed, it is ROUTED
+ * on the same predicate as the runner itself, via `runner-target.outputs.npmcache`.
+ *
+ * What this guard is defending against is the growth case, which is the shape
+ * this repo keeps getting caught by (docs/false-safety-guards.md: "a hardcoded
+ * list next to a set that grows"). Adding a job is routine; adding a job that
+ * copy-pastes `cache: npm` from its neighbour silently re-adds the 521 MB
+ * download for that job only, and nothing else in the repo would notice.
+ *
+ * It therefore asserts BEHAVIOUR, not presence:
+ *   - the two `npmcache` values are checked in the RIGHT branch of the resolve
+ *     script (swapping them would leave both an `npmcache` output and 13 routed
+ *     consumers in place while doing precisely the wrong thing on both runners);
+ *   - every routed setup-node step is checked, discovered by scanning rather than
+ *     from a list this file holds.
+ *
+ * The scan is a small indentation-aware reader rather than a file-wide grep,
+ * because a file-wide grep for `cache: npm` is satisfied by the prose in ci.yml's
+ * own comments explaining why `cache: npm` was removed. Every assertion below is
+ * anchored to a step body. `parses ci.yml into jobs and steps` is the positive
+ * control: if the reader ever stops understanding ci.yml's shape it fails there,
+ * loudly, instead of letting every later assertion pass over an empty set.
+ */
+
+const SETUP_NODE = 'actions/setup-node@'
+const ROUTED_CACHE = '${{ needs.runner-target.outputs.npmcache }}'
+
+/** Runner-target outputs that mean "this job's runner depends on the trust predicate". */
+const ROUTED_RUNNER_OUTPUTS = ['needs.runner-target.outputs.runner', 'needs.runner-target.outputs.winrunner']
+
+/**
+ * Split ci.yml's `jobs:` mapping into per-job blocks.
+ *
+ * Job ids are the only keys at exactly two-space indent, and ci.yml has a single
+ * top-level `jobs:` key, so this needs no general YAML support — but it must not
+ * silently return nothing, which is what the positive control below checks.
+ */
+function parseJobs(ciYml) {
+  const lines = ciYml.split('\n')
+  const jobsAt = lines.findIndex(l => l === 'jobs:')
+  assert.notEqual(jobsAt, -1, "ci.yml should have a top-level 'jobs:' key")
+
+  const starts = []
+  for (let i = jobsAt + 1; i < lines.length; i++) {
+    const m = /^ {2}([A-Za-z0-9_-]+):\s*$/.exec(lines[i])
+    if (m) starts.push({ id: m[1], line: i })
+  }
+
+  return starts.map((s, idx) => {
+    const end = idx + 1 < starts.length ? starts[idx + 1].line : lines.length
+    const body = lines.slice(s.line, end)
+    const runsOn = body.find(l => /^\s*runs-on:/.test(l)) ?? ''
+    return { id: s.id, line: s.line + 1, body, runsOn, steps: parseSteps(body) }
+  })
+}
+
+/**
+ * Split a job body into step blocks.
+ *
+ * A step begins at a `- ` list item under `steps:`; the block runs until the next
+ * list item at the same indent or the end of the job. Only step bodies are ever
+ * asserted on, which is what keeps ci.yml's explanatory comments — several of
+ * which quote `cache: npm` verbatim — out of the guard's reach.
+ */
+function parseSteps(bodyLines) {
+  const stepsAt = bodyLines.findIndex(l => /^\s*steps:\s*$/.test(l))
+  if (stepsAt === -1) return []
+
+  const starts = []
+  let indent = null
+  for (let i = stepsAt + 1; i < bodyLines.length; i++) {
+    const m = /^(\s*)- /.exec(bodyLines[i])
+    if (!m) continue
+    if (indent === null) indent = m[1].length
+    if (m[1].length === indent) starts.push(i)
+  }
+
+  return starts.map((start, idx) => {
+    const end = idx + 1 < starts.length ? starts[idx + 1] : bodyLines.length
+    return bodyLines.slice(start, end)
+  })
+}
+
+/** The value of a `with:` input inside a single step block, or undefined. */
+function stepInput(stepLines, key) {
+  for (const line of stepLines) {
+    const m = new RegExp(`^\\s*${key}:\\s*(.*)$`).exec(line)
+    if (!m) continue
+    let v = m[1].trim()
+    if ((v.startsWith("'") && v.endsWith("'")) || (v.startsWith('"') && v.endsWith('"'))) {
+      v = v.slice(1, -1)
+    }
+    return v
+  }
+  return undefined
+}
+
+describe('CI npm cache routing (#7383)', () => {
+  let ciYml
+  let jobs
+  let setupNodeSteps
+
+  before(async () => {
+    ciYml = await readFile(new URL('../../../.github/workflows/ci.yml', import.meta.url), 'utf8')
+    jobs = parseJobs(ciYml)
+    setupNodeSteps = jobs.flatMap(job =>
+      job.steps.filter(s => s.some(l => l.includes(SETUP_NODE))).map(step => ({ job, step }))
+    )
+  })
+
+  // ---- positive control -------------------------------------------------
+  // Every assertion below quantifies over what the reader found. If the reader
+  // breaks, they all pass over an empty set and report a clean green — the exact
+  // "cannot check this treated as nothing to check" failure in
+  // docs/false-safety-guards.md. These three make that impossible.
+
+  it('parses ci.yml into jobs and steps', () => {
+    assert.ok(jobs.length >= 15, `expected to parse >=15 jobs from ci.yml, got ${jobs.length}`)
+    assert.ok(
+      jobs.some(j => j.id === 'runner-target'),
+      `expected a 'runner-target' job among: ${jobs.map(j => j.id).join(', ')}`
+    )
+    assert.ok(
+      jobs.every(j => j.runsOn !== ''),
+      `every job should have a runs-on: ${jobs.filter(j => j.runsOn === '').map(j => j.id).join(', ')}`
+    )
+  })
+
+  it('finds the setup-node steps', () => {
+    assert.ok(
+      setupNodeSteps.length >= 15,
+      `expected >=15 setup-node steps, found ${setupNodeSteps.length}`
+    )
+  })
+
+  it('finds the routed setup-node steps', () => {
+    const routed = setupNodeSteps.filter(({ job }) =>
+      ROUTED_RUNNER_OUTPUTS.some(o => job.runsOn.includes(o))
+    )
+    assert.ok(
+      routed.length >= 13,
+      `expected >=13 setup-node steps in runner-target-routed jobs, found ${routed.length}`
+    )
+  })
+
+  // ---- the resolve job emits the output, with the right value per branch ----
+
+  it('runner-target exposes an npmcache output', () => {
+    const job = jobs.find(j => j.id === 'runner-target')
+    assert.ok(
+      job.body.some(l => /^\s*npmcache:\s*\$\{\{\s*steps\.resolve\.outputs\.npmcache\s*\}\}\s*$/.test(l)),
+      "runner-target must expose 'npmcache: ${{ steps.resolve.outputs.npmcache }}' in its outputs"
+    )
+  })
+
+  it('resolves npmcache empty for self-hosted and npm for hosted, in that order', () => {
+    // The resolve script's if-branch is the SAME predicate that picks the runner:
+    // the `if` body is the trusted/self-hosted case, the `else` body is the fork
+    // case. Asserting each npmcache value inside its own branch is what makes a
+    // swap fail — checking only that both strings appear somewhere would not.
+    const job = jobs.find(j => j.id === 'runner-target')
+    const text = job.body.join('\n')
+
+    const ifAt = text.indexOf('echo \'runner=["self-hosted"')
+    const elseAt = text.indexOf('echo \'runner="ubuntu-24.04"\'')
+    assert.ok(ifAt !== -1, "expected the self-hosted branch to set runner=[\"self-hosted\", ...]")
+    assert.ok(elseAt !== -1, 'expected the fork branch to set runner="ubuntu-24.04"')
+    assert.ok(ifAt < elseAt, 'expected the self-hosted branch to come first')
+
+    const selfHostedBranch = text.slice(ifAt, elseAt)
+    const hostedBranch = text.slice(elseAt)
+
+    assert.match(
+      selfHostedBranch,
+      /echo 'npmcache=' >> "\$GITHUB_OUTPUT"/,
+      'the self-hosted branch must set npmcache to the EMPTY string — its ~/.npm is already warm, ' +
+        'and restoring the 521 MB actions/cache entry over it is what #7383 is about'
+    )
+    assert.match(
+      hostedBranch,
+      /echo 'npmcache=npm' >> "\$GITHUB_OUTPUT"/,
+      'the fork/hosted branch must set npmcache=npm — a fresh ubuntu-24.04 VM has an empty ~/.npm ' +
+        'and genuinely needs the restore'
+    )
+  })
+
+  // ---- every routed consumer takes the cache from that output --------------
+
+  it('a routed setup-node step that caches at all, caches via npmcache', () => {
+    // Not every routed job wants a cache: `scripts-tests` and `release-pr-subject`
+    // use setup-node for the Node runtime alone and never install anything, so
+    // "has no cache" is correct for them and must stay allowed. The rule is about
+    // the value when one IS declared.
+    const offenders = []
+    for (const { job, step } of setupNodeSteps) {
+      if (!ROUTED_RUNNER_OUTPUTS.some(o => job.runsOn.includes(o))) continue
+      const cache = stepInput(step, 'cache')
+      if (cache !== undefined && cache !== ROUTED_CACHE) {
+        offenders.push(`${job.id} (ci.yml:${job.line}) has cache: ${cache}`)
+      }
+    }
+    assert.deepEqual(
+      offenders,
+      [],
+      'a job routed through runner-target must take setup-node\'s cache from ' +
+        `'cache: ${ROUTED_CACHE}'. Hardcoding 'npm' re-adds a 521 MB per-job download on the ` +
+        `self-hosted pool (#7383):\n  ${offenders.join('\n  ')}`
+    )
+  })
+
+  it('every routed job that runs npm ci declares the routed cache', () => {
+    // The other half of the rule, and the one that catches an OMISSION rather
+    // than a wrong value: a new routed job that installs dependencies but leaves
+    // `cache:` off entirely costs the self-hosted pool nothing (which is why it
+    // would go unnoticed) while making every fork PR do a cold `npm ci` of the
+    // whole monorepo on a fresh VM.
+    const installers = jobs.filter(
+      job =>
+        ROUTED_RUNNER_OUTPUTS.some(o => job.runsOn.includes(o)) &&
+        job.body.some(l => /(^|\s)npm ci(\s|$)/.test(l))
+    )
+    assert.ok(
+      installers.length >= 12,
+      `expected >=12 routed jobs running 'npm ci', found ${installers.length} ` +
+        '(positive control: if this drops, the scan stopped seeing the install steps)'
+    )
+
+    const offenders = installers
+      .filter(job => {
+        const step = job.steps.find(s => s.some(l => l.includes(SETUP_NODE)))
+        return !step || stepInput(step, 'cache') !== ROUTED_CACHE
+      })
+      .map(job => `${job.id} (ci.yml:${job.line})`)
+    assert.deepEqual(
+      offenders,
+      [],
+      `routed jobs that run 'npm ci' must set 'cache: ${ROUTED_CACHE}': ${offenders.join(', ')}`
+    )
+  })
+
+  it('no setup-node step hardcodes cache: npm', () => {
+    // Deliberately covers UNROUTED jobs too. A hosted-pinned job hardcoding the
+    // cache is defensible today, but the ones that exist (dashboard-smoke) do not
+    // set a cache at all, so there is no legitimate hardcode left in the file —
+    // and the moment one appears it is worth a deliberate look rather than a
+    // copy-paste. Anchored to step bodies, so ci.yml's comments about `cache: npm`
+    // do not trip it.
+    const offenders = setupNodeSteps
+      .filter(({ step }) => stepInput(step, 'cache') === 'npm')
+      .map(({ job }) => `${job.id} (ci.yml:${job.line})`)
+    assert.deepEqual(offenders, [], `setup-node steps hardcoding 'cache: npm': ${offenders.join(', ')}`)
+  })
+
+  it('every routed cache still declares cache-dependency-path for the hosted branch', () => {
+    // `cache-dependency-path` is inert when `cache` resolves to empty, which is
+    // exactly what makes it easy to delete as dead config — but it is what the
+    // FORK-PR branch keys on. Dropping it would silently narrow the hosted cache
+    // key to the default (the root lockfile alone) in a monorepo with three, so
+    // a lockfile change under packages/ would reuse a stale entry.
+    const cached = setupNodeSteps.filter(({ step }) => stepInput(step, 'cache') === ROUTED_CACHE)
+    assert.ok(
+      cached.length >= 13,
+      `expected >=13 routed-cache setup-node steps, found ${cached.length} ` +
+        '(positive control for the assertion below)'
+    )
+
+    const missing = cached
+      .filter(({ step }) => stepInput(step, 'cache-dependency-path') !== '**/package-lock.json')
+      .map(({ job }) => `${job.id} (ci.yml:${job.line})`)
+    assert.deepEqual(
+      missing,
+      [],
+      `steps using the routed cache must keep cache-dependency-path: '**/package-lock.json': ${missing.join(', ')}`
+    )
+  })
+})

--- a/packages/server/tests/ci-npm-cache-routing.test.js
+++ b/packages/server/tests/ci-npm-cache-routing.test.js
@@ -1,6 +1,6 @@
 import { before, describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { readFile } from 'node:fs/promises'
+import { readFile, readdir } from 'node:fs/promises'
 
 /**
  * #7383 — setup-node's npm cache must be routed, never hardcoded.
@@ -111,16 +111,30 @@ function code(lines) {
   return lines.filter(l => !/^\s*#/.test(l))
 }
 
-/** The value of a `with:` input inside a single step block, or undefined. */
+/**
+ * The value of a `with:` input inside a single step block, or undefined.
+ *
+ * Must strip a TRAILING comment, not just a whole-line one. `cache: npm # hosted-only`
+ * parses as `npm` in YAML, and a naive read of the rest of the line sees
+ * `npm # hosted-only` — which matches no rule and so slips past every assertion
+ * here. Verified: adding exactly that line to a job left the suite 9/9 green
+ * while the workflow really did hardcode the cache.
+ */
 function stepInput(stepLines, key) {
   for (const line of code(stepLines)) {
     const m = new RegExp(`^\\s*${key}:\\s*(.*)$`).exec(line)
     if (!m) continue
-    let v = m[1].trim()
-    if ((v.startsWith("'") && v.endsWith("'")) || (v.startsWith('"') && v.endsWith('"'))) {
-      v = v.slice(1, -1)
+    const raw = m[1].trim()
+
+    // A quoted scalar ends at its closing quote; anything after it is a comment.
+    if (raw.startsWith("'") || raw.startsWith('"')) {
+      const q = raw[0]
+      const close = raw.indexOf(q, 1)
+      return close === -1 ? raw.slice(1) : raw.slice(1, close)
     }
-    return v
+    // Otherwise a ` #` (whitespace-preceded, per YAML) starts a comment. `${{ }}`
+    // expressions contain no `#`, so this cannot truncate a routed value.
+    return raw.replace(/\s+#.*$/, '').trim()
   }
   return undefined
 }
@@ -145,7 +159,11 @@ describe('CI npm cache routing (#7383)', () => {
   // docs/false-safety-guards.md. These three make that impossible.
 
   it('parses ci.yml into jobs and steps', () => {
-    assert.ok(jobs.length >= 15, `expected to parse >=15 jobs from ci.yml, got ${jobs.length}`)
+    // Thresholds are LOOSE on purpose. Their job is to catch a reader that has
+    // stopped understanding ci.yml (which yields zero), not to pin the job count
+    // — sitting them on today's exact numbers would turn "a job was merged away"
+    // into a failure that blames the reader for someone else's refactor.
+    assert.ok(jobs.length >= 10, `expected to parse >=10 jobs from ci.yml, got ${jobs.length}`)
     assert.ok(
       jobs.some(j => j.id === 'runner-target'),
       `expected a 'runner-target' job among: ${jobs.map(j => j.id).join(', ')}`
@@ -158,8 +176,8 @@ describe('CI npm cache routing (#7383)', () => {
 
   it('finds the setup-node steps', () => {
     assert.ok(
-      setupNodeSteps.length >= 15,
-      `expected >=15 setup-node steps, found ${setupNodeSteps.length}`
+      setupNodeSteps.length >= 8,
+      `expected >=8 setup-node steps, found ${setupNodeSteps.length} — the reader is probably broken`
     )
   })
 
@@ -168,8 +186,9 @@ describe('CI npm cache routing (#7383)', () => {
       ROUTED_RUNNER_OUTPUTS.some(o => job.runsOn.includes(o))
     )
     assert.ok(
-      routed.length >= 13,
-      `expected >=13 setup-node steps in runner-target-routed jobs, found ${routed.length}`
+      routed.length >= 8,
+      `expected >=8 setup-node steps in runner-target-routed jobs, found ${routed.length} — ` +
+        'the reader is probably broken'
     )
   })
 
@@ -263,9 +282,9 @@ describe('CI npm cache routing (#7383)', () => {
         job.steps.some(step => code(step).some(l => /(^|\s)npm ci(\s|$)/.test(l)))
     )
     assert.ok(
-      installers.length >= 12,
-      `expected >=12 routed jobs running 'npm ci', found ${installers.length} ` +
-        '(positive control: if this drops, the scan stopped seeing the install steps)'
+      installers.length >= 8,
+      `expected >=8 routed jobs running 'npm ci', found ${installers.length} ` +
+        '(positive control: if this drops to nothing, the scan stopped seeing install steps)'
     )
 
     const offenders = installers
@@ -302,8 +321,8 @@ describe('CI npm cache routing (#7383)', () => {
     // a lockfile change under packages/ would reuse a stale entry.
     const cached = setupNodeSteps.filter(({ step }) => stepInput(step, 'cache') === ROUTED_CACHE)
     assert.ok(
-      cached.length >= 13,
-      `expected >=13 routed-cache setup-node steps, found ${cached.length} ` +
+      cached.length >= 8,
+      `expected >=8 routed-cache setup-node steps, found ${cached.length} ` +
         '(positive control for the assertion below)'
     )
 
@@ -314,6 +333,72 @@ describe('CI npm cache routing (#7383)', () => {
       missing,
       [],
       `steps using the routed cache must keep cache-dependency-path: '**/package-lock.json': ${missing.join(', ')}`
+    )
+  })
+})
+
+
+/**
+ * The same rule, across EVERY workflow file — not just ci.yml.
+ *
+ * This block exists because the first version of this fix did exactly what
+ * MEMORY records as the repo's recurring miss: corrected the roster it was
+ * looking at and walked past the entry one file over. `maestro-nightly.yml`
+ * pins `[self-hosted, macOS, ARM64, chroxy-mac]` and was hardcoding `cache: npm`
+ * with a live 1.86 GB entry, restored over a ~/.npm measured at 4.8 GB on that
+ * very runner — the identical defect, invisible to a ci.yml-scoped guard, and
+ * invisible to the sibling `ci-cache-key.test.js` for the same reason (it also
+ * carried the bare `package-lock.json` key that test forbids).
+ *
+ * A workflow-scoped guard would have to be rewritten every time the class turns
+ * up somewhere new. This one is scoped to the DEFECT: any setup-node step whose
+ * job names a self-hosted runner literally. That covers files that do not exist
+ * yet.
+ */
+describe('npm cache across all workflows (#7383)', () => {
+  let workflows
+
+  before(async () => {
+    const dir = new URL('../../../.github/workflows/', import.meta.url)
+    const names = (await readdir(dir)).filter(n => n.endsWith('.yml') || n.endsWith('.yaml'))
+    workflows = await Promise.all(
+      names.map(async name => ({ name, jobs: parseJobs(await readFile(new URL(name, dir), 'utf8')) }))
+    )
+  })
+
+  it('reads every workflow file', () => {
+    // Positive control. A readdir that returns nothing, or a reader that finds no
+    // jobs, would make the assertion below vacuous — which is precisely how the
+    // maestro-nightly instance stayed invisible in the first place.
+    assert.ok(workflows.length >= 5, `expected >=5 workflow files, found ${workflows.length}`)
+    assert.ok(
+      workflows.some(w => w.name === 'maestro-nightly.yml'),
+      'expected maestro-nightly.yml to be among the scanned workflows'
+    )
+    const totalJobs = workflows.reduce((n, w) => n + w.jobs.length, 0)
+    assert.ok(totalJobs >= 20, `expected >=20 jobs across all workflows, found ${totalJobs}`)
+  })
+
+  it('no self-hosted job hardcodes an npm cache', () => {
+    const offenders = []
+    for (const { name, jobs } of workflows) {
+      for (const job of jobs) {
+        // `runs-on` naming self-hosted LITERALLY. ci.yml's routed jobs go through
+        // `runner-target` instead and are covered by the suite above; those may
+        // legitimately resolve to a hosted runner for a fork PR.
+        if (!/self-hosted/.test(job.runsOn)) continue
+        for (const step of job.steps) {
+          if (!step.some(l => l.includes(SETUP_NODE))) continue
+          const cache = stepInput(step, 'cache')
+          if (cache) offenders.push(`${name}:${job.line} ${job.id} -> cache: ${cache}`)
+        }
+      }
+    }
+    assert.deepEqual(
+      offenders,
+      [],
+      'a job pinned to a self-hosted runner must not restore an npm cache — its ~/.npm is ' +
+        `already warm, so the restore is a download over a superset of itself (#7383):\n  ${offenders.join('\n  ')}`
     )
   })
 })


### PR DESCRIPTION
## What

`runner-target` gains a third output, `npmcache`, riding the same trust predicate that already picks the runner. It feeds `setup-node`'s `cache:` input: **empty on the self-hosted pool, `npm` on GitHub-hosted**. Thirteen jobs stop hardcoding `cache: npm`.

## Why

The self-hosted pool members are long-lived — the Mac Docker members have been up for weeks, and the winbox VM's `/opt/actions-runner/_work` persists across jobs. Their `~/.npm` is **already warm: 2.2 GB, populated since the container was built**. On top of that superset, `cache: npm` made every job download and unpack a **521 MB** actions/cache tarball. Twelve Linux jobs per run, all of it redundant.

Worse than redundant, it is the step that *fails*. On `chroxy-linux-winbox-01` the restore stalls outright:

```
23:04:46  Cache hit for: node-cache-Linux-x64-npm-c28dd98f…
23:04:48  Received 0 of 521063625 (0.0%), 0.0 MBs/sec     ← ×104, zero bytes in 102s
23:06:30  ##[warning]Failed to restore: The operation cannot be completed in timeout.
23:06:30  npm cache is not found
23:13:24  ##[error]The operation was canceled.            ← 6m54s of silence, then the job wall
```

setup-node never returns, the job burns its entire `timeout-minutes`, and every real step is marked `skipped`. `gh pr checks` renders that as **`fail`** — which is why nine cancellations across four PRs all looked like broken tests. One of them had already run **2343/2343 green**.

### Measured, over 15 recent runs

| runner | n | p50 | p90 | max |
|---|---:|---:|---:|---:|
| `chroxy-linux-winbox-01` | 26 | 58s | 244s | **521s** |
| `chroxy-linux-9ca9e00142fe` | 71 | 55s | 99s | 181s |
| `chroxy-linux-0ca56d3576e2` | 73 | 57s | 98s | 173s |

Every cancellation in that window is on winbox; the Mac members pay the same toll without hitting a wall.

## Two corrections to the issue

1. **Narrowing `cache-dependency-path` could not have worked.** That glob feeds the cache **key hash**, not the archive. Narrowing it changes nothing about what gets downloaded, and it *raises* the hit rate — making the slow path more frequent, not less.
2. **The root fault is the runner, not the budget.** The winbox VM sits on Hyper-V's **Default Switch** (NAT); a TLS connection that establishes and then transfers zero bytes is that path's signature. But no `timeout-minutes` value is safe while a variable, unbounded infrastructure cost sits inside the job budget — a 10-minute job died exactly as a 5-minute one did. This PR takes the cost out; the runner's network fault is filed separately.

## The guard

`packages/server/tests/ci-npm-cache-routing.test.js` asserts **behaviour, not presence**:

- the two `npmcache` values are checked **inside their own branch** of the resolve script — a swap fails, where "both strings appear somewhere" would not;
- every routed job that runs `npm ci` must declare the cache — an **omission** fails, not just a wrong value;
- **no** setup-node step may hardcode `npm` — the copy-paste-a-neighbouring-job case, which is this repo's recurring defect shape (a hardcoded list beside a set that grows) and the reason adding a job must not be able to silently re-add 521 MB.

The scan is anchored to **step bodies**, not a file-wide grep — a grep for `cache: npm` is satisfied by ci.yml's own comments explaining why it was removed. Three **positive controls** assert the reader actually found the jobs and steps, so a reader that stops understanding ci.yml fails loudly instead of passing vacuously over an empty set.

### Proven to fail

Seven mutations, each **asserted to have landed** before the run, tree verified green before and after:

| # | mutation | result |
|---|---|---|
| A | one job hardcodes `cache: npm` again | RED (4 assertions) |
| B | one `npm ci` job drops `cache:` entirely | RED (2) |
| C | npmcache branches swapped | RED |
| D | `npmcache=npm` in **both** branches | RED |
| E | `npmcache` output declaration removed | RED |
| F | `cache-dependency-path` deleted as "dead config" | RED |
| G | positive control — ci.yml shape changed so the reader finds nothing | RED (9) |

## Evidence

This PR's own CI run is the measurement: setup-node on the self-hosted pool should drop from p50 ~55s / p90 ~244s to near-zero, with every job well inside its budget. Numbers posted below once it lands.

Related to #7383