### PR TITLE
fix(store-core): one signal decides "this permission was already answered"

### DIFF
--- a/packages/app/__tests__/contract-switch.test.ts
+++ b/packages/app/__tests__/contract-switch.test.ts
@@ -199,6 +199,11 @@ function seedStore(fx: ContractFixture) {
   // writes (raw / raw_background / terminal_output) via expect.terminalWrites,
   // mirroring the dashboard harness's _terminalWrites.
   const terminalWrites: string[] = [];
+  // #7388: the app has no toast mechanism by design (#4878/#4879), so this
+  // stays empty — captured anyway so the assertion below is the SAME assertion
+  // on both clients, and a fixture declaring `infoNotifications: []` for the app
+  // side actually proves the absence rather than skipping the check.
+  const infoNotifications: string[] = [];
   const store = createMockStore({
     activeSessionId: fx.init?.activeSessionId ?? null,
     sessions: [],
@@ -211,6 +216,10 @@ function seedStore(fx: ContractFixture) {
       terminalWrites.push(d);
     },
     _terminalWrites: terminalWrites,
+    addInfoNotification: (m: string) => {
+      infoNotifications.push(m);
+    },
+    _infoNotifications: infoNotifications,
     // #6325: flat connection-state fields the real store always initialises;
     // seed them so handlers that read them (client_joined → connectedClients,
     // activity_delta/_snapshot → activity, server_error → serverErrors,
@@ -314,6 +323,13 @@ describe('contract switch fixtures — app real handleMessage (#5556.5)', () => 
         expect((store.getState() as unknown as { _terminalWrites: string[] })._terminalWrites).toEqual(
           exp!.terminalWrites,
         );
+      }
+      // #7388: the ordered addInfoNotification args. Omitted slice = "don't
+      // care"; an empty array asserts NO toast fired.
+      if (exp!.infoNotifications) {
+        expect(
+          (store.getState() as unknown as { _infoNotifications: string[] })._infoNotifications,
+        ).toEqual(exp!.infoNotifications);
       }
     });
   }

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -73,9 +73,11 @@ import {
   // #7380 — one wording for the #2833 already-answered race, shared with the
   // dashboard (which surfaces the same words as an info toast).
   PERMISSION_ALREADY_ANSWERED_NOTICE,
-  // #7380 — a REAL user decision, not merely `answered` being set:
-  // history_replay_end stamps '(resolved)' on prompts nobody answered.
-  isPermissionDecision,
+  // #7388 — one predicate for "was this permission already answered?", shared
+  // with the dashboard so the #2833 suppression cannot drift between clients.
+  // Keys on a REAL user decision, not merely `answered` being set:
+  // history_replay_end stamps '(resolved)' on prompts nobody answered (#7380).
+  isPermissionRequestAnswered,
   handlePermissionTimeout as sharedPermissionTimeout,
   // permission_rules_updated migrated to the shared dispatch table (#5556)
   // #5454 — remaining both-sides duplicates extracted into store-core
@@ -3174,28 +3176,20 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         // The signal is the prompt's own `answered` decision token (#6222/#6223),
         // set synchronously by `markPromptAnsweredByRequestId` the moment
         // `sendPermissionResponse` puts the frame on the wire — so it is always
-        // present before any server reply can arrive. The dashboard gates the
-        // same behaviour on its separate `resolvedPermissions` map; that the two
-        // clients read different signals for one question is #7388.
+        // present before any server reply can arrive.
         //
-        // `isPermissionDecision`, NOT `answered !== undefined`. `history_replay_end`
-        // blanket-stamps `answered: '(resolved)'` on every unanswered prompt in the
-        // active session, and that placeholder is indistinguishable from a real
-        // decision under a defined-check — so a prompt the user never answered
-        // would be told "your response was already recorded" AND lose its expiry
-        // note. Only the four real decision tokens count.
+        // #7388: the scan itself now lives in store-core and the DASHBOARD calls
+        // the same function, so this question has one implementation rather than
+        // two that happened to agree. See `isPermissionRequestAnswered` for why
+        // it is `isPermissionDecision` and not a defined-check (the
+        // `history_replay_end` '(resolved)' placeholder), and why it walks every
+        // session (the push-notification path answers background prompts).
         //
-        // Scan every session, not just the target: the push-notification path
-        // answers prompts in background sessions, which is exactly what
-        // `markPromptAnsweredByRequestId` walks all sessions for.
-        const alreadyAnswered = Object.values(get().sessionStates).some((ss) =>
-          ss.messages.some(
-            (m) =>
-              m.requestId === expiredRequestId &&
-              m.type === 'prompt' &&
-              isPermissionDecision(m.answered)
-          )
-        );
+        // No third argument: the app has no flat message list — `addMessage`
+        // writes into the ACTIVE session (connection.ts), so sessionStates is
+        // the whole universe here. The dashboard, which does have one and stamps
+        // `answered` into it, passes it.
+        const alreadyAnswered = isPermissionRequestAnswered(get().sessionStates, expiredRequestId);
         if (!alreadyAnswered) {
           console.warn(`[ws] Permission ${expiredRequestId} expired: ${msg.message}`);
           const expTargetId = (msg.sessionId as string) || get().activeSessionId;

--- a/packages/dashboard/src/store/contract-switch.test.ts
+++ b/packages/dashboard/src/store/contract-switch.test.ts
@@ -114,6 +114,7 @@ function seedStore(fx: ContractFixture) {
     sessionStates[id] = { ...createEmptySessionState(), ...(seed as Partial<SessionState>) }
   }
   const terminalWrites: string[] = []
+  const infoNotifications: string[] = []
   const store = createMockStore({
     connectionPhase: 'connected',
     socket: null,
@@ -151,6 +152,14 @@ function seedStore(fx: ContractFixture) {
     // The dashboard `error` handler routes structured errors here; stub so the
     // `error` fixture exercises the switch without a real toast store.
     addServerError: () => {},
+    // #7388: the permission_expired already-answered branch raises the #2839
+    // info toast. Captured (not just stubbed) so a fixture can assert the
+    // dashboard's HALF of "same reassurance, different channel" — the app says
+    // it as a transcript line, which the messages slice already covers.
+    addInfoNotification: (m: string) => {
+      infoNotifications.push(m)
+    },
+    _infoNotifications: infoNotifications,
     _terminalWrites: terminalWrites,
   } as unknown as ConnectionState)
   // #6325: checkpoint_restored calls get().switchSession(newId) — stub it to write
@@ -237,6 +246,15 @@ describe('contract switch fixtures — dashboard real handleMessage (#5556.5)', 
           (store.getState() as unknown as { _terminalWrites: string[] })._terminalWrites,
           `${fx.name}: terminal writes`,
         ).toEqual(exp!.terminalWrites)
+      }
+      // #7388: the ordered addInfoNotification args (the dashboard's toast
+      // channel). Omitted slice = "don't care", so existing fixtures are
+      // unaffected; an empty array asserts NO toast fired.
+      if (exp!.infoNotifications) {
+        expect(
+          (store.getState() as unknown as { _infoNotifications: string[] })._infoNotifications,
+          `${fx.name}: info notifications`,
+        ).toEqual(exp!.infoNotifications)
       }
     })
   }

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -5388,7 +5388,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         sharedPermissionExpired(msg);
       if (expiredRequestId) {
         // #6559 — prune the pulled input for an expired prompt. Hoisted above the
-        // alreadyResolved early-return so both branches drop it (guarded copy-delete).
+        // alreadyAnswered early-return so both branches drop it (guarded copy-delete).
         set((s) => {
           if (!s.permissionInputs || !Object.prototype.hasOwnProperty.call(s.permissionInputs, expiredRequestId)) return {};
           const next = { ...s.permissionInputs };
@@ -5427,12 +5427,12 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         // bookkeeping. Relay child expiry upward and this gate goes silent on it
         // — stamp `answered` on the child row (or give it a real prompt message)
         // in the same change.
-        const alreadyResolved = isPermissionRequestAnswered(
+        const alreadyAnswered = isPermissionRequestAnswered(
           get().sessionStates,
           expiredRequestId,
           get().messages,
         );
-        if (alreadyResolved) {
+        if (alreadyAnswered) {
           // #5008 — drain the banner stack without dropping the row from the
           // widget's durable history. See handlePermissionResolved for the
           // full rationale; this branch handles the #2833 race where expiry

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -5408,9 +5408,25 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         // which (a) is dashboard-only, (b) is capped at 1000 entries so a long
         // session could evict the answer and resurrect the bug, and (c) cannot be
         // seeded by `FixtureInitialState`, which is why this path had no
-        // cross-client contract coverage at all. `resolvedPermissions` is
-        // untouched for everything else that reads it (PermissionPrompt's
-        // remount-durable answered UI, ChildAgentEventList, ViewerPreWriteReview).
+        // cross-client contract coverage at all. Every OTHER read of
+        // `resolvedPermissions` is untouched (PermissionPrompt's remount-durable
+        // answered UI, ChildAgentEventList, ViewerPreWriteReview) — only this
+        // gate moves.
+        //
+        // KNOWN LIMIT, and the condition that would make it a bug: a permission
+        // with no `type:'prompt'` ChatMessage is invisible here. Child-agent
+        // permissions are exactly that — they arrive as
+        // `agent_event{eventType:'permission_request'}` and live in the parent
+        // Task bubble's `childAgentEvents[]`, so `ChildAgentEventList`'s Allow
+        // reaches `sendPermissionResponse` (setting `resolvedPermissions`) while
+        // `markPromptAnsweredByRequestId` finds no message to stamp. It is not a
+        // bug TODAY because no `permission_expired` ever reaches a child
+        // requestId: byok-session relays the child's `permission_request` upward
+        // (byok-session.js) but its FORWARDED set carries no `permission_expired`,
+        // and `_expirePendingPermissions` fires on the CHILD session's own
+        // bookkeeping. Relay child expiry upward and this gate goes silent on it
+        // — stamp `answered` on the child row (or give it a real prompt message)
+        // in the same change.
         const alreadyResolved = isPermissionRequestAnswered(
           get().sessionStates,
           expiredRequestId,

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -65,6 +65,9 @@ import {
   // #7380 — one wording for the #2833 already-answered race, shared with the app
   // (which surfaces it as a transcript line, having no toast by design).
   PERMISSION_ALREADY_ANSWERED_NOTICE,
+  // #7388 — one predicate for "was this permission already answered?", shared
+  // with the app so the #2833 suppression cannot drift between the two clients.
+  isPermissionRequestAnswered,
   // permission_rules_updated migrated to the shared dispatch table (#5556)
   // #5454 — dashboard adopts the shared permission family + the remaining
   // both-sides duplicates
@@ -5392,11 +5395,27 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
           delete next[expiredRequestId];
           return { permissionInputs: next };
         });
-        // If the user already resolved this request (via Allow/Deny/AllowSession),
-        // this is the race condition from #2833 — the server expired the prompt
-        // after we answered. Suppress the "Expired — already handled" message
-        // append so the UI does not surface this as an error to the user.
-        const alreadyResolved = Boolean(get().resolvedPermissions?.[expiredRequestId]);
+        // If this request was already answered (via Allow/Deny/AllowSession, on
+        // this client or another), this is the race condition from #2833 — the
+        // server expired the prompt after we answered. Suppress the
+        // "Expired — already handled" append so the UI does not surface it as an
+        // error to the user.
+        //
+        // #7388: the gate is the SHARED `isPermissionRequestAnswered`, reading the
+        // prompt's own `answered` decision token — the same signal the app uses,
+        // so "was this already answered?" now has one implementation instead of
+        // two that happened to agree. It previously read `resolvedPermissions`,
+        // which (a) is dashboard-only, (b) is capped at 1000 entries so a long
+        // session could evict the answer and resurrect the bug, and (c) cannot be
+        // seeded by `FixtureInitialState`, which is why this path had no
+        // cross-client contract coverage at all. `resolvedPermissions` is
+        // untouched for everything else that reads it (PermissionPrompt's
+        // remount-durable answered UI, ChildAgentEventList, ViewerPreWriteReview).
+        const alreadyResolved = isPermissionRequestAnswered(
+          get().sessionStates,
+          expiredRequestId,
+          get().messages,
+        );
         if (alreadyResolved) {
           // #5008 — drain the banner stack without dropping the row from the
           // widget's durable history. See handlePermissionResolved for the

--- a/packages/dashboard/src/store/permission-expired-dismiss.test.ts
+++ b/packages/dashboard/src/store/permission-expired-dismiss.test.ts
@@ -148,11 +148,17 @@ describe('permission_expired drains banners while preserving widget history (#15
 
 // ---------------------------------------------------------------------------
 // #2839: surface an info toast when permission_expired arrives for a
-// requestId that the user already resolved locally (race condition with
-// server-side expiry).
+// requestId that the user already answered (race condition with server-side
+// expiry).
+//
+// #7388 — the gate is now the prompt's own `answered` decision token, read via
+// the SHARED `isPermissionRequestAnswered` (the same call the app makes), not
+// the dashboard-only `resolvedPermissions` map. These tests therefore seed an
+// ANSWERED prompt; the last one below is the positive control proving the old
+// signal alone no longer suppresses.
 // ---------------------------------------------------------------------------
 describe('permission_expired info toast for resolved requests (#2839)', () => {
-  it('fires addInfoNotification when the requestId is in resolvedPermissions', () => {
+  it('fires addInfoNotification when the matching prompt carries a decision token', () => {
     const addInfoNotification = vi.fn()
     const store = createMockStore({
       activeSessionId: 'sess-1',
@@ -160,7 +166,11 @@ describe('permission_expired info toast for resolved requests (#2839)', () => {
       resolvedPermissions: { 'req-abc': 'allow' },
       addInfoNotification,
       sessionStates: {
-        'sess-1': { messages: [] },
+        'sess-1': {
+          messages: [
+            { type: 'prompt', content: 'Allow write?', requestId: 'req-abc', answered: 'allow' },
+          ],
+        },
       } as unknown as ConnectionState['sessionStates'],
     })
     setStore(store)
@@ -203,7 +213,7 @@ describe('permission_expired info toast for resolved requests (#2839)', () => {
     expect(addInfoNotification).not.toHaveBeenCalled()
   })
 
-  it('marks the matching session notification as read (banner drains, widget retains) for resolved ids (#5008)', () => {
+  it('marks the matching session notification as read (banner drains, widget retains) for answered ids (#5008)', () => {
     const addInfoNotification = vi.fn()
     const store = createMockStore({
       activeSessionId: 'sess-1',
@@ -213,7 +223,11 @@ describe('permission_expired info toast for resolved requests (#2839)', () => {
       resolvedPermissions: { 'req-abc': 'allow' },
       addInfoNotification,
       sessionStates: {
-        'sess-1': { messages: [] },
+        'sess-1': {
+          messages: [
+            { type: 'prompt', content: 'Allow write?', requestId: 'req-abc', answered: 'allow' },
+          ],
+        },
       } as unknown as ConnectionState['sessionStates'],
     })
     setStore(store)
@@ -231,5 +245,103 @@ describe('permission_expired info toast for resolved requests (#2839)', () => {
     expect(list).toHaveLength(1)
     expect(list[0]!.readAt).toBeTypeOf('number')
     expect(addInfoNotification).toHaveBeenCalled()
+  })
+
+  // #7388 positive control. Without this, every test above would still pass if
+  // the gate silently fell back to `resolvedPermissions` — they all seed BOTH
+  // signals, because in production both are written together. This is the one
+  // input that separates them, and it is the input that matters: a long session
+  // evicts old entries from `resolvedPermissions` (capped at 1000 by
+  // `capResolvedPermissions`) while `answered` lives on the message forever.
+  it('does NOT suppress on resolvedPermissions alone — the retired signal (#7388)', () => {
+    const addInfoNotification = vi.fn()
+    const store = createMockStore({
+      activeSessionId: 'sess-1',
+      sessionNotifications: [],
+      resolvedPermissions: { 'req-abc': 'allow' },
+      addInfoNotification,
+      sessionStates: {
+        'sess-1': {
+          messages: [
+            // The map says answered; the message does not. The message wins.
+            { type: 'prompt', content: 'Allow write?', requestId: 'req-abc' },
+          ],
+        },
+      } as unknown as ConnectionState['sessionStates'],
+    })
+    setStore(store)
+    setConnectionContext(mockCtx)
+
+    handleMessage({
+      type: 'permission_expired',
+      requestId: 'req-abc',
+      message: 'Permission timed out',
+    }, mockCtx)
+
+    expect(addInfoNotification).not.toHaveBeenCalled()
+    const msg = store.getState().sessionStates['sess-1']!.messages[0]!
+    expect(msg.content).toContain('(Expired')
+  })
+
+  // #7388 / #7380 — `answered` merely being SET is not a decision.
+  // `history_replay_end` blanket-stamps '(resolved)' on prompts NOBODY answered;
+  // suppressing on it would tell those users their response was recorded.
+  it("does NOT suppress on history_replay_end's '(resolved)' placeholder", () => {
+    const addInfoNotification = vi.fn()
+    const store = createMockStore({
+      activeSessionId: 'sess-1',
+      sessionNotifications: [],
+      resolvedPermissions: {},
+      addInfoNotification,
+      sessionStates: {
+        'sess-1': {
+          messages: [
+            { type: 'prompt', content: 'Allow write?', requestId: 'req-abc', answered: '(resolved)' },
+          ],
+        },
+      } as unknown as ConnectionState['sessionStates'],
+    })
+    setStore(store)
+    setConnectionContext(mockCtx)
+
+    handleMessage({
+      type: 'permission_expired',
+      requestId: 'req-abc',
+      message: 'Permission timed out',
+    }, mockCtx)
+
+    expect(addInfoNotification).not.toHaveBeenCalled()
+    const msg = store.getState().sessionStates['sess-1']!.messages[0]!
+    expect(msg.content).toContain('(Expired')
+  })
+
+  // #7388 — the dashboard's flat `messages` list is a real answered-prompt
+  // location (markPromptAnsweredByRequestId falls back to it when the prompt is
+  // in no session, and so does the permission_resolved handler). Passing it to
+  // the shared predicate is load-bearing, not defensive.
+  it('suppresses when the answered prompt lives only in the flat messages list', () => {
+    const addInfoNotification = vi.fn()
+    const store = createMockStore({
+      activeSessionId: 'sess-1',
+      sessionNotifications: [],
+      resolvedPermissions: {},
+      addInfoNotification,
+      messages: [
+        { type: 'prompt', content: 'Allow write?', requestId: 'req-abc', answered: 'deny' },
+      ] as unknown as ConnectionState['messages'],
+      sessionStates: {
+        'sess-1': { messages: [] },
+      } as unknown as ConnectionState['sessionStates'],
+    })
+    setStore(store)
+    setConnectionContext(mockCtx)
+
+    handleMessage({
+      type: 'permission_expired',
+      requestId: 'req-abc',
+      message: 'Permission timed out',
+    }, mockCtx)
+
+    expect(addInfoNotification).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/dashboard/src/store/store.test.ts
+++ b/packages/dashboard/src/store/store.test.ts
@@ -2391,7 +2391,7 @@ describe('resolvedPermissions + Allow for Session (#2833, #2834)', () => {
     expect(state.memoryStackLoading).toBe(false);
   });
 
-  it('permission_expired for an already-resolved requestId does not mutate the prompt message', async () => {
+  it('permission_expired for an already-answered requestId does not mutate the prompt message', async () => {
     const { useConnectionStore } = await import('./connection');
     const { createEmptySessionState } = await import('./utils');
     const { _testMessageHandler } = await import('./message-handler');
@@ -2405,6 +2405,11 @@ describe('resolvedPermissions + Allow for Session (#2833, #2834)', () => {
           messages: [{
             id: 'm1', type: 'prompt', content: originalContent, timestamp: 1,
             requestId: 'req-resolved', tool: 'Write',
+            // #7388: the decision token on the message is what the gate reads
+            // now (shared `isPermissionRequestAnswered`, same as the app).
+            // `sendPermissionResponse` writes this and `resolvedPermissions`
+            // together, so both are seeded here as production would have them.
+            answered: 'allow',
           }],
         },
       },

--- a/packages/store-core/src/contract-fixtures/coverage-lint.test.ts
+++ b/packages/store-core/src/contract-fixtures/coverage-lint.test.ts
@@ -44,6 +44,7 @@ import {
 } from '@chroxy/protocol/handler-coverage'
 import { SWITCH_FIXTURES } from './fixtures'
 import { DISPATCH_TABLE_TYPES } from '../dispatch-table'
+import { PERMISSION_ALREADY_ANSWERED_NOTICE } from '../handlers/permission'
 
 const here = dirname(fileURLToPath(import.meta.url))
 const appHandlerPath = resolve(here, '../../../app/src/store/message-handler.ts')
@@ -308,5 +309,34 @@ describe('both-clients SWITCH_FIXTURES coverage lint (#5619)', () => {
         '(migrated to the dispatch table, renamed, or single-platform). Move or ' +
         `remove them:\n  ${stale.join('\n  ')}`,
     ).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// #7388 — the fixture table is PURE DATA (type-only imports) so all four test
+// runners can consume it, which means a fixture asserting a SHARED string has
+// to spell it out as a literal. That literal is a copy, and a copy drifts —
+// exactly the defect class this repo catalogues. Pin it here, where a runtime
+// import IS allowed: rewording PERMISSION_ALREADY_ANSWERED_NOTICE without
+// updating the fixture fails HERE, naming the cause, instead of failing in two
+// client suites as an opaque string mismatch.
+// ---------------------------------------------------------------------------
+
+describe('shared-string literals inlined into fixtures stay pinned to their source', () => {
+  it('the permission_expired already-answered fixture quotes PERMISSION_ALREADY_ANSWERED_NOTICE verbatim', () => {
+    const fx = SWITCH_FIXTURES.find(
+      (f) => f.name === 'permission_expired does NOT expire a prompt the user already answered (#2833 race)',
+    )
+    expect(fx, 'the #7388 already-answered fixture must exist').toBeDefined()
+
+    // App side: the notice is a transcript system line.
+    const appMessages = (fx!.divergent?.app.sessions?.s1?.messages ?? []) as Array<Record<string, unknown>>
+    const appNotice = appMessages.find((m) => m.type === 'system')
+    expect(appNotice?.content, 'app transcript notice').toBe(PERMISSION_ALREADY_ANSWERED_NOTICE)
+
+    // Dashboard side: the same words, as an info toast.
+    expect(fx!.divergent?.dashboard.infoNotifications, 'dashboard toast').toEqual([
+      PERMISSION_ALREADY_ANSWERED_NOTICE,
+    ])
   })
 })

--- a/packages/store-core/src/contract-fixtures/fixtures.ts
+++ b/packages/store-core/src/contract-fixtures/fixtures.ts
@@ -2046,14 +2046,13 @@ export const SWITCH_FIXTURES: ContractFixture[] = [
     // — so the fixture seeds a prompt carrying the requestId.
     //
     // Both clients take the same path here because the seeded prompt is
-    // UNANSWERED, which is now the load-bearing detail: as of #7380 the app's
-    // already-answered early-return is gated on the prompt's own `answered`
-    // token, which FixtureInitialState CAN seed. The dashboard's stays gated on
-    // `resolvedPermissions`, which it cannot. So the suppression path — the one
-    // #7375 made routine — still has no cross-client contract coverage, and it is
-    // the difference in signal, not the harness, that prevents it. Unifying them
-    // (and then covering it here, `divergent` if they legitimately differ) is
-    // #7388.
+    // UNANSWERED — the load-bearing detail. As of #7388 BOTH clients gate the
+    // already-answered early-return on the prompt's own `answered` decision
+    // token (shared `isPermissionRequestAnswered`), which FixtureInitialState
+    // CAN seed, so the suppression path — the one #7375 made routine — is
+    // covered by the two fixtures below rather than being untestable here. It
+    // previously was untestable: the dashboard gated on `resolvedPermissions`,
+    // which the harness cannot seed.
     //
     // The banner-drain is a sessionNotifications side effect outside the asserted
     // messages slice.
@@ -2070,6 +2069,151 @@ export const SWITCH_FIXTURES: ContractFixture[] = [
               content: 'Bash: rm -rf /tmp/x',
               tool: 'Bash',
               requestId: 'req-1',
+              options: [{ label: 'Allow', value: 'allow' }, { label: 'Deny', value: 'deny' }],
+            } as unknown as ChatMessage,
+          ],
+        },
+      },
+    },
+    message: {
+      type: 'permission_expired',
+      requestId: 'req-1',
+      sessionId: 's1',
+      message: 'permission response could not be routed (expired/handled)',
+    },
+    expect: {
+      sessions: {
+        s1: {
+          messages: [
+            {
+              id: 'prompt-req-1',
+              type: 'prompt',
+              content: 'Bash: rm -rf /tmp/x\n(Expired — this permission was already handled or timed out)',
+              tool: 'Bash',
+            },
+          ],
+        },
+      },
+    },
+  },
+  {
+    // #7388 — the #2833 race, which #7375 turned from a five-minute-timeout edge
+    // case into a routine one (permission_expired now fires whenever a turn
+    // dies). The user answered; the server expired the prompt anyway. NEITHER
+    // client may append "(Expired — …)" to a prompt that was answered, and the
+    // prompt's `expiresAt`/content must be left alone.
+    //
+    // This is the fixture the old note here said could not exist: the gate used
+    // to be the dashboard's `resolvedPermissions` map (unseedable by
+    // FixtureInitialState) on one side and the app's `answered` token on the
+    // other. Both now call the shared `isPermissionRequestAnswered`, which reads
+    // `answered` — a seedable ChatMessage field — so the suppression path is
+    // finally covered on BOTH clients from one row.
+    //
+    // MUTATION THAT MUST GO RED: point either client's gate back at its own
+    // signal (dashboard `resolvedPermissions[requestId]`, which this fixture
+    // deliberately does not seed) and the dashboard side appends the expired
+    // suffix — message count and content both diverge from the expectation below.
+    name: 'permission_expired does NOT expire a prompt the user already answered (#2833 race)',
+    type: 'permission_expired',
+    init: {
+      activeSessionId: 's1',
+      sessions: {
+        s1: {
+          messages: [
+            {
+              id: 'prompt-req-1',
+              type: 'prompt',
+              content: 'Bash: rm -rf /tmp/x',
+              tool: 'Bash',
+              requestId: 'req-1',
+              // The decision token the send path stamps (#6222/#6223) — an enum
+              // value, never a display label.
+              answered: 'allow',
+              options: [{ label: 'Allow', value: 'allow' }, { label: 'Deny', value: 'deny' }],
+            } as unknown as ChatMessage,
+          ],
+        },
+      },
+    },
+    message: {
+      type: 'permission_expired',
+      requestId: 'req-1',
+      sessionId: 's1',
+      message: 'permission response could not be routed (expired/handled)',
+    },
+    divergent: {
+      app: {
+        sessions: {
+          s1: {
+            messages: [
+              {
+                id: 'prompt-req-1',
+                type: 'prompt',
+                // Unchanged — no "(Expired …)" suffix.
+                content: 'Bash: rm -rf /tmp/x',
+                tool: 'Bash',
+              },
+              // The reassurance, as a transcript line.
+              { type: 'system', content: 'Already answered — your response was already recorded' },
+            ],
+          },
+        },
+        // Proven absent, not assumed: the app has no toast mechanism (#4878/#4879).
+        infoNotifications: [],
+      },
+      dashboard: {
+        sessions: {
+          s1: {
+            messages: [
+              {
+                id: 'prompt-req-1',
+                type: 'prompt',
+                content: 'Bash: rm -rf /tmp/x',
+                tool: 'Bash',
+              },
+            ],
+          },
+        },
+        // Same words, different channel — asserted, not merely asserted-about.
+        infoNotifications: ['Already answered — your response was already recorded'],
+      },
+      reason:
+        'Both clients suppress the expiry note identically (shared isPermissionRequestAnswered). ' +
+        'They differ only in the CHANNEL for the reassurance: the dashboard raises an info ' +
+        'toast (#2839), the app has no toast mechanism by design (#4878/#4879) and appends the ' +
+        'same shared string (PERMISSION_ALREADY_ANSWERED_NOTICE) to the transcript (#7380). ' +
+        'Hence one extra system message on the app side and an infoNotifications entry on the ' +
+        'dashboard side.',
+    },
+  },
+  {
+    // #7388 / #7380 — the INVERSE input, and the reason the gate is
+    // `isPermissionDecision` rather than `answered !== undefined`.
+    // `history_replay_end` blanket-stamps the placeholder `answered: '(resolved)'`
+    // on every unanswered prompt in the active session. Under a defined-check
+    // that placeholder is indistinguishable from a real decision, so a prompt
+    // NOBODY answered would be told "your response was already recorded" and
+    // would silently lose its expiry note.
+    //
+    // MUTATION THAT MUST GO RED: relax `isPermissionRequestAnswered` to
+    // `m.answered !== undefined` (or to any non-empty string) and both clients
+    // suppress here — the expired suffix vanishes from the expectation below.
+    name: 'permission_expired still expires a prompt carrying only the (resolved) replay placeholder',
+    type: 'permission_expired',
+    init: {
+      activeSessionId: 's1',
+      sessions: {
+        s1: {
+          messages: [
+            {
+              id: 'prompt-req-1',
+              type: 'prompt',
+              content: 'Bash: rm -rf /tmp/x',
+              tool: 'Bash',
+              requestId: 'req-1',
+              // NOT a decision token — history_replay_end's placeholder.
+              answered: '(resolved)',
               options: [{ label: 'Allow', value: 'allow' }, { label: 'Deny', value: 'deny' }],
             } as unknown as ChatMessage,
           ],

--- a/packages/store-core/src/handlers/permission.ts
+++ b/packages/store-core/src/handlers/permission.ts
@@ -140,14 +140,21 @@ export const PERMISSION_ALREADY_ANSWERED_NOTICE =
  * The system message text is the same line both clients append to the
  * matching prompt today: `"(Expired — this permission was already handled or
  * timed out)"`. The handler does NOT decide whether to apply it — the call
- * site gates on `requestId` and on whether the prompt was already resolved.
+ * site gates on `requestId` and on whether the prompt was already answered.
  *
- * That already-resolved gate stays platform-specific because the two clients
- * read DIFFERENT signals for it: the dashboard keys on its `resolvedPermissions`
- * map, the app (#7380) on the prompt message's own `answered` field — via
- * `isPermissionDecision`, NOT a defined-check, because `history_replay_end`
- * stamps the placeholder `'(resolved)'` on prompts nobody answered. Unifying
- * the two signals is #7388.
+ * #7388: that gate is now ONE predicate, `isPermissionRequestAnswered`
+ * (pending-permissions.ts), which both clients call — keyed on the prompt's own
+ * `answered` decision token via `isPermissionDecision`, NOT a defined-check,
+ * because `history_replay_end` stamps the placeholder `'(resolved)'` on prompts
+ * nobody answered. It previously WAS platform-specific (dashboard:
+ * `resolvedPermissions`; app: `answered`, #7380), which left the suppression
+ * path — the one #7375 made routine — with no cross-client contract coverage,
+ * because `resolvedPermissions` is not seedable by `FixtureInitialState`.
+ *
+ * What the two clients still legitimately differ on is the CHANNEL for the
+ * reassurance: the dashboard raises an info toast, the app appends
+ * {@link PERMISSION_ALREADY_ANSWERED_NOTICE} to the transcript. That difference
+ * is pinned by a `divergent` contract fixture, not left to chance.
  */
 export function handlePermissionExpired(msg: Record<string, unknown>): {
   requestId: string | null

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -956,6 +956,9 @@ export {
   // (history_replay_end stamps '(resolved)' on prompts nobody answered).
   isPermissionDecision,
   PERMISSION_DECISION_TOKENS,
+  // #7388 — the ONE "was this permission already answered by a user?" gate,
+  // applied by both clients' permission_expired handlers (the #2833 race).
+  isPermissionRequestAnswered,
   firstLivePermissionPrompt,
   livePermissionPrompts,
   countLivePermissionPrompts,

--- a/packages/store-core/src/pending-permissions.test.ts
+++ b/packages/store-core/src/pending-permissions.test.ts
@@ -11,6 +11,8 @@ import {
   selectNextPendingSession,
   pathMatchesViewer,
   findPendingWriteForFile,
+  isPermissionRequestAnswered,
+  PERMISSION_DECISION_TOKENS,
 } from './pending-permissions'
 
 const NOW = 1_000_000
@@ -225,5 +227,75 @@ describe('findPendingWriteForFile (#6859)', () => {
     const msgs = [editPrompt({ expiresAt: NOW2 + 100 })]
     expect(findPendingWriteForFile(msgs, FILE, NOW2, isReviewableTool)?.requestId).toBe('req-1')
     expect(findPendingWriteForFile(msgs, FILE, NOW2 + 101, isReviewableTool)).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// #7388 — the ONE "was this permission already answered?" gate. Both clients'
+// permission_expired handlers call this; if it says yes they suppress the
+// "(Expired — …)" note and reassure instead (the #2833 race).
+// ---------------------------------------------------------------------------
+
+describe('isPermissionRequestAnswered', () => {
+  it('is true for every real decision token, in any session', () => {
+    for (const token of PERMISSION_DECISION_TOKENS) {
+      expect(
+        isPermissionRequestAnswered(states({ s1: [prompt({ answered: token })] }), 'req-1'),
+        `token ${token}`,
+      ).toBe(true)
+    }
+  })
+
+  it('is false for an unanswered prompt', () => {
+    expect(isPermissionRequestAnswered(states({ s1: [prompt()] }), 'req-1')).toBe(false)
+  })
+
+  it("rejects history_replay_end's '(resolved)' placeholder — the #7380 inverse bug", () => {
+    // `answered` merely being SET is not a decision: history_replay_end stamps
+    // this on prompts NOBODY answered. A defined-check here would tell those
+    // users "your response was already recorded" and swallow the expiry note.
+    expect(isPermissionRequestAnswered(states({ s1: [prompt({ answered: '(resolved)' })] }), 'req-1')).toBe(
+      false,
+    )
+    // And not just that one placeholder — any unknown string is rejected, so a
+    // FUTURE placeholder cannot quietly qualify either.
+    expect(isPermissionRequestAnswered(states({ s1: [prompt({ answered: 'whatever' })] }), 'req-1')).toBe(
+      false,
+    )
+    expect(isPermissionRequestAnswered(states({ s1: [prompt({ answered: '' })] }), 'req-1')).toBe(false)
+  })
+
+  it('scans EVERY session, not just the first — the push path answers background prompts', () => {
+    const st = states({
+      s1: [prompt({ id: 'other', requestId: 'req-other', answered: 'allow' })],
+      s2: [prompt({ id: 'bg', answered: 'deny' })],
+    })
+    expect(isPermissionRequestAnswered(st, 'req-1')).toBe(true)
+  })
+
+  it('matches on requestId, and only on a prompt bubble', () => {
+    expect(isPermissionRequestAnswered(states({ s1: [prompt({ answered: 'allow' })] }), 'req-2')).toBe(false)
+    // An AskUserQuestion answer, or any non-prompt bubble carrying the id, must
+    // not stand in for a permission decision.
+    expect(
+      isPermissionRequestAnswered(
+        states({ s1: [prompt({ type: 'response', answered: 'allow' })] }),
+        'req-1',
+      ),
+    ).toBe(false)
+  })
+
+  it('also reads the flat message list (the dashboard stamps `answered` there too)', () => {
+    expect(
+      isPermissionRequestAnswered(states({ s1: [] }), 'req-1', [prompt({ answered: 'allow' })]),
+    ).toBe(true)
+    expect(isPermissionRequestAnswered(states({ s1: [] }), 'req-1', [prompt()])).toBe(false)
+  })
+
+  it('is false for a missing/empty requestId and tolerates absent state', () => {
+    expect(isPermissionRequestAnswered(states({ s1: [prompt({ answered: 'allow' })] }), '')).toBe(false)
+    expect(isPermissionRequestAnswered(states({ s1: [prompt({ answered: 'allow' })] }), null)).toBe(false)
+    expect(isPermissionRequestAnswered(undefined, 'req-1')).toBe(false)
+    expect(isPermissionRequestAnswered(null, 'req-1', null)).toBe(false)
   })
 })

--- a/packages/store-core/src/pending-permissions.ts
+++ b/packages/store-core/src/pending-permissions.ts
@@ -52,6 +52,59 @@ export function isPermissionDecision(answered: string | undefined | null): boole
   return (PERMISSION_DECISION_TOKENS as readonly string[]).includes(answered ?? '')
 }
 
+/**
+ * True iff the permission request `requestId` was ALREADY ANSWERED by a user —
+ * the gate both clients apply when a `permission_expired` arrives for it (the
+ * #2833 race, which #7375 made routine: `permission_expired` now fires whenever
+ * a turn dies, not only on the five-minute timeout).
+ *
+ * #7388 — this is the ONE signal for that question. Before it the two clients
+ * answered it from different state: the app from the prompt's own `answered`
+ * token (#7380), the dashboard from its separate `resolvedPermissions` map.
+ * Both were correct for the input each happened to see, which is exactly the
+ * shape `docs/false-safety-guards.md` catalogues; and the dashboard's map is
+ * additionally CAPPED (`capResolvedPermissions`, 1000 entries) while `answered`
+ * lives on the message forever, so a long session could evict the entry and
+ * start telling users an answered permission had "expired" again.
+ *
+ * Unified on `answered` because it is the cross-client token (#6222/#6223), it
+ * is what `isLivePermissionPrompt` already keys on, and — unlike
+ * `resolvedPermissions` — it is seedable by `FixtureInitialState`, so this path
+ * can finally carry cross-client contract coverage.
+ *
+ * `isPermissionDecision`, NOT a defined-check: `history_replay_end` blanket-
+ * stamps the placeholder `'(resolved)'` on every unanswered prompt in the
+ * active session, and under `answered !== undefined` a prompt nobody touched
+ * would read as answered — the inverse bug, caught in #7380's first draft.
+ *
+ * Scans every session, not just the target one: the push-notification path
+ * answers prompts in background sessions, which is why
+ * `markPromptAnsweredByRequestId` walks all sessions too.
+ *
+ * `flatMessages` is OPTIONAL because only the dashboard has such a list: its
+ * `markPromptAnsweredByRequestId` and its `permission_resolved` fallback both
+ * stamp `answered` onto the top-level `messages` array, so omitting it there
+ * would leave a real answered-prompt location unscanned. The app has no flat
+ * list at all — its `addMessage` writes into the active session — so it passes
+ * nothing rather than passing a field that does not exist.
+ */
+export function isPermissionRequestAnswered(
+  sessionStates: Record<string, { messages: ChatMessage[] } | undefined> | undefined | null,
+  requestId: string | null | undefined,
+  flatMessages?: ChatMessage[] | null,
+): boolean {
+  if (!requestId) return false
+  const answeredIn = (messages: ChatMessage[] | undefined | null): boolean =>
+    !!messages?.some(
+      (m) => m.requestId === requestId && m.type === 'prompt' && isPermissionDecision(m.answered),
+    )
+  if (answeredIn(flatMessages)) return true
+  for (const id in sessionStates ?? {}) {
+    if (answeredIn(sessionStates![id]?.messages)) return true
+  }
+  return false
+}
+
 /** True iff `m` is a live, unanswered permission prompt (not an AskUserQuestion). */
 export function isLivePermissionPrompt(m: ChatMessage, now: number): boolean {
   return (


### PR DESCRIPTION
Closes #7388

## The split this removes

Both clients suppress the `(Expired — this permission was already handled or timed out)` note when `permission_expired` arrives for a request the user already answered — the #2833 race, which #7375 turned from a five-minute-timeout edge case into a routine one. They decided "already answered" from **different state**:

| client | signal (before) |
|---|---|
| dashboard | `resolvedPermissions[requestId]` — a separate store map |
| app (#7380) | the prompt message's own `answered` decision token |

Both were correct for the input each happened to see. That is the shape `docs/false-safety-guards.md` catalogues, and here it had two concrete costs:

- **`resolvedPermissions` is capped** at 1000 entries (`capResolvedPermissions`), while `answered` lives on the message forever. A long session evicts the entry and the dashboard resumes telling users an answered permission "expired".
- **`resolvedPermissions` cannot be seeded by `FixtureInitialState`**, so the suppression path — the one #7375 made common — had *no cross-client contract coverage at all*. The fixture table carried a note saying exactly that.

## What changed

`isPermissionRequestAnswered` in `store-core/pending-permissions.ts` is now the one predicate, called by both clients' `permission_expired` handlers.

- Keys on `isPermissionDecision`, **not** a defined-check: `history_replay_end` blanket-stamps `answered: '(resolved)'` on prompts nobody answered, and a defined-check would tell those users their response was recorded (the inverse bug, caught in #7380's first draft).
- Scans every session (the push-notification path answers background prompts).
- The dashboard also passes its flat `messages` list — its own `markPromptAnsweredByRequestId` and `permission_resolved` fallback stamp `answered` there. The app has no flat list (`addMessage` writes into the active session) and passes nothing.

`resolvedPermissions` is untouched for everything else that reads it (`PermissionPrompt`'s remount-durable answered UI, `ChildAgentEventList`, `ViewerPreWriteReview`). Only the expiry gate moves.

## Coverage — the acceptance item that was blocked

- **Two new `SWITCH_FIXTURES` rows**, driven through BOTH clients' real `handleMessage`:
  - an **answered** prompt → neither client appends the expired note. `divergent`, because the two differ only in the *channel* for the reassurance: the dashboard raises the #2839 info toast, the app appends the same shared string to the transcript (#4878/#4879 — no toast by design).
  - a prompt carrying **only the `'(resolved)'` replay placeholder** → both clients still expire it.
- Both contract-switch drivers now capture and assert `infoNotifications`, so the dashboard's toast *and* the app's proven-absent toast are checked rather than described.
- The fixture table is pure data (type-only imports), so the shared notice is inlined as a literal — a new lint in `coverage-lint.test.ts` pins that literal to `PERMISSION_ALREADY_ANSWERED_NOTICE`, so a reword fails there by name instead of failing two client suites as an opaque string mismatch.
- Unit tests for the predicate, plus a dashboard **positive control** proving `resolvedPermissions` alone no longer suppresses — without it every other test would still pass if the gate silently fell back, since production writes both signals together.
- The stale note in `fixtures.ts` is corrected.

## Proven red before green

| mutation | result |
|---|---|
| dashboard gate reverted to `resolvedPermissions[requestId]` | dashboard contract-switch **fails** (expired suffix appears) |
| predicate relaxed to `answered !== undefined` | app **and** dashboard contract-switch fail on the placeholder fixture, and the store-core unit test fails |

Restored from a `cp` backup, not `git checkout --`.

## Third acceptance item: not applicable

> The app's `permission_expired` handler clears `options` but does not stamp `expiresAt`

Already fixed in #7389 — the app stamps `expiresAt: Date.now()`, with a test carrying a positive control (`REVIEW: an expired UNANSWERED prompt stops counting as live (#7335 mobile half)`). No change needed here.

## Gates

- `packages/store-core` — 2174 tests pass, typecheck clean
- `packages/dashboard` — 5218 tests pass, typecheck clean
- `packages/app` — 2354 tests pass, typecheck clean
- `packages/protocol` — 392 tests pass