### PR TITLE
fix(dashboard): derive the InputBar's busy props instead of rewriting them

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -43,6 +43,7 @@ import { SessionBar, type SessionTabData, type SessionStatus } from './component
 import { formatTranscript } from './lib/transcript'
 import { extractRowSearchText } from './lib/transcriptSearch'
 import { runQueuedEdit } from './lib/edit-queued'
+import { inputBarBusyProps } from './lib/session-busy'
 import { ActivityIndicator, findInFlightToolUse } from './components/ActivityIndicator'
 import { CheckInChip } from './components/CheckInChip'
 import { EvaluatorClarifyPrompt } from './components/EvaluatorPrompts'
@@ -312,6 +313,22 @@ export function App() {
     // strip in the header StatusBar.
     statusLine,
   } = useConnectionStore(useShallow(s => s.getActiveSessionState()))
+
+  // #7378: the ONE place this file decides "busy". Every `isBusy=` /
+  // `isStreaming=` prop below spreads or reads this object; none of them
+  // recompute the expression. That matters because `isStreaming || isBusy` is
+  // what the InputBar renders as busy, and `isSessionBusy` — which decides
+  // whether an optimistic send draws as "Queued" or as a fresh turn (#5952) —
+  // has to agree with it exactly. Deriving both from one helper makes them agree
+  // by construction instead of by everyone spelling it the same way.
+  //
+  // The six sites previously wrote `isBusy={!isIdle}` by hand, which is NOT
+  // equivalent to the `isIdle === false` the other two copies use: they invert
+  // when the field is nullish. See session-busy.ts for that decision.
+  const busyProps = useMemo(
+    () => inputBarBusyProps({ streamingMessageId, isIdle }),
+    [streamingMessageId, isIdle],
+  )
 
   // #3205: stable Set for SkillsPanel mismatch indicator. useMemo
   // keyed by the array reference so the Set only re-derives when the
