### PR TITLE
fix(ci): scope the npm cache-key guard to the defect, not to ci.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           node-version: 22
           cache: npm
-          cache-dependency-path: package-lock.json
+          cache-dependency-path: '**/package-lock.json'
 
       - name: Install dependencies
         run: npm ci
@@ -118,7 +118,7 @@ jobs:
         with:
           node-version: 22
           cache: npm
-          cache-dependency-path: package-lock.json
+          cache-dependency-path: '**/package-lock.json'
 
       - name: Install dependencies
         run: npm ci
@@ -174,7 +174,7 @@ jobs:
         with:
           node-version: 22
           cache: npm
-          cache-dependency-path: package-lock.json
+          cache-dependency-path: '**/package-lock.json'
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
@@ -320,7 +320,7 @@ jobs:
         with:
           node-version: 22
           cache: npm
-          cache-dependency-path: package-lock.json
+          cache-dependency-path: '**/package-lock.json'
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable

--- a/docs/false-safety-guards.md
+++ b/docs/false-safety-guards.md
@@ -824,3 +824,48 @@ indistinguishable from a pattern that matched nothing.
 **Guard against it:** when a field decides what a tool reads, confine what the tool
 **returns**, not what it was asked for. And when auditing a floor, ask what the tool
 reads — not which of its fields the list happens to scan.
+
+### 16. The guard scoped to one file, and the value it could not spell — 
+
+Two instances, one PR, both in the same guard.
+
+**The file.** `ci-cache-key.test.js` enforced that setup-node's
+`cache-dependency-path` is `**/package-lock.json` — this is a three-lockfile
+monorepo, and the default key is the root file alone, so a bare key means a
+dependency change under `packages/` restores a stale cache. It read `ci.yml`
+and nothing else. `maestro-nightly.yml` carried the bare key (found while fixing
+`#7383`, not by this guard) and `release.yml` carried it **four times** — so a
+*release* build could be cut from a stale cache, which is the worst place in the
+repo for it. Cause #1 again, in its purest form: a guard whose roster is a
+hardcoded list of one file, beside a directory that grows.
+
+The fix is the same one that worked in `#7383`: **scope to the defect, not the
+file.** Discovery is `readdir`, so a workflow that does not exist yet is covered.
+
+**And the value it could not spell — found in review of that fix.** The reader
+took `runs-on` as a single line. GitHub accepts two spellings of one label set:
+
+```yaml
+runs-on: [self-hosted, macOS, ARM64]   # flow — the value is on the line
+runs-on:                               # block — the line holds NOTHING
+  - self-hosted
+```
+
+The block form yielded the literal string `"runs-on:"`, so `/self-hosted/` never
+matched and every self-hosted rule `continue`d past the job. A workflow pinned to
+`[self-hosted, macOS, ARM64]` in block form while hardcoding `cache: npm` —
+`#7383`'s defect verbatim — passed **all 14 tests green**. Reproduced before
+fixing.
+
+This is a variant worth naming on its own: **two spellings of identical config,
+one of them invisible to the guard.** The repo happens to use only the flow form,
+so no amount of scanning the real workflows could have revealed it — which is why
+the reader now has unit tests driven by *synthetic* YAML. A guard that only ever
+sees the inputs the repo currently produces is untested against the inputs it
+exists to catch.
+
+**Guard against it:** when a reader becomes shared infrastructure, test the
+reader, with inputs the repo does not currently contain. A consumer's positive
+control catches a reader that finds *nothing*; nothing catches a reader that
+finds *most things*.
+

