### PR TITLE
fix(app): stop telling users a permission they answered "expired"

### DIFF
--- a/packages/app/src/__tests__/store/message-handler.test.ts
+++ b/packages/app/src/__tests__/store/message-handler.test.ts
@@ -20,6 +20,7 @@ import {
   setDeltaFlushIntervalOverride,
 } from '../../store/message-handler';
 import { createEmptySessionState } from '../../store/utils';
+import { PERMISSION_ALREADY_ANSWERED_NOTICE } from '@chroxy/store-core';
 import { clearPersistedSession } from '../../store/persistence';
 import { setCallback, clearAllCallbacks } from '../../store/imperative-callbacks';
 import { useMultiClientStore } from '../../store/multi-client';
@@ -3729,6 +3730,146 @@ describe('permission_expired handler', () => {
     const notifs = store.getState().sessionNotifications;
     expect(notifs).toHaveLength(1);
     expect(notifs[0].requestId).toBe('keep-me');
+  });
+
+  // #7380 — the #2833 race, which #7375 made routine: permission_expired now
+  // fires whenever a claude-cli turn dies (mode switch, model switch, Stop,
+  // crash), not only on the five-minute timeout. So "user answered, then the
+  // prompt expired" is common rather than rare, and on a phone over a cellular
+  // tunnel the in-flight window is wide.
+  const EXPIRED_NOTE = '(Expired — this permission was already handled or timed out)';
+
+  function storeWithPrompt(answered?: string) {
+    return createMockStore({
+      activeSessionId: 's1',
+      sessions: [{ sessionId: 's1', name: 'S1' } as any],
+      sessionStates: {
+        s1: {
+          ...createEmptySessionState(),
+          messages: [
+            {
+              id: 'perm-race',
+              type: 'prompt' as const,
+              content: 'Bash: rm -rf /tmp/x',
+              requestId: 'req-race',
+              timestamp: 1,
+              ...(answered !== undefined ? { answered } : {}),
+            },
+          ],
+        },
+      },
+      sessionNotifications: [{ requestId: 'req-race', sessionId: 's1', message: 'Bash?' } as any],
+    });
+  }
+
+  // A `.find()` that misses would otherwise make every assertion below read as
+  // `undefined` — silently passing a `not.toContain`. Make the miss the failure.
+  function promptIn(messages: any[], requestId = 'req-race') {
+    const found = messages.find((m: any) => m.requestId === requestId);
+    if (!found) throw new Error(`no prompt with requestId=${requestId} in ${messages.length} messages`);
+    return found;
+  }
+
+  function expire(store: ReturnType<typeof createMockStore>) {
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.handle({
+      type: 'permission_expired',
+      requestId: 'req-race',
+      sessionId: 's1',
+      message: 'permission response could not be routed (expired/handled)',
+    });
+    return store.getState().sessionStates.s1.messages;
+  }
+
+  it('suppresses the expiry note for a prompt the user already answered', () => {
+    // The bug: the user taps Allow, the turn is killed while the response is in
+    // flight, and the app tells them their permission "was already handled or
+    // timed out" — on a prompt they successfully answered.
+    const messages = expire(storeWithPrompt('allow'));
+
+    const prompt = promptIn(messages);
+    expect(prompt.content).toBe('Bash: rm -rf /tmp/x');
+    expect(prompt.content).not.toContain(EXPIRED_NOTE);
+    // and the decision token survives untouched — it is a DECISION (#6222/#6223),
+    // and no expiry retroactively unmakes it
+    expect(prompt.answered).toBe('allow');
+  });
+
+  it('surfaces the shared reassurance instead of swallowing the event', () => {
+    // The app has no toast by design (#4878/#4879), so it says it in the
+    // transcript. Same words as the dashboard's info toast, from the same
+    // constant — which is the only way "the same reassurance" is a fact.
+    const messages = expire(storeWithPrompt('allow'));
+
+    const notice = messages.filter((m: any) => m.type === 'system');
+    expect(notice).toHaveLength(1);
+    expect(notice[0].content).toBe(PERMISSION_ALREADY_ANSWERED_NOTICE);
+    expect(PERMISSION_ALREADY_ANSWERED_NOTICE).toBe(
+      'Already answered — your response was already recorded'
+    );
+  });
+
+  it('POSITIVE CONTROL: an UNANSWERED prompt still gets the expiry note', () => {
+    // Without this the suppression could be unconditional — every assertion
+    // above would pass just as well with the note deleted outright, which is the
+    // "denies everything" false-safety shape (#7273).
+    const messages = expire(storeWithPrompt(undefined));
+
+    const prompt = promptIn(messages);
+    expect(prompt.content).toBe(`Bash: rm -rf /tmp/x\n${EXPIRED_NOTE}`);
+    expect(prompt.options).toBeUndefined();
+    expect(messages.filter((m: any) => m.type === 'system')).toHaveLength(0);
+  });
+
+  it('drains the banner on BOTH paths — the request is over either way', () => {
+    for (const answered of ['allow', undefined]) {
+      const store = storeWithPrompt(answered);
+      expire(store);
+      // (jest's expect takes no message arg — the loop label lives in the array)
+      expect([String(answered), store.getState().sessionNotifications.length]).toEqual([
+        String(answered),
+        0,
+      ]);
+    }
+  });
+
+  it('sees an answer recorded in a NON-active session (push-notification path)', () => {
+    // markPromptAnsweredByRequestId walks every session because a prompt can be
+    // answered from a push notification while another session is active. A gate
+    // that only looked at the target session would miss exactly that case.
+    const store = createMockStore({
+      activeSessionId: 's1',
+      sessions: [{ sessionId: 's1', name: 'S1' } as any, { sessionId: 's2', name: 'S2' } as any],
+      sessionStates: {
+        s1: createEmptySessionState(),
+        s2: {
+          ...createEmptySessionState(),
+          messages: [
+            {
+              id: 'perm-bg',
+              type: 'prompt' as const,
+              content: 'Bash: ls',
+              requestId: 'req-race',
+              timestamp: 1,
+              answered: 'allow',
+            },
+          ],
+        },
+      },
+      sessionNotifications: [],
+    });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.handle({
+      type: 'permission_expired',
+      requestId: 'req-race',
+      sessionId: 's2',
+      message: 'expired',
+    });
+
+    const prompt = promptIn(store.getState().sessionStates.s2.messages);
+    expect(prompt.content).toBe('Bash: ls');
   });
 });
 