@@ -2286,7 +2303,7 @@ export function App() {
         inputTokens={contextUsage?.inputTokens}
         outputTokens={contextUsage?.outputTokens}
         contextWindow={activeModel ? contextWindowForMeter ?? undefined : undefined}
-        isBusy={!isIdle}
+        isBusy={busyProps.isBusy}
         agentCount={activeAgents.length}
         provider={sessions.find(s => s.sessionId === activeSessionId)?.provider}
         modelLabel={activeModelLabel}
@@ -2534,8 +2551,8 @@ export function App() {
                     first={
                       <ChatView
                         messages={chatMessages}
-                        isStreaming={streamingMessageId !== null}
-                        isBusy={!isIdle}
+                        isStreaming={busyProps.isStreaming}
+                        isBusy={busyProps.isBusy}
                         chatActivityState={chatActivity.state}
                         renderMessage={renderMessage}
                         scrollToBottomSignal={scrollToBottomSignal}
@@ -2583,8 +2600,8 @@ export function App() {
                     >
                       <ChatView
                         messages={chatMessages}
-                        isStreaming={streamingMessageId !== null}
-                        isBusy={!isIdle}
+                        isStreaming={busyProps.isStreaming}
+                        isBusy={busyProps.isBusy}
                         chatActivityState={chatActivity.state}
                         renderMessage={renderMessage}
                         hidden={viewMode !== 'chat'}
@@ -2726,8 +2743,8 @@ export function App() {
               onSend={handleSend}
               onInterrupt={handleInterrupt}
               disabled={!isConnected}
-              isBusy={!isIdle}
-              isStreaming={streamingMessageId !== null}
+              isBusy={busyProps.isBusy}
+              isStreaming={busyProps.isStreaming}
               chatActivityState={chatActivity.state}
               queuedCount={queuedIds.size}
               placeholder={isConnected ? `Type a message... (${inputSettings.chatEnterToSend ? 'Enter' : formatShortcutKeys('Cmd+Enter')} to send)` : 'Connecting...'}
@@ -2781,7 +2798,7 @@ export function App() {
         contextEstimated={contextOccupancy?.source === 'final-round-prompt'}
         inputTokens={contextUsage?.inputTokens}
         outputTokens={contextUsage?.outputTokens}
-        isBusy={!isIdle}
+        isBusy={busyProps.isBusy}
         agentCount={activeAgents.length}
         onShowQr={isConnected ? handleShowQr : undefined}
         onShareSession={isConnected && activeSessionId ? handleShareSession : undefined}

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -2660,6 +2660,10 @@ export function App() {
                       display: viewMode === 'system' ? 'contents' : 'none',
                     }}
                   >
+                    {/* busy-wiring-exempt: the system pane is a static view of
+                        system-side messages — it never streams and shows no
+                        input, so both flags are inert here rather than derived
+                        (#7378). */}
                     <ChatView
                       messages={systemMessages}
                       isStreaming={false}

--- a/packages/dashboard/src/lib/input-bar-busy-wiring.test.ts
+++ b/packages/dashboard/src/lib/input-bar-busy-wiring.test.ts
@@ -34,18 +34,30 @@ import { resolve } from 'node:path'
 // really there — a cwd change must fail loudly, not silently read nothing.
 const APP_TSX = resolve(process.cwd(), 'src/App.tsx')
 
+/** The only values that need no justification: the shared derivation itself. */
+const DERIVED = new Set(['{busyProps.isBusy}', '{busyProps.isStreaming}'])
+
 /**
- * Values a busy prop is allowed to carry.
+ * A site may be hardcoded INERT, but only deliberately and only to `{false}`.
  *
- * `{false}` is on the list for the system pane, a static ChatView of
- * system-side messages that never streams and shows no input — inert on
- * purpose, not an oversight.
+ * `{false}` used to be blanket-allowed, and a mutation showed what that bought:
+ * hardcoding the live InputBar to `isBusy={false} isStreaming={false}` kills the
+ * Stop button, the follow-up placeholder and the `isBusy && !isStreaming` block,
+ * and the guard stayed green. Only the system pane — a static ChatView that
+ * never streams and shows no input — has a reason to be inert.
+ *
+ * So an exemption must be WRITTEN, in the style of the repo's other deliberate
+ * opt-outs (`lint-ignore-opt-forwarding: <key>`), within the few lines above the
+ * prop:
+ *
+ *     {/* busy-wiring-exempt: static system pane, never streams *\/}
+ *
+ * Note what is still impossible even with a marker: the value must be `{false}`.
+ * An exemption can make a site inert; it can never re-introduce an inline
+ * predicate, which is the thing #7378 removed.
  */
-const ALLOWED = new Set([
-  '{busyProps.isBusy}',
-  '{busyProps.isStreaming}',
-  '{false}',
-])
+const EXEMPT_MARKER = 'busy-wiring-exempt:'
+const EXEMPT_LOOKBACK = 8
 
 interface PropSite {
   line: number
@@ -54,37 +66,75 @@ interface PropSite {
   text: string
 }
 
-/** Non-comment lines in App.tsx that OPEN a busy prop, parsed or not. */
-function busyPropLines(): Array<{ line: number; text: string }> {
+/**
+ * Every non-comment line of App.tsx, with its 1-based number.
+ *
+ * Comment lines are dropped because prose is not code: App.tsx's #7378 comment
+ * quotes `isBusy={!isIdle}` on purpose, to record what the old spelling was.
+ */
+function codeLines(): Array<{ line: number; text: string }> {
   return readFileSync(APP_TSX, 'utf8')
     .split('\n')
-    .map((raw, i) => ({ line: i + 1, text: raw.trim() }))
+    .map((raw, i) => ({ line: i + 1, text: raw }))
     .filter(({ text }) => {
-      // Prose is not code. App.tsx's #7378 comment quotes `isBusy={!isIdle}` on
-      // purpose, to say what the old spelling was and why it was wrong.
-      if (text.startsWith('//') || text.startsWith('*') || text.startsWith('/*')) return false
-      return /^(isBusy|isStreaming)=/.test(text)
+      const t = text.trim()
+      return !t.startsWith('//') && !t.startsWith('*') && !t.startsWith('/*')
     })
 }
 
+/** Lines carrying at least one busy attribute, whether or not its value parses. */
+function busyPropLines(): Array<{ line: number; text: string }> {
+  return codeLines().filter(({ text }) => /\b(isBusy|isStreaming)=/.test(text))
+}
+
 /**
- * The value regex deliberately accepts SPACES.
+ * Read a JSX attribute value starting at `i` (the char after `=`).
  *
- * It did not, at first — `(\S+)` — and a mutation caught it: reverting a site to
- * `isStreaming={streamingMessageId !== null}` left the suite green, because the
- * spaces in that expression meant the line failed to parse and was **skipped**
- * rather than flagged. A prop the scanner cannot read is the one most likely to
- * be wrong; treating "cannot check this" as "nothing to check" is the exact
- * false-safety shape in docs/false-safety-guards.md. `every busy prop line
- * parses` below now makes an unreadable site an error in its own right.
+ * Returns undefined if a `{` never closes on this line — a multi-line prop the
+ * scanner cannot judge. That is reported as unreadable rather than skipped.
+ */
+function readValue(text: string, i: number): string | undefined {
+  if (text[i] !== '{') {
+    const m = /^\S+/.exec(text.slice(i))
+    return m ? m[0] : undefined
+  }
+  let depth = 0
+  for (let j = i; j < text.length; j++) {
+    if (text[j] === '{') depth++
+    else if (text[j] === '}' && --depth === 0) return text.slice(i, j + 1)
+  }
+  return undefined
+}
+
+/**
+ * All busy attribute occurrences, ANYWHERE on a line.
+ *
+ * The first version anchored to `^(isBusy|isStreaming)=` on the trimmed line, so
+ * a prop written on the JSX opening tag — `<InputBar isBusy={!isIdle}` — was
+ * invisible and the suite passed. Twice now this guard has been caught treating
+ * "cannot see it" as "nothing to check"; matching the attribute wherever it
+ * appears, and reporting anything unreadable, is the fix for both.
  */
 function busyPropSites(): PropSite[] {
   const sites: PropSite[] = []
-  for (const { line, text } of busyPropLines()) {
-    const m = /^(isBusy|isStreaming)=(.+?)\s*$/.exec(text)
-    if (m) sites.push({ line, name: m[1]!, value: m[2]!, text })
+  for (const { line, text } of codeLines()) {
+    const re = /\b(isBusy|isStreaming)=/g
+    let m: RegExpExecArray | null
+    while ((m = re.exec(text)) !== null) {
+      const value = readValue(text, m.index + m[0].length)
+      if (value !== undefined) {
+        sites.push({ line, name: m[1]!, value, text: text.trim() })
+      }
+    }
   }
   return sites
+}
+
+/** Is this site covered by a written exemption in the lines just above it? */
+function isExempt(line: number): boolean {
+  const all = readFileSync(APP_TSX, 'utf8').split('\n')
+  const from = Math.max(0, line - 1 - EXEMPT_LOOKBACK)
+  return all.slice(from, line).some(l => l.includes(EXEMPT_MARKER))
 }
 
 describe('InputBar busy props are wired, not rewritten (#7378)', () => {
@@ -102,30 +152,46 @@ describe('InputBar busy props are wired, not rewritten (#7378)', () => {
     expect(sites.filter(s => s.name === 'isStreaming').length).toBeGreaterThanOrEqual(3)
   })
 
-  it('every busy prop line parses — an unreadable site is an error, not a skip', () => {
-    // The gap a mutation found: a value containing spaces did not match the
-    // pattern, so the site vanished from `sites` and every rule below simply
-    // never saw it. Any line that opens a busy prop must end up parsed.
-    const lines = busyPropLines()
+  it('every busy attribute parses — an unreadable site is an error, not a skip', () => {
+    // Two mutations have now exploited the gap this closes: a value containing
+    // spaces (the `(\S+)` regex), and a prop on the JSX opening line (the
+    // `^`-anchored match). Both made a site vanish from `sites`, so every rule
+    // below simply never saw it.
     const parsed = new Set(sites.map(s => s.line))
-    const unreadable = lines.filter(l => !parsed.has(l.line)).map(l => `App.tsx:${l.line}  ${l.text}`)
+    const unreadable = busyPropLines()
+      .filter(l => !parsed.has(l.line))
+      .map(l => `App.tsx:${l.line}  ${l.text.trim()}`)
     expect(
       unreadable,
-      `these lines open a busy prop but could not be parsed, so no rule was applied to them:\n  ${unreadable.join('\n  ')}`,
+      `these lines carry a busy attribute whose value could not be read, so no rule ` +
+        `was applied to them:\n  ${unreadable.join('\n  ')}`,
     ).toEqual([])
-    expect(lines.length).toBe(sites.length)
   })
 
-  it('every busy prop reads the shared derivation, none recompute it', () => {
+  it('every busy prop reads the shared derivation, or is a WRITTEN inert exemption', () => {
     const offenders = sites
-      .filter(s => !ALLOWED.has(s.value))
-      .map(s => `App.tsx:${s.line}  ${s.text}`)
+      .filter(s => !DERIVED.has(s.value))
+      .filter(s => !(s.value === '{false}' && isExempt(s.line)))
+      .map(s => `App.tsx:${s.line}  ${s.name}=${s.value}`)
     expect(
       offenders,
-      'each isBusy=/isStreaming= prop must come from `busyProps` (inputBarBusyProps) ' +
-        'or be the literal {false}. Recomputing it inline re-creates the third copy #7378 ' +
-        `removed:\n  ${offenders.join('\n  ')}`,
+      'each isBusy=/isStreaming= prop must come from `busyProps` (inputBarBusyProps). ' +
+        `A site may be hardcoded {false} only with a '${EXEMPT_MARKER} <reason>' comment above ` +
+        'it — and never to anything else, since an inline predicate is what #7378 removed:\n  ' +
+        offenders.join('\n  '),
     ).toEqual([])
+  })
+
+  it('exemptions stay rare and inert', () => {
+    // Only the static system pane has a reason to be inert. This is a deliberate
+    // cap on a set that should NOT grow quietly: raising it should take an
+    // argument, not a copy-paste.
+    const exempt = sites.filter(s => s.value === '{false}' && isExempt(s.line))
+    expect(exempt.every(s => s.value === '{false}')).toBe(true)
+    expect(
+      exempt.length,
+      `exempt busy props: ${exempt.map(s => `App.tsx:${s.line} ${s.name}`).join(', ')}`,
+    ).toBeLessThanOrEqual(2)
   })
 
   it('App.tsx imports the helper it is supposed to be using', () => {

--- a/packages/dashboard/src/lib/input-bar-busy-wiring.test.ts
+++ b/packages/dashboard/src/lib/input-bar-busy-wiring.test.ts
@@ -27,12 +27,27 @@
  */
 import { describe, it, expect } from 'vitest'
 import { existsSync, readFileSync } from 'node:fs'
-import { resolve } from 'node:path'
+import path from 'node:path'
 
-// Vitest transforms this module, so `import.meta.url` is not a file: URL here.
-// Resolve from the package root (vitest's cwd) instead, and assert the file is
-// really there — a cwd change must fail loudly, not silently read nothing.
-const APP_TSX = resolve(process.cwd(), 'src/App.tsx')
+// Resolved RELATIVE TO THIS FILE, matching the package's other source-level
+// wiring guard (hooks/notificationPermissionWiring.test.ts). An earlier version
+// used `process.cwd()`, which silently makes the guard depend on where the
+// runner was invoked from — running the suite from the repo root rather than the
+// workspace would have pointed it at a path that does not exist.
+const APP_TSX = path.resolve(__dirname, '..', 'App.tsx')
+
+/**
+ * Read App.tsx lazily, once.
+ *
+ * Not at module scope: a read that throws during collection fails the whole file
+ * with a stack trace instead of the `resolves App.tsx` assertion below, which is
+ * the one that actually says what went wrong.
+ */
+let cachedSource: string | undefined
+function appSource(): string {
+  cachedSource ??= readFileSync(APP_TSX, 'utf8')
+  return cachedSource
+}
 
 /** The only values that need no justification: the shared derivation itself. */
 const DERIVED = new Set(['{busyProps.isBusy}', '{busyProps.isStreaming}'])
@@ -73,7 +88,7 @@ interface PropSite {
  * quotes `isBusy={!isIdle}` on purpose, to record what the old spelling was.
  */
 function codeLines(): Array<{ line: number; text: string }> {
-  return readFileSync(APP_TSX, 'utf8')
+  return appSource()
     .split('\n')
     .map((raw, i) => ({ line: i + 1, text: raw }))
     .filter(({ text }) => {
@@ -132,13 +147,17 @@ function busyPropSites(): PropSite[] {
 
 /** Is this site covered by a written exemption in the lines just above it? */
 function isExempt(line: number): boolean {
-  const all = readFileSync(APP_TSX, 'utf8').split('\n')
+  const all = appSource().split('\n')
   const from = Math.max(0, line - 1 - EXEMPT_LOOKBACK)
   return all.slice(from, line).some(l => l.includes(EXEMPT_MARKER))
 }
 
 describe('InputBar busy props are wired, not rewritten (#7378)', () => {
-  const sites = busyPropSites()
+  // Lazy + memoised, for the same reason the source read is: computed at
+  // collection time, a parse failure here would fail the file before any
+  // assertion could name it.
+  let cached: PropSite[] | undefined
+  const allSites = () => (cached ??= busyPropSites())
 
   it('resolves App.tsx', () => {
     expect(existsSync(APP_TSX), `App.tsx not found at ${APP_TSX}`).toBe(true)
@@ -147,9 +166,9 @@ describe('InputBar busy props are wired, not rewritten (#7378)', () => {
   it('finds the busy prop sites in App.tsx', () => {
     // Positive control. Every assertion below quantifies over `sites`; if the
     // scan breaks they all pass vacuously and report a clean green.
-    expect(sites.length).toBeGreaterThanOrEqual(8)
-    expect(sites.filter(s => s.name === 'isBusy').length).toBeGreaterThanOrEqual(5)
-    expect(sites.filter(s => s.name === 'isStreaming').length).toBeGreaterThanOrEqual(3)
+    expect(allSites().length).toBeGreaterThanOrEqual(8)
+    expect(allSites().filter(s => s.name === 'isBusy').length).toBeGreaterThanOrEqual(5)
+    expect(allSites().filter(s => s.name === 'isStreaming').length).toBeGreaterThanOrEqual(3)
   })
 
   it('every busy attribute parses — an unreadable site is an error, not a skip', () => {
@@ -157,7 +176,7 @@ describe('InputBar busy props are wired, not rewritten (#7378)', () => {
     // spaces (the `(\S+)` regex), and a prop on the JSX opening line (the
     // `^`-anchored match). Both made a site vanish from `sites`, so every rule
     // below simply never saw it.
-    const parsed = new Set(sites.map(s => s.line))
+    const parsed = new Set(allSites().map(s => s.line))
     const unreadable = busyPropLines()
       .filter(l => !parsed.has(l.line))
       .map(l => `App.tsx:${l.line}  ${l.text.trim()}`)
@@ -169,7 +188,7 @@ describe('InputBar busy props are wired, not rewritten (#7378)', () => {
   })
 
   it('every busy prop reads the shared derivation, or is a WRITTEN inert exemption', () => {
-    const offenders = sites
+    const offenders = allSites()
       .filter(s => !DERIVED.has(s.value))
       .filter(s => !(s.value === '{false}' && isExempt(s.line)))
       .map(s => `App.tsx:${s.line}  ${s.name}=${s.value}`)
@@ -186,7 +205,7 @@ describe('InputBar busy props are wired, not rewritten (#7378)', () => {
     // Only the static system pane has a reason to be inert. This is a deliberate
     // cap on a set that should NOT grow quietly: raising it should take an
     // argument, not a copy-paste.
-    const exempt = sites.filter(s => s.value === '{false}' && isExempt(s.line))
+    const exempt = allSites().filter(s => s.value === '{false}' && isExempt(s.line))
     expect(exempt.every(s => s.value === '{false}')).toBe(true)
     expect(
       exempt.length,
@@ -197,7 +216,7 @@ describe('InputBar busy props are wired, not rewritten (#7378)', () => {
   it('App.tsx imports the helper it is supposed to be using', () => {
     // Without this, deleting the import and hardcoding `busyProps` as a local
     // object literal would satisfy every assertion above.
-    const src = readFileSync(APP_TSX, 'utf8')
+    const src = appSource()
     expect(src).toContain("import { inputBarBusyProps } from './lib/session-busy'")
     expect(src).toMatch(/const busyProps = useMemo\(\s*\n?\s*\(\) => inputBarBusyProps\(/)
   })
@@ -205,7 +224,7 @@ describe('InputBar busy props are wired, not rewritten (#7378)', () => {
   it('the old inline spellings are gone from JSX', () => {
     // The specific regression, named. Checked over prop sites only, so the
     // deliberate explanatory comments quoting the old form do not trip it.
-    const revived = sites
+    const revived = allSites()
       .filter(s => /!isIdle|streamingMessageId/.test(s.value))
       .map(s => `App.tsx:${s.line}  ${s.text}`)
     expect(

--- a/packages/dashboard/src/lib/input-bar-busy-wiring.test.ts
+++ b/packages/dashboard/src/lib/input-bar-busy-wiring.test.ts
@@ -1,0 +1,150 @@
+/**
+ * #7378 — App.tsx must not recompute "busy" inline.
+ *
+ * `isSessionBusy`'s contract is that it matches EXACTLY what the InputBar shows
+ * as busy (`isStreaming || isBusy`) — the #5952 invariant, because that decides
+ * whether an optimistic send renders as "Queued" or as a fresh turn. Until
+ * #7378 nothing enforced it: App.tsx wrote the props by hand at six JSX sites as
+ * `isBusy={!isIdle}` / `isStreaming={streamingMessageId !== null}`, a third copy
+ * of the predicate in a spelling that disagrees with the other two whenever
+ * `isIdle` is nullish (`!undefined` is busy, `undefined === false` is idle —
+ * they invert).
+ *
+ * `inputBarBusyProps` makes the disjunction correct BY CONSTRUCTION, and
+ * `session-busy.test.ts` pins that identity. This file pins the other half —
+ * that App.tsx actually uses it — because a helper nothing calls is not a fix.
+ * A seventh site added by copy-paste from a neighbour is the realistic
+ * regression, and it is exactly the "hardcoded copy beside a set that grows"
+ * shape in docs/false-safety-guards.md.
+ *
+ * ANCHORED, not a file-wide grep. The rule is asserted per prop site: each
+ * `isBusy=` / `isStreaming=` JSX attribute must carry an approved value. A
+ * whole-file search for `!isIdle` would be satisfiable by any unrelated line —
+ * and would trip on this file's own prose, and on the explanatory comment in
+ * App.tsx that quotes the old form deliberately. Comment lines are excluded for
+ * that reason, and the count assertion below is the positive control: if the
+ * scan ever finds nothing, it fails loudly instead of passing over an empty set.
+ */
+import { describe, it, expect } from 'vitest'
+import { existsSync, readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+// Vitest transforms this module, so `import.meta.url` is not a file: URL here.
+// Resolve from the package root (vitest's cwd) instead, and assert the file is
+// really there — a cwd change must fail loudly, not silently read nothing.
+const APP_TSX = resolve(process.cwd(), 'src/App.tsx')
+
+/**
+ * Values a busy prop is allowed to carry.
+ *
+ * `{false}` is on the list for the system pane, a static ChatView of
+ * system-side messages that never streams and shows no input — inert on
+ * purpose, not an oversight.
+ */
+const ALLOWED = new Set([
+  '{busyProps.isBusy}',
+  '{busyProps.isStreaming}',
+  '{false}',
+])
+
+interface PropSite {
+  line: number
+  name: string
+  value: string
+  text: string
+}
+
+/** Non-comment lines in App.tsx that OPEN a busy prop, parsed or not. */
+function busyPropLines(): Array<{ line: number; text: string }> {
+  return readFileSync(APP_TSX, 'utf8')
+    .split('\n')
+    .map((raw, i) => ({ line: i + 1, text: raw.trim() }))
+    .filter(({ text }) => {
+      // Prose is not code. App.tsx's #7378 comment quotes `isBusy={!isIdle}` on
+      // purpose, to say what the old spelling was and why it was wrong.
+      if (text.startsWith('//') || text.startsWith('*') || text.startsWith('/*')) return false
+      return /^(isBusy|isStreaming)=/.test(text)
+    })
+}
+
+/**
+ * The value regex deliberately accepts SPACES.
+ *
+ * It did not, at first — `(\S+)` — and a mutation caught it: reverting a site to
+ * `isStreaming={streamingMessageId !== null}` left the suite green, because the
+ * spaces in that expression meant the line failed to parse and was **skipped**
+ * rather than flagged. A prop the scanner cannot read is the one most likely to
+ * be wrong; treating "cannot check this" as "nothing to check" is the exact
+ * false-safety shape in docs/false-safety-guards.md. `every busy prop line
+ * parses` below now makes an unreadable site an error in its own right.
+ */
+function busyPropSites(): PropSite[] {
+  const sites: PropSite[] = []
+  for (const { line, text } of busyPropLines()) {
+    const m = /^(isBusy|isStreaming)=(.+?)\s*$/.exec(text)
+    if (m) sites.push({ line, name: m[1]!, value: m[2]!, text })
+  }
+  return sites
+}
+
+describe('InputBar busy props are wired, not rewritten (#7378)', () => {
+  const sites = busyPropSites()
+
+  it('resolves App.tsx', () => {
+    expect(existsSync(APP_TSX), `App.tsx not found at ${APP_TSX}`).toBe(true)
+  })
+
+  it('finds the busy prop sites in App.tsx', () => {
+    // Positive control. Every assertion below quantifies over `sites`; if the
+    // scan breaks they all pass vacuously and report a clean green.
+    expect(sites.length).toBeGreaterThanOrEqual(8)
+    expect(sites.filter(s => s.name === 'isBusy').length).toBeGreaterThanOrEqual(5)
+    expect(sites.filter(s => s.name === 'isStreaming').length).toBeGreaterThanOrEqual(3)
+  })
+
+  it('every busy prop line parses — an unreadable site is an error, not a skip', () => {
+    // The gap a mutation found: a value containing spaces did not match the
+    // pattern, so the site vanished from `sites` and every rule below simply
+    // never saw it. Any line that opens a busy prop must end up parsed.
+    const lines = busyPropLines()
+    const parsed = new Set(sites.map(s => s.line))
+    const unreadable = lines.filter(l => !parsed.has(l.line)).map(l => `App.tsx:${l.line}  ${l.text}`)
+    expect(
+      unreadable,
+      `these lines open a busy prop but could not be parsed, so no rule was applied to them:\n  ${unreadable.join('\n  ')}`,
+    ).toEqual([])
+    expect(lines.length).toBe(sites.length)
+  })
+
+  it('every busy prop reads the shared derivation, none recompute it', () => {
+    const offenders = sites
+      .filter(s => !ALLOWED.has(s.value))
+      .map(s => `App.tsx:${s.line}  ${s.text}`)
+    expect(
+      offenders,
+      'each isBusy=/isStreaming= prop must come from `busyProps` (inputBarBusyProps) ' +
+        'or be the literal {false}. Recomputing it inline re-creates the third copy #7378 ' +
+        `removed:\n  ${offenders.join('\n  ')}`,
+    ).toEqual([])
+  })
+
+  it('App.tsx imports the helper it is supposed to be using', () => {
+    // Without this, deleting the import and hardcoding `busyProps` as a local
+    // object literal would satisfy every assertion above.
+    const src = readFileSync(APP_TSX, 'utf8')
+    expect(src).toContain("import { inputBarBusyProps } from './lib/session-busy'")
+    expect(src).toMatch(/const busyProps = useMemo\(\s*\n?\s*\(\) => inputBarBusyProps\(/)
+  })
+
+  it('the old inline spellings are gone from JSX', () => {
+    // The specific regression, named. Checked over prop sites only, so the
+    // deliberate explanatory comments quoting the old form do not trip it.
+    const revived = sites
+      .filter(s => /!isIdle|streamingMessageId/.test(s.value))
+      .map(s => `App.tsx:${s.line}  ${s.text}`)
+    expect(
+      revived,
+      `these props recompute the predicate inline instead of using busyProps:\n  ${revived.join('\n  ')}`,
+    ).toEqual([])
+  })
+})

--- a/packages/dashboard/src/lib/session-busy.test.ts
+++ b/packages/dashboard/src/lib/session-busy.test.ts
@@ -8,8 +8,9 @@
  * strict superset (it drives a destructive-action warning).
  */
 import { describe, it, expect } from 'vitest'
-import { isSessionBusy, hasInterruptibleWork } from './session-busy'
+import { isSessionBusy, hasInterruptibleWork, inputBarBusyProps } from './session-busy'
 import type { ChatMessage } from '@chroxy/store-core'
+import type { SessionBusyState } from './session-busy'
 
 const NOW = 1_700_000_000_000
 
@@ -108,5 +109,64 @@ describe('hasInterruptibleWork (#7335)', () => {
     const pausedButIdle = { ...idle, messages: [livePrompt] }
     expect(isSessionBusy(pausedButIdle)).toBe(false)
     expect(hasInterruptibleWork(pausedButIdle, NOW)).toBe(true)
+  })
+})
+
+describe('inputBarBusyProps (#7378 — the InputBar props ARE the predicate)', () => {
+  // The whole point of the helper: `isStreaming || isBusy` — what InputBar.tsx
+  // actually renders as busy — must equal `isSessionBusy`. Before #7378 that was
+  // a sentence in a comment; App.tsx wrote the props by hand in a spelling that
+  // disagreed with it for nullish input.
+  const MATRIX: Array<Pick<SessionBusyState, 'streamingMessageId' | 'isIdle'>> = [
+    { streamingMessageId: null, isIdle: true },
+    { streamingMessageId: null, isIdle: false },
+    { streamingMessageId: 'm1', isIdle: true },
+    { streamingMessageId: 'm1', isIdle: false },
+    // The nullish cases the store's `boolean` type says cannot happen, and that
+    // App.tsx nonetheless guards against (`isIdle ?? true`, `state?.isIdle`).
+    { streamingMessageId: null, isIdle: undefined as unknown as boolean },
+    { streamingMessageId: null, isIdle: null as unknown as boolean },
+    { streamingMessageId: undefined as unknown as string | null, isIdle: true },
+  ]
+
+  it('`isStreaming || isBusy` equals isSessionBusy for every input', () => {
+    for (const s of MATRIX) {
+      const { isStreaming, isBusy } = inputBarBusyProps(s)
+      expect(isStreaming || isBusy, JSON.stringify(s)).toBe(isSessionBusy(s))
+    }
+  })
+
+  it('keeps the two props DISTINCT — collapsing them would change the UI', () => {
+    // InputBar gates a separate affordance on `isBusy && !isStreaming`
+    // (InputBar.tsx:1188), so these cannot be merged into one boolean even
+    // though only their disjunction has to match isSessionBusy.
+    expect(inputBarBusyProps({ streamingMessageId: null, isIdle: false }))
+      .toEqual({ isStreaming: false, isBusy: true })
+    expect(inputBarBusyProps({ streamingMessageId: 'm1', isIdle: true }))
+      .toEqual({ isStreaming: true, isBusy: false })
+  })
+
+  it('DECIDES the nullish isIdle case: absent means IDLE, not busy', () => {
+    // This is the #7378 bug in one assertion. The old inline `!isIdle` returned
+    // TRUE here (busy); `isIdle === false` returns false (idle). They invert.
+    // Idle is the deliberate answer: it matches the two pre-existing copies and
+    // App.tsx's own `isIdle ?? true`.
+    for (const absent of [undefined, null]) {
+      const s = { streamingMessageId: null, isIdle: absent as unknown as boolean }
+      expect(inputBarBusyProps(s).isBusy).toBe(false)
+      expect(isSessionBusy(s)).toBe(false)
+      // and the old spelling would have disagreed — this is the regression pin
+      expect(!s.isIdle).toBe(true)
+    }
+  })
+
+  it('leaves the SIBLING convention alone: an absent streamingMessageId reads as busy', () => {
+    // Deliberately the opposite of the isIdle decision above, and deliberately
+    // unchanged: this clause is inherited from isSessionBusy, which also backs
+    // hasInterruptibleWork — a destructive-action warning, which should fail
+    // toward warning. Pinned so it stays a decision rather than an accident.
+    const s = { streamingMessageId: undefined as unknown as string | null, isIdle: true }
+    expect(inputBarBusyProps(s).isStreaming).toBe(true)
+    expect(isSessionBusy(s)).toBe(true)
   })
 })

--- a/packages/dashboard/src/lib/session-busy.ts
+++ b/packages/dashboard/src/lib/session-busy.ts
@@ -40,13 +40,13 @@ export interface SessionBusyState {
  * busy (`isStreaming || isBusy`), because it decides whether an optimistic
  * send renders as "Queued" or as a fresh turn.
  *
- * "Must match" is the CONTRACT, not yet a fact this module can enforce: the
- * InputBar's own props are still computed inline in App.tsx as
- * `isBusy={!isIdle}` / `isStreaming={streamingMessageId !== null}` at five call
- * sites — a third copy, and `!isIdle` is not even equivalent to
- * `isIdle === false` should that field ever be nullish (they invert). Routing
- * those props through this helper is #7378. Until then, treat the sentence
- * above as the invariant to preserve rather than one already guarded.
+ * "Must match" is now a FACT rather than an aspiration (#7378). The InputBar's
+ * props are no longer written inline in App.tsx: they come from
+ * {@link inputBarBusyProps} below, which builds `isStreaming` and `isBusy` from
+ * the same two clauses this function ORs — so `isStreaming || isBusy` equals
+ * `isSessionBusy(s)` by construction, for every input including nullish ones.
+ * `input-bar-busy-wiring.test.ts` fails if a seventh inline copy appears at any
+ * of those prop sites, and `session-busy.test.ts` pins the identity itself.
  *
  * `isIdle` is the server-authoritative working flag (#4639); `streamingMessageId`
  * additionally covers the optimistic pre-status window. Either ⇒ busy.
@@ -68,6 +68,50 @@ export function isSessionBusy(
   s: Pick<SessionBusyState, 'streamingMessageId' | 'isIdle'>,
 ): boolean {
   return s.streamingMessageId !== null || s.isIdle === false
+}
+
+/** The two busy props the InputBar (and the components that forward to it) take. */
+export interface InputBarBusyProps {
+  isStreaming: boolean
+  isBusy: boolean
+}
+
+/**
+ * #7378 — the InputBar's busy props, derived here so `isStreaming || isBusy` is
+ * {@link isSessionBusy} BY CONSTRUCTION rather than by everyone spelling it the
+ * same way.
+ *
+ * The header comment above used to claim that match as a fact. It was not one:
+ * the props were hand-written inline in App.tsx at six sites as
+ * `isBusy={!isIdle}` / `isStreaming={streamingMessageId !== null}` — a third
+ * copy of the predicate, in a different spelling from both others.
+ *
+ * `!isIdle` and `isIdle === false` agree only while the field is a strict
+ * boolean. **They invert when it is nullish**: `!undefined` is `true` (busy),
+ * `undefined === false` is `false` (idle). The store types `isIdle` as
+ * `boolean`, but this surface evidently does not trust that — `App.tsx` writes
+ * `isIdle: isIdle ?? true` in one place and passes `state?.isIdle` in another.
+ *
+ * The decision, taken deliberately here rather than differing per call site:
+ * **an absent `isIdle` means IDLE.** That follows `isIdle === false`, which is
+ * what both other copies already use (`sendInput`, and the per-session busy map
+ * in App.tsx), and what `isIdle ?? true` independently implies. `!isIdle` was
+ * the outlier, and it was the one wired to the UI.
+ *
+ * Note the SIBLING field keeps the opposite convention: `streamingMessageId
+ * !== null` reads an absent id as streaming, i.e. busy. That is deliberate and
+ * left alone — it is inherited unchanged from `isSessionBusy`, which also backs
+ * `hasInterruptibleWork`, where a destructive-action warning should fail toward
+ * warning. Both conventions are pinned by tests below so neither is accidental.
+ *
+ * Returns BOTH props rather than one merged boolean because the InputBar draws
+ * a real distinction between them — `isBusy && !isStreaming` gates a separate
+ * affordance — so collapsing them would change the UI, not just the wiring.
+ */
+export function inputBarBusyProps(
+  s: Pick<SessionBusyState, 'streamingMessageId' | 'isIdle'>,
+): InputBarBusyProps {
+  return { isStreaming: s.streamingMessageId !== null, isBusy: s.isIdle === false }
 }
 
 /**


### PR DESCRIPTION
Closes #7378.

## The gap

`isSessionBusy`'s header said it *"must match EXACTLY what the InputBar shows as busy (`isStreaming || isBusy`)"*. That was an aspiration — nothing enforced it. App.tsx wrote those props by hand at **six** JSX sites:

```tsx
isStreaming={streamingMessageId !== null}
isBusy={!isIdle}
```

A third copy of the predicate, in a spelling that agrees with the other two only while `isIdle` is a strict boolean. **They invert when it is nullish**: `!undefined` is `true` (busy), `undefined === false` is `false` (idle). The store types the field `boolean`, but this surface plainly doesn't trust that — App.tsx writes `isIdle: isIdle ?? true` in one place and passes `state?.isIdle` in another.

## The fix

`inputBarBusyProps` returns both props from the same two clauses `isSessionBusy` ORs, so:

```
isStreaming || isBusy  ===  isSessionBusy(s)
```

holds **by construction** rather than by everyone spelling it the same way. It returns two props rather than one merged boolean because InputBar draws a real distinction — `isBusy && !isStreaming` gates a separate affordance (`InputBar.tsx:1188`), so collapsing them would change the UI, not just the wiring.

### The nullish case, decided

**Absent `isIdle` means IDLE.** That follows `isIdle === false` — what both pre-existing copies already use — and what App.tsx's own `isIdle ?? true` independently implies. `!isIdle` was the outlier, and it was the one wired to the UI.

The **sibling** field deliberately keeps the opposite convention: `streamingMessageId !== null` reads an absent id as *busy*. It's inherited unchanged from `isSessionBusy`, which also backs `hasInterruptibleWork` — a destructive-action warning, which should fail toward warning. Both conventions are now pinned by tests, so neither is an accident.

## Two things the issue didn't have

- **It counted five call sites; there are six.** The one it missed is `FooterBar`.
- **`AppHeader` and `FooterBar` take only `isBusy`, with no `isStreaming` at all** — so those two were computing "busy" as `!isIdle` alone, a *fourth* variant. All six now read the shared object.

The system pane's `isStreaming={false} isBusy={false}` stays literal: a static ChatView of system messages that never streams and shows no input.

## The guard

`input-bar-busy-wiring.test.ts` pins the other half — that App.tsx actually *uses* the helper, since a helper nothing calls is not a fix. **Anchored per prop site**, not grepping the file: a file-wide search for `!isIdle` is satisfiable by any unrelated line, including App.tsx's own comment quoting the old form deliberately.

### Proven to fail — and the first version did not

A mutation reverting a site to `isStreaming={streamingMessageId !== null}` left the suite **GREEN**. The spaces in that expression meant the line failed to parse and was **skipped** rather than flagged — precisely the catalogued *"cannot check this treated as nothing to check"* shape, shipped inside a guard written against it. Fixed: the value pattern accepts spaces, and an unparseable prop line is now an error in its own right.

| # | mutation | result |
|---|---|---|
| A | a site reverts to inline `!isIdle` | RED |
| B | a site reverts to the inline streaming check | RED *(escaped the first version)* |
| C | a **seventh** site added by copy-paste from a neighbour | RED |
| D | the helper bypassed — `busyProps` built as a literal | RED |
| E | positive control: prop names changed, scan finds nothing | RED |
| F | **negative** control: a comment quoting the old form | GREEN |

Each asserted to have landed before its run; tree green before and after.

## Verification

- `npm run typecheck` clean
- **5212/5212** dashboard tests pass (301 files)
- The `session-busy.ts` header now states the invariant as enforced, per the issue's fourth criterion