--- a/packages/server/tests/ci-cache-key.test.js
+++ b/packages/server/tests/ci-cache-key.test.js
@@ -98,8 +98,15 @@ describe('setup-node npm cache key covers every lockfile (#7386)', () => {
     // A step with no `cache:` at all (scripts-tests, release-pr-subject,
     // dashboard-smoke, maestro) uses setup-node for the Node runtime alone and
     // is correctly exempt — cache-dependency-path is inert without `cache:`.
-    // An empty `cache:` (the self-hosted branch of #7383's routing) is likewise
-    // exempt by the same falsiness.
+    //
+    // The exemption is on the LITERAL text, which is the only thing a static
+    // reader has. #7383's routed steps carry `cache: ${{ ... .npmcache }}`, a
+    // non-empty string here even though it resolves to empty on the self-hosted
+    // branch at runtime — so they are REQUIRED to declare the path, and do. That
+    // is the right answer for the reason that matters: the same expression
+    // resolves to `npm` on the hosted fork-PR branch, which is exactly the case
+    // the key has to be correct for. A literal `cache: ''` would be exempt by
+    // falsiness; no workflow writes one today.
     const offenders = steps
       .filter(({ step }) => {
         const cache = stepInput(step, 'cache')

--- a/packages/server/tests/ci-cache-key.test.js
+++ b/packages/server/tests/ci-cache-key.test.js
@@ -1,52 +1,118 @@
 import { before, describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { readFile } from 'node:fs/promises'
+import {
+  readWorkflows,
+  assertReaderSane,
+  stepInput,
+  SETUP_NODE,
+  LOCKFILE_GLOB,
+} from './helpers/workflow-reader.js'
 
-describe('CI workflow cache configuration', () => {
-  let ciYml
+/**
+ * setup-node's npm cache KEY must cover all three lockfiles — in every workflow.
+ *
+ * This repo is an npm-workspaces monorepo with three `package-lock.json` files.
+ * `actions/setup-node`'s default `cache-dependency-path` is the ROOT lockfile
+ * alone, so a job that omits the input, or sets it to the bare
+ * `package-lock.json`, hashes only the root file: a dependency change under
+ * `packages/` does not bust the key and the job restores a stale `~/.npm`.
+ *
+ * WHY THIS SCANS EVERY WORKFLOW (#7386)
+ * -------------------------------------
+ * It used to read `ci.yml` and nothing else, which made it blind to the exact
+ * defect it exists to catch. Two instances lived one file over the whole time
+ * it was green:
+ *
+ *   - `maestro-nightly.yml` carried `cache-dependency-path: package-lock.json`
+ *     (found while fixing #7383, not by this guard);
+ *   - `release.yml` carried it FOUR times — so a release build could be cut from
+ *     a stale cache, which is the worst place in the repo for this to happen.
+ *
+ * That is the first recurring cause in docs/false-safety-guards.md — "a
+ * hardcoded list next to a set that grows" — and a file-scoped guard is a
+ * hardcoded list of one. The rule is now scoped to the DEFECT: any setup-node
+ * step, in any workflow file, including files that do not exist yet. Discovery
+ * is `readdir`, never a roster held here.
+ *
+ * The reader is shared with `ci-npm-cache-routing.test.js`
+ * (`helpers/workflow-reader.js`) rather than transcribed, so the two guards
+ * cannot drift apart in what they can see.
+ */
+describe('setup-node npm cache key covers every lockfile (#7386)', () => {
+  let workflows
+  let steps
 
   before(async () => {
-    ciYml = await readFile(
-      new URL('../../../.github/workflows/ci.yml', import.meta.url),
-      'utf8'
+    workflows = await readWorkflows()
+    steps = workflows.flatMap(w =>
+      w.jobs.flatMap(job =>
+        job.steps
+          .filter(s => s.some(l => l.includes(SETUP_NODE)))
+          .map(step => ({ where: `${w.name}:${job.line} ${job.id}`, step }))
+      )
     )
   })
 
-  it('loads ci.yml', () => {
-    assert.ok(ciYml.length > 0)
+  // ---- positive control ---------------------------------------------------
+  // Both rules below quantify over `steps`. A reader that finds nothing passes
+  // them vacuously and reports a clean green — the failure mode that let
+  // release.yml's four offenders sit under a green guard for as long as they did.
+
+  it('reads every workflow and finds the setup-node steps', () => {
+    assertReaderSane(workflows)
+    assert.ok(
+      steps.length >= 15,
+      `expected >=15 setup-node steps across all workflows, found ${steps.length}`
+    )
+    // The specific file this guard was blind to, named so a readdir/parse
+    // regression that drops it is a failure rather than a smaller scan.
+    assert.ok(
+      steps.some(s => s.where.startsWith('release.yml:')),
+      `expected setup-node steps in release.yml among: ${[...new Set(steps.map(s => s.where.split(':')[0]))].join(', ')}`
+    )
   })
 
-  it('uses glob pattern for npm cache-dependency-path', () => {
-    // Every cache-dependency-path should use the glob pattern, not just the root lockfile
-    const lines = ciYml.split('\n')
-    const cacheDependencyLines = lines.filter(l => l.includes('cache-dependency-path:'))
+  // ---- the rules ----------------------------------------------------------
 
-    assert.ok(cacheDependencyLines.length > 0, 'should have cache-dependency-path entries')
+  it('every declared cache-dependency-path is the lockfile glob', () => {
+    const offenders = steps
+      .map(({ where, step }) => ({ where, value: stepInput(step, 'cache-dependency-path') }))
+      .filter(({ value }) => value !== undefined && value !== LOCKFILE_GLOB)
+      .map(({ where, value }) => `${where} -> ${value}`)
 
-    for (const line of cacheDependencyLines) {
-      const parts = line.split('cache-dependency-path:')
-      if (parts.length < 2) continue
-
-      let value = parts[1].trim()
-      // Strip matching surrounding quotes if present
-      if (
-        (value.startsWith('"') && value.endsWith('"')) ||
-        (value.startsWith("'") && value.endsWith("'"))
-      ) {
-        value = value.slice(1, -1)
-      }
-
-      assert.equal(
-        value,
-        '**/package-lock.json',
-        `cache-dependency-path should use glob pattern '**/package-lock.json', found: ${line.trim()}`
-      )
-    }
+    assert.deepEqual(
+      offenders,
+      [],
+      `cache-dependency-path must be '${LOCKFILE_GLOB}'. The bare 'package-lock.json' hashes only ` +
+        'the ROOT lockfile, so a dependency change under packages/ leaves the key intact and the ' +
+        `job restores a stale cache (#7386):\n  ${offenders.join('\n  ')}`
+    )
   })
 
-  it('does not use bare root-only lockfile path', () => {
-    // Ensure no job uses just 'package-lock.json' without the glob
-    const matches = ciYml.match(/cache-dependency-path:\s+['"]?package-lock\.json['"]?(?:\s+#.*)?$/gm)
-    assert.equal(matches, null, 'should not have bare package-lock.json cache paths')
+  it('every setup-node step that caches at all declares a cache-dependency-path', () => {
+    // The omission half, and the one a value-only rule cannot see: leaving the
+    // input off entirely is not "no cache key", it is the DEFAULT key — the root
+    // lockfile alone, i.e. exactly the bug the rule above forbids spelling out.
+    // "Cannot see a value" must not read as "nothing to check".
+    //
+    // A step with no `cache:` at all (scripts-tests, release-pr-subject,
+    // dashboard-smoke, maestro) uses setup-node for the Node runtime alone and
+    // is correctly exempt — cache-dependency-path is inert without `cache:`.
+    // An empty `cache:` (the self-hosted branch of #7383's routing) is likewise
+    // exempt by the same falsiness.
+    const offenders = steps
+      .filter(({ step }) => {
+        const cache = stepInput(step, 'cache')
+        return !!cache && stepInput(step, 'cache-dependency-path') === undefined
+      })
+      .map(({ where }) => where)
+
+    assert.deepEqual(
+      offenders,
+      [],
+      "a setup-node step with a non-empty 'cache:' must declare " +
+        `'cache-dependency-path: ${LOCKFILE_GLOB}' — omitting it silently keys the cache on the ` +
+        `root lockfile alone:\n  ${offenders.join('\n  ')}`
+    )
   })
 })

--- a/packages/server/tests/ci-npm-cache-routing.test.js
+++ b/packages/server/tests/ci-npm-cache-routing.test.js
@@ -1,6 +1,17 @@
 import { before, describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { readFile, readdir } from 'node:fs/promises'
+import { readFile } from 'node:fs/promises'
+import {
+  parseJobs,
+  code,
+  stepInput,
+  readWorkflows,
+  assertReaderSane,
+  SETUP_NODE,
+  ROUTED_CACHE,
+  ROUTED_RUNNER_OUTPUTS,
+  LOCKFILE_GLOB,
+} from './helpers/workflow-reader.js'
 
 /**
  * #7383 — setup-node's npm cache must be routed, never hardcoded.
@@ -40,104 +51,13 @@ import { readFile, readdir } from 'node:fs/promises'
  * loudly, instead of letting every later assertion pass over an empty set.
  */
 
-const SETUP_NODE = 'actions/setup-node@'
-const ROUTED_CACHE = '${{ needs.runner-target.outputs.npmcache }}'
-
-/** Runner-target outputs that mean "this job's runner depends on the trust predicate". */
-const ROUTED_RUNNER_OUTPUTS = ['needs.runner-target.outputs.runner', 'needs.runner-target.outputs.winrunner']
-
 /**
- * Split ci.yml's `jobs:` mapping into per-job blocks.
- *
- * Job ids are the only keys at exactly two-space indent, and ci.yml has a single
- * top-level `jobs:` key, so this needs no general YAML support — but it must not
- * silently return nothing, which is what the positive control below checks.
+ * The reader (parseJobs / parseSteps / code / stepInput / readWorkflows) moved to
+ * `helpers/workflow-reader.js` in #7386, when `ci-cache-key.test.js` needed the
+ * same one. Transcribing it would have made two implementations of the thing
+ * both guards depend on being right — see that module's header. Its rationale
+ * comments moved with it; nothing here changed behaviourally.
  */
-function parseJobs(ciYml) {
-  const lines = ciYml.split('\n')
-  const jobsAt = lines.findIndex(l => l === 'jobs:')
-  assert.notEqual(jobsAt, -1, "ci.yml should have a top-level 'jobs:' key")
-
-  const starts = []
-  for (let i = jobsAt + 1; i < lines.length; i++) {
-    const m = /^ {2}([A-Za-z0-9_-]+):\s*$/.exec(lines[i])
-    if (m) starts.push({ id: m[1], line: i })
-  }
-
-  return starts.map((s, idx) => {
-    const end = idx + 1 < starts.length ? starts[idx + 1].line : lines.length
-    const body = lines.slice(s.line, end)
-    const runsOn = body.find(l => /^\s*runs-on:/.test(l)) ?? ''
-    return { id: s.id, line: s.line + 1, body, runsOn, steps: parseSteps(body) }
-  })
-}
-
-/**
- * Split a job body into step blocks.
- *
- * A step begins at a `- ` list item under `steps:`; the block runs until the next
- * list item at the same indent or the end of the job. Only step bodies are ever
- * asserted on, which is what keeps ci.yml's explanatory comments — several of
- * which quote `cache: npm` verbatim — out of the guard's reach.
- */
-function parseSteps(bodyLines) {
-  const stepsAt = bodyLines.findIndex(l => /^\s*steps:\s*$/.test(l))
-  if (stepsAt === -1) return []
-
-  const starts = []
-  let indent = null
-  for (let i = stepsAt + 1; i < bodyLines.length; i++) {
-    const m = /^(\s*)- /.exec(bodyLines[i])
-    if (!m) continue
-    if (indent === null) indent = m[1].length
-    if (m[1].length === indent) starts.push(i)
-  }
-
-  return starts.map((start, idx) => {
-    const end = idx + 1 < starts.length ? starts[idx + 1] : bodyLines.length
-    return bodyLines.slice(start, end)
-  })
-}
-
-/**
- * Drop comment lines.
- *
- * ci.yml is heavily commented and several of those comments quote the very
- * strings this file matches on — `cache: npm` in the rationale for removing it,
- * and `npm ci` twice in `server-tests-windows`'s explanation of its 20-minute
- * budget. A guard that reads prose as configuration is satisfiable by prose.
- */
-function code(lines) {
-  return lines.filter(l => !/^\s*#/.test(l))
-}
-
-/**
- * The value of a `with:` input inside a single step block, or undefined.
- *
- * Must strip a TRAILING comment, not just a whole-line one. `cache: npm # hosted-only`
- * parses as `npm` in YAML, and a naive read of the rest of the line sees
- * `npm # hosted-only` — which matches no rule and so slips past every assertion
- * here. Verified: adding exactly that line to a job left the suite 9/9 green
- * while the workflow really did hardcode the cache.
- */
-function stepInput(stepLines, key) {
-  for (const line of code(stepLines)) {
-    const m = new RegExp(`^\\s*${key}:\\s*(.*)$`).exec(line)
-    if (!m) continue
-    const raw = m[1].trim()
-
-    // A quoted scalar ends at its closing quote; anything after it is a comment.
-    if (raw.startsWith("'") || raw.startsWith('"')) {
-      const q = raw[0]
-      const close = raw.indexOf(q, 1)
-      return close === -1 ? raw.slice(1) : raw.slice(1, close)
-    }
-    // Otherwise a ` #` (whitespace-preceded, per YAML) starts a comment. `${{ }}`
-    // expressions contain no `#`, so this cannot truncate a routed value.
-    return raw.replace(/\s+#.*$/, '').trim()
-  }
-  return undefined
-}
 
 describe('CI npm cache routing (#7383)', () => {
   let ciYml
@@ -327,12 +247,12 @@ describe('CI npm cache routing (#7383)', () => {
     )
 
     const missing = cached
-      .filter(({ step }) => stepInput(step, 'cache-dependency-path') !== '**/package-lock.json')
+      .filter(({ step }) => stepInput(step, 'cache-dependency-path') !== LOCKFILE_GLOB)
       .map(({ job }) => `${job.id} (ci.yml:${job.line})`)
     assert.deepEqual(
       missing,
       [],
-      `steps using the routed cache must keep cache-dependency-path: '**/package-lock.json': ${missing.join(', ')}`
+      `steps using the routed cache must keep cache-dependency-path: '${LOCKFILE_GLOB}': ${missing.join(', ')}`
     )
   })
 })
@@ -359,24 +279,20 @@ describe('npm cache across all workflows (#7383)', () => {
   let workflows
 
   before(async () => {
-    const dir = new URL('../../../.github/workflows/', import.meta.url)
-    const names = (await readdir(dir)).filter(n => n.endsWith('.yml') || n.endsWith('.yaml'))
-    workflows = await Promise.all(
-      names.map(async name => ({ name, jobs: parseJobs(await readFile(new URL(name, dir), 'utf8')) }))
-    )
+    workflows = await readWorkflows()
   })
 
   it('reads every workflow file', () => {
     // Positive control. A readdir that returns nothing, or a reader that finds no
     // jobs, would make the assertion below vacuous — which is precisely how the
-    // maestro-nightly instance stayed invisible in the first place.
-    assert.ok(workflows.length >= 5, `expected >=5 workflow files, found ${workflows.length}`)
+    // maestro-nightly instance stayed invisible in the first place. The shared
+    // floor lives in the reader module so this guard and ci-cache-key.test.js
+    // cannot disagree about what "the reader still works" means.
+    assertReaderSane(workflows)
     assert.ok(
       workflows.some(w => w.name === 'maestro-nightly.yml'),
       'expected maestro-nightly.yml to be among the scanned workflows'
     )
-    const totalJobs = workflows.reduce((n, w) => n + w.jobs.length, 0)
-    assert.ok(totalJobs >= 20, `expected >=20 jobs across all workflows, found ${totalJobs}`)
   })
 
   it('no self-hosted job hardcodes an npm cache', () => {

--- a/packages/server/tests/ci-workflow-reader.test.js
+++ b/packages/server/tests/ci-workflow-reader.test.js
@@ -1,0 +1,147 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { parseJobs, parseSteps, stepInput, code } from './helpers/workflow-reader.js'
+
+/**
+ * Unit tests for the shared workflow reader (#7386).
+ *
+ * The reader is what `ci-cache-key.test.js` and `ci-npm-cache-routing.test.js`
+ * both quantify over, so anything it cannot SEE is something those guards
+ * silently do not check — the "cannot check this treated as nothing to check"
+ * cause in docs/false-safety-guards.md. Their positive controls catch a reader
+ * that finds NOTHING; they cannot catch a reader that finds most things.
+ *
+ * That gap was not hypothetical. Until this file existed, a job whose
+ * `runs-on:` used a YAML block sequence parsed to the literal `"runs-on:"`,
+ * so `/self-hosted/` never matched and every self-hosted rule skipped the job.
+ * A workflow pinned to `[self-hosted, macOS, ARM64]` in block form while
+ * hardcoding `cache: npm` — the #7383 defect verbatim — passed all 14 tests
+ * green. Reproduced, then fixed, then pinned here.
+ *
+ * These drive synthetic YAML rather than the repo's real workflows on purpose:
+ * a spelling the repo does not currently use is exactly the one no
+ * repo-scanning guard can prove it handles.
+ */
+
+const BLOCK_SEQUENCE = `
+name: probe
+on: workflow_dispatch
+jobs:
+  probe:
+    runs-on:
+      - self-hosted
+      - macOS
+      - ARM64
+    steps:
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+          cache: npm
+`
+
+const FLOW_SEQUENCE = `
+name: probe
+on: workflow_dispatch
+jobs:
+  probe:
+    runs-on: [self-hosted, macOS, ARM64]
+    steps:
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+          cache: npm
+`
+
+describe('workflow reader: runs-on spellings (#7386)', () => {
+  it('sees the labels of a FLOW-sequence runs-on', () => {
+    const [job] = parseJobs(FLOW_SEQUENCE, 'flow.yml')
+    assert.match(job.runsOn, /self-hosted/)
+    assert.match(job.runsOn, /ARM64/)
+  })
+
+  it('sees the labels of a BLOCK-sequence runs-on', () => {
+    // The regression this file exists for. Before the fix this was the string
+    // "    runs-on:" and every self-hosted rule skipped the job.
+    const [job] = parseJobs(BLOCK_SEQUENCE, 'block.yml')
+    assert.match(job.runsOn, /self-hosted/)
+    assert.match(job.runsOn, /ARM64/)
+  })
+
+  it('agrees between the two spellings of the same label set', () => {
+    // The property that matters, stated directly: two ways of writing identical
+    // config must not produce different verdicts. This is the assertion that
+    // fails if only ONE of the two branches above is ever fixed.
+    const block = parseJobs(BLOCK_SEQUENCE, 'block.yml')[0]
+    const flow = parseJobs(FLOW_SEQUENCE, 'flow.yml')[0]
+    const visible = runsOn => ['self-hosted', 'macOS', 'ARM64'].filter(l => runsOn.includes(l))
+    assert.deepEqual(visible(block.runsOn), visible(flow.runsOn))
+    assert.deepEqual(visible(block.runsOn), ['self-hosted', 'macOS', 'ARM64'])
+  })
+
+  it('stops at the next key rather than swallowing the rest of the job', () => {
+    const [job] = parseJobs(BLOCK_SEQUENCE, 'block.yml')
+    assert.doesNotMatch(job.runsOn, /setup-node/, 'runs-on must not absorb the steps block')
+    assert.doesNotMatch(job.runsOn, /cache/, 'runs-on must not absorb step inputs')
+  })
+
+  it('leaves a scalar runs-on and an expression runs-on intact', () => {
+    const scalar = parseJobs('jobs:\n  a:\n    runs-on: ubuntu-24.04\n    steps: []\n', 'a.yml')[0]
+    assert.match(scalar.runsOn, /ubuntu-24\.04/)
+    const routed = parseJobs(
+      'jobs:\n  a:\n    runs-on: ${{ fromJSON(needs.runner-target.outputs.runner) }}\n    steps: []\n',
+      'a.yml'
+    )[0]
+    assert.match(routed.runsOn, /needs\.runner-target\.outputs\.runner/)
+  })
+
+  it('returns an empty runs-on for a job that declares none', () => {
+    // Must be the EMPTY string, not the word "runs-on:" — the routing guard's
+    // `jobs.every(j => j.runsOn !== '')` sanity check depends on it.
+    const [job] = parseJobs('jobs:\n  a:\n    steps: []\n', 'a.yml')
+    assert.equal(job.runsOn, '')
+  })
+})
+
+describe('workflow reader: step + input parsing (#7386)', () => {
+  it('splits steps and reads with: inputs', () => {
+    const [job] = parseJobs(BLOCK_SEQUENCE, 'block.yml')
+    assert.equal(job.steps.length, 1)
+    assert.equal(stepInput(job.steps[0], 'cache'), 'npm')
+    assert.equal(stepInput(job.steps[0], 'node-version'), '22')
+    assert.equal(stepInput(job.steps[0], 'cache-dependency-path'), undefined)
+  })
+
+  it('strips a TRAILING comment from an input value', () => {
+    // `cache: npm # hosted only` parses as `npm` in YAML. Reading the rest of
+    // the line instead yields `npm # hosted only`, which matches no rule — the
+    // bypass verified during #7383.
+    const yml = `jobs:\n  a:\n    runs-on: ubuntu-24.04\n    steps:\n      - uses: actions/setup-node@x\n        with:\n          cache: npm # hosted only\n`
+    const [job] = parseJobs(yml, 'a.yml')
+    assert.equal(stepInput(job.steps[0], 'cache'), 'npm')
+  })
+
+  it('reads a quoted value up to its closing quote', () => {
+    const yml = `jobs:\n  a:\n    runs-on: ubuntu-24.04\n    steps:\n      - uses: actions/setup-node@x\n        with:\n          cache-dependency-path: '**/package-lock.json' # three lockfiles\n`
+    const [job] = parseJobs(yml, 'a.yml')
+    assert.equal(stepInput(job.steps[0], 'cache-dependency-path'), '**/package-lock.json')
+  })
+
+  it('does not read a commented-out input as configuration', () => {
+    // ci.yml's comments quote `cache: npm` verbatim in the rationale for having
+    // removed it. A guard that reads prose as config is satisfiable by prose.
+    const yml = `jobs:\n  a:\n    runs-on: ubuntu-24.04\n    steps:\n      - uses: actions/setup-node@x\n        with:\n          # cache: npm\n          node-version: 22\n`
+    const [job] = parseJobs(yml, 'a.yml')
+    assert.equal(stepInput(job.steps[0], 'cache'), undefined)
+    assert.equal(code(job.steps[0]).some(l => l.includes('cache: npm')), false)
+  })
+
+  it('returns no steps for a job with no steps: key', () => {
+    assert.deepEqual(parseSteps(['  a:', '    runs-on: ubuntu-24.04']), [])
+  })
+
+  it('fails loudly on a file with no jobs: key', () => {
+    // "Cannot parse this" must be an error in its own right, not a skip that
+    // reports zero jobs and lets every rule pass vacuously.
+    assert.throws(() => parseJobs('name: nope\non: push\n', 'nope.yml'), /top-level 'jobs:' key/)
+  })
+})

--- a/packages/server/tests/helpers/workflow-reader.js
+++ b/packages/server/tests/helpers/workflow-reader.js
@@ -1,6 +1,8 @@
 /**
  * A small indentation-aware reader for `.github/workflows/*.yml`, shared by the
- * CI guards in `tests/ci-*.test.js`.
+ * CI guards in `packages/server/tests/ci-*.test.js` — today `ci-cache-key`
+ * (#7386), `ci-npm-cache-routing` (#7383) and `ci-workflow-reader` (this
+ * module's own tests).
  *
  * WHY THIS IS A MODULE AND NOT A COPY IN EACH TEST
  * ------------------------------------------------

--- a/packages/server/tests/helpers/workflow-reader.js
+++ b/packages/server/tests/helpers/workflow-reader.js
@@ -71,9 +71,46 @@ export function parseJobs(yml, name = 'workflow') {
   return starts.map((s, idx) => {
     const end = idx + 1 < starts.length ? starts[idx + 1].line : lines.length
     const body = lines.slice(s.line, end)
-    const runsOn = body.find(l => /^\s*runs-on:/.test(l)) ?? ''
-    return { id: s.id, line: s.line + 1, body, runsOn, steps: parseSteps(body) }
+    return { id: s.id, line: s.line + 1, body, runsOn: runsOnOf(body), steps: parseSteps(body) }
   })
+}
+
+/**
+ * A job's whole `runs-on:` value as one string — the key line PLUS its block
+ * body when the labels are written as a YAML block sequence.
+ *
+ * This used to be `body.find(l => /^\s*runs-on:/.test(l))`, a single line, and
+ * that is a false-safety guard of the kind this repo catalogues. GitHub accepts
+ * two spellings of the same label set:
+ *
+ *     runs-on: [self-hosted, macOS, ARM64]        # flow — the whole value is on the line
+ *     runs-on:                                    # block — the line holds NOTHING
+ *       - self-hosted
+ *       - macOS
+ *
+ * Under the old reader the block form yielded the literal string `"runs-on:"`,
+ * so `/self-hosted/.test(job.runsOn)` was false and every self-hosted rule
+ * `continue`d past the job. Reproduced before this fix: a workflow pinned to
+ * `[self-hosted, macOS, ARM64]` in block form while hardcoding `cache: npm` —
+ * precisely the #7383 defect — passed all 14 tests green. Two spellings of
+ * identical config must not disagree, least of all in a module whose stated job
+ * is covering files that do not exist yet.
+ *
+ * Blank and comment lines are skipped rather than treated as the end of the
+ * block, so a commented label list does not truncate the value early.
+ */
+function runsOnOf(bodyLines) {
+  const at = bodyLines.findIndex(l => /^\s*runs-on:/.test(l))
+  if (at === -1) return ''
+  const keyIndent = /^(\s*)/.exec(bodyLines[at])[1].length
+  const parts = [bodyLines[at]]
+  for (let i = at + 1; i < bodyLines.length; i++) {
+    const line = bodyLines[i]
+    if (/^\s*$/.test(line) || /^\s*#/.test(line)) continue
+    if (/^(\s*)/.exec(line)[1].length <= keyIndent) break
+    parts.push(line)
+  }
+  return parts.join(' ')
 }
 
 /**

--- a/packages/server/tests/helpers/workflow-reader.js
+++ b/packages/server/tests/helpers/workflow-reader.js
@@ -1,0 +1,192 @@
+/**
+ * A small indentation-aware reader for `.github/workflows/*.yml`, shared by the
+ * CI guards in `tests/ci-*.test.js`.
+ *
+ * WHY THIS IS A MODULE AND NOT A COPY IN EACH TEST
+ * ------------------------------------------------
+ * It began as a private reader inside `ci-npm-cache-routing.test.js` (#7383).
+ * #7386 needed the same reader in `ci-cache-key.test.js`, and transcribing it
+ * would have produced a second implementation of the one thing both guards
+ * depend on being right — the defect class the root CLAUDE.md names outright:
+ * "the copy is always the convenient thing to write and always the thing that
+ * drifts". Both guards now fail together, or neither does.
+ *
+ * WHY IT IS NOT A YAML PARSER
+ * ---------------------------
+ * The guards must anchor every assertion to a STEP BODY, because ci.yml's own
+ * comments quote the exact strings they match on — `cache: npm` appears
+ * verbatim in the rationale for having removed it, and `npm ci` twice in
+ * `server-tests-windows`'s explanation of its timeout budget. A guard that
+ * reads prose as configuration is satisfiable by prose. A real parser would
+ * also work, but the structural facts these guards need (which job, which step,
+ * which `with:` input) are exactly what this reader exposes, with the comment
+ * handling made explicit rather than incidental.
+ *
+ * EVERY CONSUMER MUST CARRY A POSITIVE CONTROL. Assertions here quantify over
+ * what the reader found; if the reader breaks it finds nothing and every rule
+ * passes over an empty set, reporting a clean green. That is the
+ * "cannot check this treated as nothing to check" failure in
+ * docs/false-safety-guards.md. `assertReaderSane` below is the shared floor.
+ */
+import assert from 'node:assert/strict'
+import { readFile, readdir } from 'node:fs/promises'
+
+/** The pinned setup-node action, matched by prefix so the SHA can move. */
+export const SETUP_NODE = 'actions/setup-node@'
+
+/** The cache value every runner-target-routed job must use (#7383). */
+export const ROUTED_CACHE = '${{ needs.runner-target.outputs.npmcache }}'
+
+/** The only correct `cache-dependency-path` in a repo with three lockfiles. */
+export const LOCKFILE_GLOB = '**/package-lock.json'
+
+/** Runner-target outputs that mean "this job's runner depends on the trust predicate". */
+export const ROUTED_RUNNER_OUTPUTS = [
+  'needs.runner-target.outputs.runner',
+  'needs.runner-target.outputs.winrunner',
+]
+
+/**
+ * Split a workflow's `jobs:` mapping into per-job blocks.
+ *
+ * Job ids are the only keys at exactly two-space indent, and these workflows
+ * each have a single top-level `jobs:` key, so this needs no general YAML
+ * support — but it must not silently return nothing, which is what each
+ * consumer's positive control checks.
+ *
+ * @param {string} yml Raw workflow text.
+ * @param {string} [name] File name, used only in the assertion message.
+ */
+export function parseJobs(yml, name = 'workflow') {
+  const lines = yml.split('\n')
+  const jobsAt = lines.findIndex(l => l === 'jobs:')
+  assert.notEqual(jobsAt, -1, `${name} should have a top-level 'jobs:' key`)
+
+  const starts = []
+  for (let i = jobsAt + 1; i < lines.length; i++) {
+    const m = /^ {2}([A-Za-z0-9_-]+):\s*$/.exec(lines[i])
+    if (m) starts.push({ id: m[1], line: i })
+  }
+
+  return starts.map((s, idx) => {
+    const end = idx + 1 < starts.length ? starts[idx + 1].line : lines.length
+    const body = lines.slice(s.line, end)
+    const runsOn = body.find(l => /^\s*runs-on:/.test(l)) ?? ''
+    return { id: s.id, line: s.line + 1, body, runsOn, steps: parseSteps(body) }
+  })
+}
+
+/**
+ * Split a job body into step blocks.
+ *
+ * A step begins at a `- ` list item under `steps:`; the block runs until the
+ * next list item at the same indent or the end of the job. Only step bodies are
+ * ever asserted on, which is what keeps a workflow's explanatory comments out
+ * of a guard's reach.
+ */
+export function parseSteps(bodyLines) {
+  const stepsAt = bodyLines.findIndex(l => /^\s*steps:\s*$/.test(l))
+  if (stepsAt === -1) return []
+
+  const starts = []
+  let indent = null
+  for (let i = stepsAt + 1; i < bodyLines.length; i++) {
+    const m = /^(\s*)- /.exec(bodyLines[i])
+    if (!m) continue
+    if (indent === null) indent = m[1].length
+    if (m[1].length === indent) starts.push(i)
+  }
+
+  return starts.map((start, idx) => {
+    const end = idx + 1 < starts.length ? starts[idx + 1] : bodyLines.length
+    return bodyLines.slice(start, end)
+  })
+}
+
+/**
+ * Drop comment lines.
+ *
+ * ci.yml is heavily commented and several of those comments quote the very
+ * strings the guards match on. A guard that reads prose as configuration is
+ * satisfiable by prose.
+ */
+export function code(lines) {
+  return lines.filter(l => !/^\s*#/.test(l))
+}
+
+/**
+ * The value of a `with:` input inside a single step block, or undefined.
+ *
+ * Must strip a TRAILING comment, not just a whole-line one. `cache: npm # hosted-only`
+ * parses as `npm` in YAML, and a naive read of the rest of the line sees
+ * `npm # hosted-only` — which matches no rule and so slips past every assertion.
+ * Verified during #7383: adding exactly that line to a job left the suite 9/9
+ * green while the workflow really did hardcode the cache.
+ */
+export function stepInput(stepLines, key) {
+  for (const line of code(stepLines)) {
+    const m = new RegExp(`^\\s*${key}:\\s*(.*)$`).exec(line)
+    if (!m) continue
+    const raw = m[1].trim()
+
+    // A quoted scalar ends at its closing quote; anything after it is a comment.
+    if (raw.startsWith("'") || raw.startsWith('"')) {
+      const q = raw[0]
+      const close = raw.indexOf(q, 1)
+      return close === -1 ? raw.slice(1) : raw.slice(1, close)
+    }
+    // Otherwise a ` #` (whitespace-preceded, per YAML) starts a comment. `${{ }}`
+    // expressions contain no `#`, so this cannot truncate a routed value.
+    return raw.replace(/\s+#.*$/, '').trim()
+  }
+  return undefined
+}
+
+/**
+ * Every workflow file, parsed. Discovered by `readdir` rather than from a list
+ * held in a test — a hardcoded roster beside a growing set is the first cause
+ * in docs/false-safety-guards.md, and it is how the `maestro-nightly.yml`
+ * instance of #7383 stayed invisible through the fix for #7383.
+ *
+ * @param {URL} [dir] Override for the workflows directory (tests only).
+ * @returns {Promise<Array<{name: string, text: string, jobs: object[]}>>}
+ */
+export async function readWorkflows(dir = new URL('../../../../.github/workflows/', import.meta.url)) {
+  const names = (await readdir(dir)).filter(n => n.endsWith('.yml') || n.endsWith('.yaml'))
+  return Promise.all(
+    names.map(async name => {
+      const text = await readFile(new URL(name, dir), 'utf8')
+      return { name, text, jobs: parseJobs(text, name) }
+    })
+  )
+}
+
+/**
+ * The shared positive control every consumer must run BEFORE its rules.
+ *
+ * Thresholds are LOOSE on purpose. Their job is to catch a reader that has
+ * stopped understanding these files (which yields zero), not to pin today's job
+ * count — sitting them on exact numbers would turn "a job was merged away" into
+ * a failure that blames the reader for someone else's refactor.
+ */
+export function assertReaderSane(workflows) {
+  assert.ok(workflows.length >= 5, `expected >=5 workflow files, found ${workflows.length}`)
+  assert.ok(
+    workflows.some(w => w.name === 'ci.yml'),
+    'expected ci.yml among the scanned workflows'
+  )
+  assert.ok(
+    workflows.some(w => w.name === 'release.yml'),
+    'expected release.yml among the scanned workflows'
+  )
+  const totalJobs = workflows.reduce((n, w) => n + w.jobs.length, 0)
+  assert.ok(totalJobs >= 20, `expected >=20 jobs across all workflows, found ${totalJobs}`)
+  const setupNodeSteps = workflows.flatMap(w =>
+    w.jobs.flatMap(j => j.steps.filter(s => s.some(l => l.includes(SETUP_NODE))))
+  )
+  assert.ok(
+    setupNodeSteps.length >= 15,
+    `expected >=15 setup-node steps across all workflows, found ${setupNodeSteps.length} — ` +
+      'the reader is probably broken'
+  )
+}


### PR DESCRIPTION
Part of #7386 — the **guard half** (item 3 of its acceptance list). The two judgement calls in that issue are deliberately left open; see "Still open" below.

## The gap

`ci-cache-key.test.js` read `ci.yml` and nothing else, which made it blind to the exact defect it exists to catch. This repo has **three** `package-lock.json` files and `actions/setup-node`'s default `cache-dependency-path` is the **root one alone** — so a bare key means a dependency change under `packages/` does not bust the cache.

Two instances lived one file over the whole time it was green:

| file | instance | found by |
|---|---|---|
| `maestro-nightly.yml` | `cache-dependency-path: package-lock.json` | #7383's fix, not this guard |
| `release.yml` | the same, **four times** | #7386's filing, not this guard |

`release.yml` is the worst place in the repo for it: a release build cut from a stale cache.

That is the first recurring cause in `docs/false-safety-guards.md` — "a hardcoded list next to a set that grows" — and a file-scoped guard is a hardcoded list of one.

## What changed

**Scoped to the defect, not the file.** The guard scans every workflow file, discovered by `readdir`, so an instance in a workflow that does not exist yet is still caught.

**Two rules, not one.** The value rule (every declared `cache-dependency-path` is `**/package-lock.json`) cannot see an *omission* — and omitting the input is not "no cache key", it is the default key, i.e. exactly the bug the value rule forbids spelling out. "Cannot see a value" must not read as "nothing to check". Steps with no `cache:` at all (`scripts-tests`, `release-pr-subject`, `dashboard-smoke`, `maestro`) use setup-node for the Node runtime alone and stay correctly exempt, as does the empty `cache:` on #7383's self-hosted branch.

**Fixes `release.yml`'s four bare keys.**

**The reader is shared, not transcribed.** `parseJobs` / `parseSteps` / `code` / `stepInput` were private to `ci-npm-cache-routing.test.js`; they now live in `tests/helpers/workflow-reader.js` and both guards import them. A second copy of the thing both guards depend on being right is the drift the root `CLAUDE.md` names outright. The positive control moved with it as `assertReaderSane`, so the two cannot disagree about what "the reader still works" means. `ci-npm-cache-routing.test.js` is otherwise unchanged behaviourally — 9/9 still green.

## Mutation-verified, each against its intended subtest

| mutation | subtest that went RED |
|---|---|
| bare `package-lock.json` in `release.yml` | `every declared cache-dependency-path is the lockfile glob` |
| bare path hidden behind a trailing `# comment` | same — the #7385 YAML-comment bypass stays closed |
| `cache: npm` with the path input **deleted** | `every setup-node step that caches at all declares a cache-dependency-path` |
| reader blinded (`readdir` yields nothing) | `reads every workflow and finds the setup-node steps` |

Restored from `cp` backups (not `git checkout --`); 14/14 green before and after.

## Evidence gathered for the rest of #7386

Reported on the issue rather than acted on here:

- **The Windows cache has never existed.** `gh api repos/blamechris/chroxy/actions/caches` returns **zero** `node-cache-Windows-*` entries of any age. `release.yml`'s `desktop-windows` `cache: npm` has always been a no-op.
- **Nothing has produced a Linux-x64 `refs/heads/main` entry since 2026-08-23T20:14Z** — before #7385 merged (2026-08-26T01:57Z). The recent `last_accessed_at` timestamps are restores, not saves. #7386's premise holds.

## Still open in #7386 (needs a decision, not code)

1. Whether the hosted Linux cache gets a deliberate producer, or fork-PR cold installs are accepted.
2. Whether the Windows `cache: npm` input is made to produce a real entry or dropped.

## Gates

- `tests/ci-cache-key.test.js` + `tests/ci-npm-cache-routing.test.js` — 14/14 pass
- All 9 `packages/server/scripts/lint-*.sh` (the Server Lint job) — pass