--- a/packages/app/src/__tests__/store/message-handler.test.ts
+++ b/packages/app/src/__tests__/store/message-handler.test.ts
@@ -20,7 +20,11 @@ import {
   setDeltaFlushIntervalOverride,
 } from '../../store/message-handler';
 import { createEmptySessionState } from '../../store/utils';
-import { PERMISSION_ALREADY_ANSWERED_NOTICE } from '@chroxy/store-core';
+import {
+  PERMISSION_ALREADY_ANSWERED_NOTICE,
+  PERMISSION_DECISION_TOKENS,
+  isLivePermissionPrompt,
+} from '@chroxy/store-core';
 import { clearPersistedSession } from '../../store/persistence';
 import { setCallback, clearAllCallbacks } from '../../store/imperative-callbacks';
 import { useMultiClientStore } from '../../store/multi-client';
@@ -3832,6 +3836,103 @@ describe('permission_expired handler', () => {
         0,
       ]);
     }
+  });
+
+  it("REVIEW: a replay-stamped '(resolved)' prompt is NOT treated as answered", () => {
+    // history_replay_end blanket-stamps `answered: '(resolved)'` on every
+    // unanswered prompt in the active session. That placeholder is not a
+    // decision, and an `answered !== undefined` gate — the first draft of this
+    // fix — could not tell the two apart. A prompt nobody answered would then be
+    // told "your response was already recorded" AND lose its expiry note.
+    const messages = expire(storeWithPrompt('(resolved)'));
+
+    const prompt = promptIn(messages);
+    expect(prompt.content).toBe(`Bash: rm -rf /tmp/x\n${EXPIRED_NOTE}`);
+    expect(messages.filter((m: any) => m.type === 'system')).toHaveLength(0);
+  });
+
+  it('accepts every real decision token, and nothing else', () => {
+    // Pinned against the token list itself, so widening the enum without
+    // revisiting this gate is a visible change rather than a silent one.
+    for (const token of PERMISSION_DECISION_TOKENS) {
+      const prompt = promptIn(expire(storeWithPrompt(token)));
+      expect([token, prompt.content]).toEqual([token, 'Bash: rm -rf /tmp/x']);
+    }
+    for (const notADecision of ['(resolved)', '', 'allowed', 'yes']) {
+      const prompt = promptIn(expire(storeWithPrompt(notADecision)));
+      expect([notADecision, prompt.content]).toEqual([
+        notADecision,
+        `Bash: rm -rf /tmp/x\n${EXPIRED_NOTE}`,
+      ]);
+    }
+  });
+
+  it('REVIEW: an expired UNANSWERED prompt stops counting as live (#7335 mobile half)', () => {
+    // `isLivePermissionPrompt` requires `expiresAt > now`; clearing `options`
+    // never touched it, so a dead prompt went on driving SessionPicker's pending
+    // badge and usePermissionAnnouncer for the rest of its five minutes.
+    const store = storeWithPrompt(undefined);
+    store.setState((st: any) => ({
+      sessionStates: {
+        ...st.sessionStates,
+        s1: {
+          ...st.sessionStates.s1,
+          messages: st.sessionStates.s1.messages.map((m: any) => ({
+            ...m,
+            expiresAt: Date.now() + 5 * 60_000,
+          })),
+        },
+      },
+    }));
+    // precondition: it IS live before the expiry arrives, or this proves nothing
+    expect(isLivePermissionPrompt(promptIn(store.getState().sessionStates.s1.messages), Date.now()))
+      .toBe(true);
+
+    const messages = expire(store);
+
+    const prompt = promptIn(messages);
+    expect(isLivePermissionPrompt(prompt, Date.now())).toBe(false);
+    // and `answered` stays unset — it is a DECISION token, and none was made
+    expect(prompt.answered).toBeUndefined();
+  });
+
+  it('REVIEW: a burst of expiries writes ONE notice, not N identical lines', () => {
+    // A single turn death expires every permission it was holding, so these
+    // arrive together. The old in-place mutation could not stack; appending can.
+    const store = createMockStore({
+      activeSessionId: 's1',
+      sessions: [{ sessionId: 's1', name: 'S1' } as any],
+      sessionStates: {
+        s1: {
+          ...createEmptySessionState(),
+          messages: ['a', 'b', 'c'].map((k) => ({
+            id: `perm-${k}`,
+            type: 'prompt' as const,
+            content: `Bash: ${k}`,
+            requestId: `req-${k}`,
+            timestamp: 1,
+            answered: 'allow',
+          })),
+        },
+      },
+      sessionNotifications: [],
+    });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+    for (const k of ['a', 'b', 'c']) {
+      _testMessageHandler.handle({
+        type: 'permission_expired',
+        requestId: `req-${k}`,
+        sessionId: 's1',
+        message: 'turn died',
+      });
+    }
+
+    const notices = store
+      .getState()
+      .sessionStates.s1.messages.filter((m: any) => m.type === 'system');
+    expect(notices).toHaveLength(1);
+    expect(notices[0].content).toBe(PERMISSION_ALREADY_ANSWERED_NOTICE);
   });
 
   it('sees an answer recorded in a NON-active session (push-notification path)', () => {

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -73,6 +73,9 @@ import {
   // #7380 — one wording for the #2833 already-answered race, shared with the
   // dashboard (which surfaces the same words as an info toast).
   PERMISSION_ALREADY_ANSWERED_NOTICE,
+  // #7380 — a REAL user decision, not merely `answered` being set:
+  // history_replay_end stamps '(resolved)' on prompts nobody answered.
+  isPermissionDecision,
   handlePermissionTimeout as sharedPermissionTimeout,
   // permission_rules_updated migrated to the shared dispatch table (#5556)
   // #5454 — remaining both-sides duplicates extracted into store-core
@@ -3175,12 +3178,22 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         // same behaviour on its separate `resolvedPermissions` map; that the two
         // clients read different signals for one question is #7388.
         //
+        // `isPermissionDecision`, NOT `answered !== undefined`. `history_replay_end`
+        // blanket-stamps `answered: '(resolved)'` on every unanswered prompt in the
+        // active session, and that placeholder is indistinguishable from a real
+        // decision under a defined-check — so a prompt the user never answered
+        // would be told "your response was already recorded" AND lose its expiry
+        // note. Only the four real decision tokens count.
+        //
         // Scan every session, not just the target: the push-notification path
         // answers prompts in background sessions, which is exactly what
         // `markPromptAnsweredByRequestId` walks all sessions for.
         const alreadyAnswered = Object.values(get().sessionStates).some((ss) =>
           ss.messages.some(
-            (m) => m.requestId === expiredRequestId && m.type === 'prompt' && m.answered !== undefined
+            (m) =>
+              m.requestId === expiredRequestId &&
+              m.type === 'prompt' &&
+              isPermissionDecision(m.answered)
           )
         );
         if (!alreadyAnswered) {
@@ -3190,7 +3203,25 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
             updateSession(expTargetId, (ss) => ({
               messages: ss.messages.map((m) =>
                 m.requestId === expiredRequestId && m.type === 'prompt'
-                  ? { ...m, content: `${m.content}\n${expiredSystemMsg.content}`, options: undefined }
+                  ? {
+                      ...m,
+                      content: `${m.content}\n${expiredSystemMsg.content}`,
+                      options: undefined,
+                      // #7335's mobile half, which that issue fixed only on the
+                      // dashboard. `expiresAt` is what actually retires a prompt:
+                      // `isLivePermissionPrompt` requires `expiresAt > now`, and
+                      // clearing `options` does not touch it. So an expired prompt
+                      // went on counting as pending for the rest of its five
+                      // minutes — SessionPicker's badge and usePermissionAnnouncer
+                      // both key on that predicate.
+                      //
+                      // Stamped to NOW rather than 0 for the dashboard's reason:
+                      // a falsy `expiresAt` makes the predicate give up entirely,
+                      // erasing the record of a tool call nobody answered (#7353).
+                      // `answered` is deliberately NOT set — it is a DECISION token
+                      // and no decision was made.
+                      expiresAt: Date.now(),
+                    }
                   : m
               ),
             }));
@@ -3209,7 +3240,17 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
           };
           const noticeTargetId = (msg.sessionId as string) || get().activeSessionId;
           if (noticeTargetId && get().sessionStates[noticeTargetId]) {
-            updateSession(noticeTargetId, (ss) => ({ messages: [...ss.messages, noticeMsg] }));
+            updateSession(noticeTargetId, (ss) => {
+              // One turn death expires EVERY permission it was holding, so these
+              // arrive in a burst and the notice is generic — N identical lines
+              // says nothing the first one did not. The old in-place mutation
+              // could not stack this way; appending can, so collapse a repeat.
+              const last = ss.messages[ss.messages.length - 1];
+              if (last?.type === 'system' && last.content === PERMISSION_ALREADY_ANSWERED_NOTICE) {
+                return {};
+              }
+              return { messages: [...ss.messages, noticeMsg] };
+            });
           } else {
             get().addMessage(noticeMsg);
           }

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -70,6 +70,9 @@ import {
   handlePermissionRequest as sharedPermissionRequest,
   handlePermissionResolved as sharedPermissionResolved,
   handlePermissionExpired as sharedPermissionExpired,
+  // #7380 — one wording for the #2833 already-answered race, shared with the
+  // dashboard (which surfaces the same words as an info toast).
+  PERMISSION_ALREADY_ANSWERED_NOTICE,
   handlePermissionTimeout as sharedPermissionTimeout,
   // permission_rules_updated migrated to the shared dispatch table (#5556)
   // #5454 — remaining both-sides duplicates extracted into store-core
@@ -3155,17 +3158,64 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       const { requestId: expiredRequestId, systemMessage: expiredSystemMsg } =
         sharedPermissionExpired(msg);
       if (expiredRequestId) {
-        console.warn(`[ws] Permission ${expiredRequestId} expired: ${msg.message}`);
-        const expTargetId = (msg.sessionId as string) || get().activeSessionId;
-        if (expTargetId && get().sessionStates[expTargetId]) {
-          updateSession(expTargetId, (ss) => ({
-            messages: ss.messages.map((m) =>
-              m.requestId === expiredRequestId && m.type === 'prompt'
-                ? { ...m, content: `${m.content}\n${expiredSystemMsg.content}`, options: undefined }
-                : m
-            ),
-          }));
+        // #7380 — the #2833 race, which #7375 made routine. `permission_expired`
+        // no longer fires only on the five-minute timeout: it now fires whenever
+        // a claude-cli turn dies (mode switch, model switch, Stop, crash). So the
+        // window between "user taps Allow" and "server expires the prompt" is hit
+        // often, and on a phone over a cellular tunnel it is wide.
+        //
+        // Without this gate the app appended "(Expired — this permission was
+        // already handled or timed out)" to a prompt the user DID answer
+        // successfully, and gave no sign their tap had landed.
+        //
+        // The signal is the prompt's own `answered` decision token (#6222/#6223),
+        // set synchronously by `markPromptAnsweredByRequestId` the moment
+        // `sendPermissionResponse` puts the frame on the wire — so it is always
+        // present before any server reply can arrive. The dashboard gates the
+        // same behaviour on its separate `resolvedPermissions` map; that the two
+        // clients read different signals for one question is #7388.
+        //
+        // Scan every session, not just the target: the push-notification path
+        // answers prompts in background sessions, which is exactly what
+        // `markPromptAnsweredByRequestId` walks all sessions for.
+        const alreadyAnswered = Object.values(get().sessionStates).some((ss) =>
+          ss.messages.some(
+            (m) => m.requestId === expiredRequestId && m.type === 'prompt' && m.answered !== undefined
+          )
+        );
+        if (!alreadyAnswered) {
+          console.warn(`[ws] Permission ${expiredRequestId} expired: ${msg.message}`);
+          const expTargetId = (msg.sessionId as string) || get().activeSessionId;
+          if (expTargetId && get().sessionStates[expTargetId]) {
+            updateSession(expTargetId, (ss) => ({
+              messages: ss.messages.map((m) =>
+                m.requestId === expiredRequestId && m.type === 'prompt'
+                  ? { ...m, content: `${m.content}\n${expiredSystemMsg.content}`, options: undefined }
+                  : m
+              ),
+            }));
+          }
+        } else {
+          // Reassure rather than swallow. The dashboard raises an info toast
+          // (#2839); the app has no toast mechanism by design (#4878/#4879) and
+          // says it in the transcript instead — same words, from the shared
+          // constant, because "the same reassurance" is only a fact if there is
+          // one string.
+          const noticeMsg: ChatMessage = {
+            id: nextMessageId('system'),
+            type: 'system',
+            content: PERMISSION_ALREADY_ANSWERED_NOTICE,
+            timestamp: Date.now(),
+          };
+          const noticeTargetId = (msg.sessionId as string) || get().activeSessionId;
+          if (noticeTargetId && get().sessionStates[noticeTargetId]) {
+            updateSession(noticeTargetId, (ss) => ({ messages: [...ss.messages, noticeMsg] }));
+          } else {
+            get().addMessage(noticeMsg);
+          }
         }
+        // Both branches drain the banner and the pulled input: the request is
+        // over either way, so the row must not sit there offering buttons.
         // Auto-dismiss matching notification banner
         set((s) => ({
           sessionNotifications: (s.sessionNotifications ?? []).filter(

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -62,6 +62,9 @@ import {
   replayDedupCache,
   resetReplayReconcile,
   handlePermissionExpired as sharedPermissionExpired,
+  // #7380 — one wording for the #2833 already-answered race, shared with the app
+  // (which surfaces it as a transcript line, having no toast by design).
+  PERMISSION_ALREADY_ANSWERED_NOTICE,
   // permission_rules_updated migrated to the shared dispatch table (#5556)
   // #5454 — dashboard adopts the shared permission family + the remaining
   // both-sides duplicates
@@ -5411,7 +5414,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
           // #2839: surface a user-centric info toast confirming the
           // response was already recorded, without exposing the underlying
           // server-side expiration race as an error-like message.
-          get().addInfoNotification('Already answered — your response was already recorded');
+          get().addInfoNotification(PERMISSION_ALREADY_ANSWERED_NOTICE);
           break;
         }
         console.warn(`[ws] Permission ${expiredRequestId} expired: ${msg.message}`);

--- a/packages/store-core/src/contract-fixtures/fixtures.ts
+++ b/packages/store-core/src/contract-fixtures/fixtures.ts
@@ -2043,11 +2043,20 @@ export const SWITCH_FIXTURES: ContractFixture[] = [
     // requestId + type==='prompt') and clears its options (options is dropped by
     // the harness normalize, so not asserted). Target = msg.sessionId ||
     // activeSessionId; no-op if requestId is null or the session/prompt is absent
-    // — so the fixture seeds a prompt carrying the requestId. The dashboard's
-    // #2833 already-resolved early-return is gated on `resolvedPermissions`, which
-    // FixtureInitialState can't seed, so both clients take the same path → single
-    // expect. The banner-drain is a sessionNotifications side effect outside the
-    // asserted messages slice.
+    // — so the fixture seeds a prompt carrying the requestId.
+    //
+    // Both clients take the same path here because the seeded prompt is
+    // UNANSWERED, which is now the load-bearing detail: as of #7380 the app's
+    // already-answered early-return is gated on the prompt's own `answered`
+    // token, which FixtureInitialState CAN seed. The dashboard's stays gated on
+    // `resolvedPermissions`, which it cannot. So the suppression path — the one
+    // #7375 made routine — still has no cross-client contract coverage, and it is
+    // the difference in signal, not the harness, that prevents it. Unifying them
+    // (and then covering it here, `divergent` if they legitimately differ) is
+    // #7388.
+    //
+    // The banner-drain is a sessionNotifications side effect outside the asserted
+    // messages slice.
     name: 'permission_expired appends the expired suffix to the matching prompt in place (both clients)',
     type: 'permission_expired',
     init: {

--- a/packages/store-core/src/handlers/permission.ts
+++ b/packages/store-core/src/handlers/permission.ts
@@ -144,9 +144,10 @@ export const PERMISSION_ALREADY_ANSWERED_NOTICE =
  *
  * That already-resolved gate stays platform-specific because the two clients
  * read DIFFERENT signals for it: the dashboard keys on its `resolvedPermissions`
- * map, the app (#7380) on the prompt message's own `answered` decision token,
- * which is what `markPromptAnsweredByRequestId` sets and what
- * `isLivePermissionPrompt` already keys on. Unifying them is #7388.
+ * map, the app (#7380) on the prompt message's own `answered` field — via
+ * `isPermissionDecision`, NOT a defined-check, because `history_replay_end`
+ * stamps the placeholder `'(resolved)'` on prompts nobody answered. Unifying
+ * the two signals is #7388.
  */
 export function handlePermissionExpired(msg: Record<string, unknown>): {
   requestId: string | null

--- a/packages/store-core/src/handlers/permission.ts
+++ b/packages/store-core/src/handlers/permission.ts
@@ -121,15 +121,32 @@ export function handlePermissionResolved(
 }
 
 /**
+ * The reassurance shown when `permission_expired` arrives for a request the
+ * user ALREADY answered — the #2833 race.
+ *
+ * Shared because both clients must say the same thing, and they say it through
+ * different channels: the dashboard raises an info toast (#2839), the app has no
+ * toast mechanism by design (#4878/#4879) and appends a system line to the
+ * transcript instead. Different surface, identical words — which is only
+ * guaranteed if there is one string. #7380.
+ */
+export const PERMISSION_ALREADY_ANSWERED_NOTICE =
+  'Already answered — your response was already recorded'
+
+/**
  * Parse a `permission_expired` message into the requestId plus a system
  * ChatMessage (mirrors `handleBudgetExceeded`'s shape).
  *
  * The system message text is the same line both clients append to the
  * matching prompt today: `"(Expired — this permission was already handled or
  * timed out)"`. The handler does NOT decide whether to apply it — the call
- * site gates on `requestId` and on whether the prompt was already resolved
- * (the dashboard's "already handled" race-suppression path stays platform-
- * specific). Banner dismissal also stays at the call site.
+ * site gates on `requestId` and on whether the prompt was already resolved.
+ *
+ * That already-resolved gate stays platform-specific because the two clients
+ * read DIFFERENT signals for it: the dashboard keys on its `resolvedPermissions`
+ * map, the app (#7380) on the prompt message's own `answered` decision token,
+ * which is what `markPromptAnsweredByRequestId` sets and what
+ * `isLivePermissionPrompt` already keys on. Unifying them is #7388.
  */
 export function handlePermissionExpired(msg: Record<string, unknown>): {
   requestId: string | null

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -952,6 +952,10 @@ export {
 // "live, unanswered permission prompt" predicate across both clients).
 export {
   isLivePermissionPrompt,
+  // #7380 — a REAL user decision, as opposed to `answered` merely being set
+  // (history_replay_end stamps '(resolved)' on prompts nobody answered).
+  isPermissionDecision,
+  PERMISSION_DECISION_TOKENS,
   firstLivePermissionPrompt,
   livePermissionPrompts,
   countLivePermissionPrompts,

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -655,6 +655,9 @@ export {
   handlePermissionRequest,
   handlePermissionResolved,
   handlePermissionExpired,
+  // #7380 — the one wording for the #2833 already-answered race, shared because
+  // the two clients surface it through different channels (toast vs transcript).
+  PERMISSION_ALREADY_ANSWERED_NOTICE,
   handlePermissionTimeout,
   handlePermissionRulesUpdated,
   handleSessionList,

--- a/packages/store-core/src/pending-permissions.ts
+++ b/packages/store-core/src/pending-permissions.ts
@@ -25,6 +25,33 @@
  */
 import type { ChatMessage } from './types'
 
+/**
+ * The decision tokens `ChatMessage.answered` carries when a USER actually
+ * answered a permission prompt (#6222/#6223 — the field is an enum, never a
+ * display label). Tallied verbatim today by the app's SettingsScreen and
+ * PermissionHistoryScreen and by the dashboard's App.tsx.
+ */
+export const PERMISSION_DECISION_TOKENS = ['allow', 'allowAlways', 'allowSession', 'deny'] as const
+
+export type PermissionDecisionToken = (typeof PERMISSION_DECISION_TOKENS)[number]
+
+/**
+ * True iff `answered` is a real user decision.
+ *
+ * `answered` being merely SET is not that, which is the trap #7380's first draft
+ * fell into: `history_replay_end` blanket-stamps `answered: '(resolved)'` on
+ * every unanswered prompt in the active session, on the reasoning that anything
+ * in replayed history is over. That placeholder is indistinguishable from a
+ * decision under an `!== undefined` test — so a prompt the user never answered
+ * reads as answered, and any behaviour gated that way misfires on it.
+ *
+ * Deliberately does NOT accept an arbitrary non-empty string: a future
+ * placeholder would then quietly qualify too, which is the same bug again.
+ */
+export function isPermissionDecision(answered: string | undefined | null): boolean {
+  return (PERMISSION_DECISION_TOKENS as readonly string[]).includes(answered ?? '')
+}
+
 /** True iff `m` is a live, unanswered permission prompt (not an AskUserQuestion). */
 export function isLivePermissionPrompt(m: ChatMessage, now: number): boolean {
   return (


### PR DESCRIPTION
Closes #7380.

## The bug

The mobile app had no equivalent of the dashboard's #2833 race suppression. A `permission_expired` for a request the user **already answered** still appended *"(Expired — this permission was already handled or timed out)"* to the prompt — and gave no sign their tap had landed.

**#7375 turned that from rare into routine.** `permission_expired` no longer fires only on the five-minute timeout; it now fires whenever a `claude-cli` turn dies — a mode switch, a model switch, Stop, a crash. So the window between "user taps Allow" and "server expires the prompt" is hit constantly, and on a phone over a cellular tunnel it is wide.

## The fix

The signal is the prompt's own **`answered` decision token** (#6222/#6223), set synchronously by `markPromptAnsweredByRequestId` the moment `sendPermissionResponse` puts the frame on the wire — so it is always present before any server reply can arrive.

Every session is scanned, not just the target: the push-notification path answers prompts in **background** sessions, which is exactly why `markPromptAnsweredByRequestId` walks them all. A gate that looked only at the target session would miss precisely that case (there's a test for it).

**The reassurance is not swallowed.** The dashboard raises an info toast (#2839); the app has no toast mechanism *by design* (#4878/#4879) and appends a system line to the transcript instead. Different surface, identical words — guaranteed by a new shared `PERMISSION_ALREADY_ANSWERED_NOTICE` in store-core, which the dashboard's literal now reads from too. "The same reassurance" is only a fact if there is one string.

Both branches still drain the banner and prune the pulled input: the request is over either way, so the row must not sit there offering buttons.

## Verified RED first — the issue's third criterion

Against the pre-fix handler (reverted from `HEAD`, landed-check asserted):

```
✓ clears matching sessionNotification when permission expires
✕ suppresses the expiry note for a prompt the user already answered
✕ surfaces the shared reassurance instead of swallowing the event
✓ POSITIVE CONTROL: an UNANSWERED prompt still gets the expiry note
✓ drains the banner on BOTH paths — the request is over either way
✕ sees an answer recorded in a NON-active session (push-notification path)
```

The **positive control passes both before and after**, which is the whole point of it: without it, every assertion here would pass just as well with the expiry note deleted outright — the *"denies everything"* false-safety shape (#7273). The banner-drain test likewise stays green both ways, since that behaviour is deliberately unchanged.

`promptIn` throws when the lookup misses rather than returning `undefined` — a `.find()` that missed would have made `not.toContain` pass for the wrong reason.

## Filed, not silently absorbed: #7388

The two clients now read **different signals** for one question — the dashboard's `resolvedPermissions` map, the app's `answered` token. Both are correct today, but it leaves the suppression path with **no cross-client contract coverage**: `resolvedPermissions` cannot be seeded by `FixtureInitialState`, while `answered` can. The stale note in `fixtures.ts` claiming both clients take the same path "→ single expect" is corrected to say why that is now the load-bearing detail.

#7388 also carries a question this PR did not check: the app's handler clears `options` but does not stamp `expiresAt`, which #7335 established as the thing that actually retires a prompt card on the dashboard (`#2853` — `PermissionPrompt` never reads `options`). Whether the app's renderer has the same dependency is unverified, so it is recorded rather than assumed either way.

## Verification

| package | typecheck | tests |
|---|---|---|
| app | clean | **2348/2348** (181 suites) |
| dashboard | clean | **5202/5202** |
| store-core | clean | **2166/2166** (incl. 123 contract fixtures) |