### PR TITLE
fix(ci): make dashboard-smoke the hosted npm cache producer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1321,12 +1321,18 @@ jobs:
       # dedicated warm job" option looked expensive — it isn't, because the job
       # exists.
       #
-      # Do not remove `cache:` here, un-pin it from a hosted runner, or gate it
-      # behind an `if:`/`needs:` without reading
-      # docs/decisions/2026-08-npm-cache-producer.md — each silently reverts fork
-      # PRs to cold-installing across ~12 jobs. Pinned by
-      # packages/server/tests/ci-npm-cache-routing.test.js, which also carries the
-      # one named exception this `cache: npm` needs.
+      # packages/server/tests/ci-npm-cache-routing.test.js pins, specifically:
+      # a producer exists that is GitHub-hosted AND x86_64 (an `ubuntu-*-arm`
+      # runner saves the arm64 entry, which no hosted fork job reads), carries
+      # `cache: npm` with the three-lockfile key, has no job-level `if:`, and sits
+      # in a workflow whose `push:` names `main` with no `paths:` filter. It also
+      # carries the one named exception this `cache: npm` needs.
+      #
+      # NOT pinned, and worth thinking about anyway: adding a `needs:` edge here
+      # would make the producer conditional on that dependency succeeding, so a
+      # flaky upstream job would quietly stop the cache being saved. Read
+      # docs/decisions/2026-08-npm-cache-producer.md before changing any of this —
+      # each of these silently reverts fork PRs to cold-installing across ~12 jobs.
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,23 @@ jobs:
         # on every job because it is what the hosted branch keys on; it is inert
         # when `cache` is empty. packages/server/tests/ci-npm-cache-routing.test.js
         # holds this whole arrangement in place.
+        #
+        # #7386 — THE HOSTED ENTRY HAS NO DEDICATED PRODUCER, and that is a
+        # decision, not an oversight. setup-node keys on RUNNER_OS/RUNNER_ARCH,
+        # not on pool, so the entry fork PRs restore used to be saved by the
+        # self-hosted `push` jobs above; emptying `npmcache` for them stopped
+        # that. A fork PR cannot help the next one either (GitHub scopes a PR's
+        # cache WRITES to its own ref). What does close it is
+        # nightly-k8s-integration.yml: ubuntu-24.04, on refs/heads/main, 06:00
+        # UTC, `cache: npm` — it saves on a key miss. So the exposure is bounded
+        # at "a lockfile change, then up to ~24h", not "every fork PR forever".
+        #
+        # THAT NIGHTLY IS LOAD-BEARING FOR THIS. Disabling it, or moving it off a
+        # hosted runner, removes the only producer — silently.
+        #
+        # Adopt the deliberate warm job when fork PRs stop being rare, or a
+        # contributor reports slow CI. The trigger conditions and the exact job
+        # to add are in docs/decisions/2026-08-npm-cache-producer.md.
         run: |
           if [ "${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}" = "true" ]; then
             echo 'runner=["self-hosted", "Linux", "chroxy-linux"]' >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,25 +115,24 @@ jobs:
         # when `cache` is empty. packages/server/tests/ci-npm-cache-routing.test.js
         # holds this whole arrangement in place.
         #
-        # #7386 — THE HOSTED ENTRY HAS NO DEDICATED PRODUCER, and that is a
-        # decision, not an oversight. setup-node keys on RUNNER_OS/RUNNER_ARCH,
-        # not on pool, so the `Linux-x64` entry fork PRs restore used to be saved
-        # by whichever self-hosted `push` jobs happened to land on the ONE x86_64
-        # pool member (the Hyper-V VM — see the mixed-arch note above; the ARM64
-        # members produced `Linux-arm64`, which no hosted fork job reads).
-        # Sporadic, not systematic. Emptying `npmcache` stopped even that.
-        # A fork PR cannot help the next one either (GitHub scopes a PR's cache
-        # WRITES to its own ref). What does close it is
-        # nightly-k8s-integration.yml: ubuntu-24.04, on refs/heads/main, 06:00
-        # UTC, `cache: npm` — it saves on a key miss. So the exposure is bounded
-        # at "a lockfile change, then up to ~24h", not "every fork PR forever".
+        # #7386 — WHO SAVES THE ENTRY THE HOSTED BRANCH RESTORES? setup-node keys
+        # on RUNNER_OS/RUNNER_ARCH, not on pool. The `Linux-x64` entry fork PRs
+        # restore used to be saved by whichever self-hosted `push` jobs happened
+        # to land on the ONE x86_64 pool member (the Hyper-V VM — see the
+        # mixed-arch note above; the ARM64 members produced `Linux-arm64`, which
+        # no hosted fork job reads). Sporadic, not systematic — and emptying
+        # `npmcache` stopped even that. A fork PR cannot help the next one either:
+        # GitHub scopes a PR's cache WRITES to its own ref.
         #
-        # THAT NIGHTLY IS LOAD-BEARING FOR THIS. Disabling it, or moving it off a
-        # hosted runner, removes the only producer — silently.
+        # The producer is now `dashboard-smoke` below — hosted, x86_64,
+        # unconditional, on push-to-main, and already running `npm ci` with no
+        # cache at all. Caching it makes that job faster and produces the entry as
+        # a side effect. `nightly-k8s-integration.yml` is the scheduled fallback.
         #
-        # Adopt the deliberate warm job when fork PRs stop being rare, or a
-        # contributor reports slow CI. The trigger conditions and the exact job
-        # to add are in docs/decisions/2026-08-npm-cache-producer.md.
+        # BOTH ARE LOAD-BEARING, and prose alone did not protect them:
+        # ci-npm-cache-routing.test.js asserts a push-to-main producer AND a
+        # scheduled one exist, scoped to the property rather than to filenames.
+        # See docs/decisions/2026-08-npm-cache-producer.md.
         run: |
           if [ "${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}" = "true" ]; then
             echo 'runner=["self-hosted", "Linux", "chroxy-linux"]' >> "$GITHUB_OUTPUT"
@@ -1304,9 +1303,35 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
+      # #7386 — THIS JOB IS THE HOSTED CACHE'S PRODUCER, deliberately.
+      #
+      # setup-node keys on RUNNER_OS/RUNNER_ARCH, not on pool, so the
+      # `node-cache-Linux-x64-npm-*` entry a FORK PR restores on ubuntu-24.04 has
+      # to be saved by some job that (a) runs on a GitHub-hosted x86_64 runner
+      # and (b) runs on `main`, since a PR's cache writes are scoped to its own
+      # ref and can never help the next PR. #7385 emptied `npmcache` on the
+      # self-hosted pool — right for those runners, but it left nothing on `main`
+      # saving the entry.
+      #
+      # This job already satisfied both conditions: hosted, x86_64 (pinned for
+      # Playwright), unconditional, on `push: branches: [main]`, running a root
+      # `npm ci`. It just had no `cache:`, so it cold-installed the monorepo every
+      # run AND saved nothing. Adding the cache costs nothing and MAKES THE JOB
+      # FASTER; the producer is a free side effect. It was the reason the "add a
+      # dedicated warm job" option looked expensive — it isn't, because the job
+      # exists.
+      #
+      # Do not remove `cache:` here, un-pin it from a hosted runner, or gate it
+      # behind an `if:`/`needs:` without reading
+      # docs/decisions/2026-08-npm-cache-producer.md — each silently reverts fork
+      # PRs to cold-installing across ~12 jobs. Pinned by
+      # packages/server/tests/ci-npm-cache-routing.test.js, which also carries the
+      # one named exception this `cache: npm` needs.
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
+          cache: npm
+          cache-dependency-path: '**/package-lock.json'
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,10 +117,13 @@ jobs:
         #
         # #7386 — THE HOSTED ENTRY HAS NO DEDICATED PRODUCER, and that is a
         # decision, not an oversight. setup-node keys on RUNNER_OS/RUNNER_ARCH,
-        # not on pool, so the entry fork PRs restore used to be saved by the
-        # self-hosted `push` jobs above; emptying `npmcache` for them stopped
-        # that. A fork PR cannot help the next one either (GitHub scopes a PR's
-        # cache WRITES to its own ref). What does close it is
+        # not on pool, so the `Linux-x64` entry fork PRs restore used to be saved
+        # by whichever self-hosted `push` jobs happened to land on the ONE x86_64
+        # pool member (the Hyper-V VM — see the mixed-arch note above; the ARM64
+        # members produced `Linux-arm64`, which no hosted fork job reads).
+        # Sporadic, not systematic. Emptying `npmcache` stopped even that.
+        # A fork PR cannot help the next one either (GitHub scopes a PR's cache
+        # WRITES to its own ref). What does close it is
         # nightly-k8s-integration.yml: ubuntu-24.04, on refs/heads/main, 06:00
         # UTC, `cache: npm` — it saves on a key miss. So the exposure is bounded
         # at "a lockfile change, then up to ~24h", not "every fork PR forever".

--- a/.github/workflows/nightly-k8s-integration.yml
+++ b/.github/workflows/nightly-k8s-integration.yml
@@ -30,13 +30,13 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
-          # #7386: this is not only a convenience for this job — it is the ONLY
-          # remaining producer of the hosted `node-cache-Linux-x64-npm-*` entry
-          # that fork PRs on ubuntu-24.04 restore. #7385 emptied `npmcache` on
-          # the self-hosted pool, which is right for those runners and removed
-          # every `push`-to-main saver. Keep this job hosted, keep it scheduled,
-          # and keep the cache on; dropping any of the three silently makes
-          # every fork PR cold-install the monorepo.
+          # #7386: this is not only a convenience for this job — it is the
+          # SCHEDULED FALLBACK producer of the hosted `node-cache-Linux-x64-npm-*`
+          # entry that fork PRs on ubuntu-24.04 restore. ci.yml's `dashboard-smoke`
+          # is the primary (every push to main); this one re-saves after the 7-day
+          # eviction on a quiet week and covers a run where the primary is skipped.
+          # Keep this job hosted, scheduled, and cached — ci-npm-cache-routing.test.js
+          # asserts a scheduled producer exists and will fail if this stops being one.
           # See docs/decisions/2026-08-npm-cache-producer.md.
           cache: npm
           cache-dependency-path: '**/package-lock.json'

--- a/.github/workflows/nightly-k8s-integration.yml
+++ b/.github/workflows/nightly-k8s-integration.yml
@@ -30,6 +30,14 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
+          # #7386: this is not only a convenience for this job — it is the ONLY
+          # remaining producer of the hosted `node-cache-Linux-x64-npm-*` entry
+          # that fork PRs on ubuntu-24.04 restore. #7385 emptied `npmcache` on
+          # the self-hosted pool, which is right for those runners and removed
+          # every `push`-to-main saver. Keep this job hosted, keep it scheduled,
+          # and keep the cache on; dropping any of the three silently makes
+          # every fork PR cold-install the monorepo.
+          # See docs/decisions/2026-08-npm-cache-producer.md.
           cache: npm
           cache-dependency-path: '**/package-lock.json'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -316,6 +316,21 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
+      # #7386 asked whether this `cache: npm` should be dropped: there are ZERO
+      # `node-cache-Windows-*` entries in the repo's cache list, of any age, so it
+      # has never hit. KEPT, because "never hits" is not the same as "dead":
+      #
+      #   - CI's server-tests-windows routes through `winrunner` to the
+      #     self-hosted chroxy-win, where #7383 sets npmcache empty — so CI never
+      #     produces a Windows entry;
+      #   - a fork PR on windows-latest writes to its own isolated ref scope;
+      #   - this workflow runs on TAG refs, whose caches a PR branch cannot read.
+      #
+      # Which is why no PR has ever seen one. But a release RE-DISPATCHED on an
+      # existing tag (`gh workflow run release.yml --ref vX.Y.Z`, a real workflow
+      # here) reads that same tag scope and hits what the first run saved. This
+      # earns its keep on the second run, not the first — don't re-file it as a
+      # no-op. See docs/decisions/2026-08-npm-cache-producer.md.
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -316,9 +316,18 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      # #7386 asked whether this `cache: npm` should be dropped: there are ZERO
-      # `node-cache-Windows-*` entries in the repo's cache list, of any age, so it
-      # has never hit. KEPT, because "never hits" is not the same as "dead":
+      # #7386 asked whether this `cache: npm` should be dropped: `gh api
+      # .../actions/caches` lists ZERO `node-cache-Windows-*` entries. KEPT — and
+      # the emptiness is explained rather than contradicted by what follows.
+      #
+      # Why the list is empty is NOT "it never saves". A tag-push run does save,
+      # into that tag's scope; actions/cache then evicts an entry after 7 days
+      # without access, and releases here are months apart (v0.11.0 on
+      # 2026-08-15, v0.9.46 before it on 2026-06-21). Any entry the last release
+      # wrote aged out long before the list was taken. "Zero right now" and "the
+      # first run saved one" are both true.
+      #
+      # Why it is not dead config:
       #
       #   - CI's server-tests-windows routes through `winrunner` to the
       #     self-hosted chroxy-win, where #7383 sets npmcache empty — so CI never
@@ -328,8 +337,10 @@ jobs:
       #
       # Which is why no PR has ever seen one. But a release RE-DISPATCHED on an
       # existing tag (`gh workflow run release.yml --ref vX.Y.Z`, a real workflow
-      # here) reads that same tag scope and hits what the first run saved. This
-      # earns its keep on the second run, not the first — don't re-file it as a
+      # here) reads that same tag scope and hits what the first run saved —
+      # PROVIDED the re-dispatch is within the 7-day eviction window, which is
+      # the realistic case, since you re-dispatch to fix a failed release rather
+      # than months later. So: narrow value, not zero. Don't re-file it as a
       # no-op. See docs/decisions/2026-08-npm-cache-producer.md.
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,6 +90,21 @@ SHAs, the default workflow token is read-only (jobs elevate their own permission
 per-workflow as needed), and workflows on pull requests from first-time
 contributors require maintainer approval before they run.
 
+### If your PR's CI looks slow
+
+PRs from a fork run on GitHub-hosted runners, which start with an empty `~/.npm`
+and rely on a restored npm cache. That cache is produced by a nightly job on
+`main`, so if a dependency change landed on `main` within roughly the last day,
+the entry your PR wants may not exist yet and each job will install the monorepo
+from scratch — a couple of extra minutes per job. **It does not fail, and it is
+not something you did.** It resolves itself after the next nightly.
+
+If you hit this more than once, please say so in your PR: it is the signal that a
+dedicated cache-warming job is now worth adding, and the maintainer is watching
+for exactly that. The reasoning, the measurements behind it, and the job to add
+are written down in
+[`docs/decisions/2026-08-npm-cache-producer.md`](docs/decisions/2026-08-npm-cache-producer.md).
+
 ## Code Style
 
 - **TypeScript** for the app, **JavaScript (ES modules)** for the server

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,9 +97,9 @@ and rely on a restored npm cache. Each job may instead install the monorepo from
 scratch — a couple of extra minutes per job. **It does not fail, and it is not
 something you did.** Two different cases:
 
-- **Your PR does not touch a `package-lock.json`.** This should be rare: the cache
-  is refreshed by a job on every push to `main`. If you see a cold install anyway,
-  it is worth reporting — it means a cache producer has gone missing.
+- **Your PR does not touch a `package-lock.json`.** A cold install here should be
+  rare — the cache is refreshed by a job on every push to `main`. If you see one
+  anyway, it is worth reporting: it means a cache producer has gone missing.
 - **Your PR changes a `package-lock.json`** — a dependency bump, or anything that
   regenerates a lockfile. The cache key is a hash of the lockfiles, so *your* key
   exists in no scope anything can read, and no job on `main` will ever create it

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,21 +97,20 @@ and rely on a restored npm cache. Each job may instead install the monorepo from
 scratch — a couple of extra minutes per job. **It does not fail, and it is not
 something you did.** Two different cases:
 
-- **Your PR does not touch a `package-lock.json`.** The cache is produced by a
-  nightly job on `main`, so if a dependency change landed on `main` within roughly
-  the last day, the entry may not exist yet. This one does resolve itself after
-  the next nightly.
+- **Your PR does not touch a `package-lock.json`.** This should be rare: the cache
+  is refreshed by a job on every push to `main`. If you see a cold install anyway,
+  it is worth reporting — it means a cache producer has gone missing.
 - **Your PR changes a `package-lock.json`** — a dependency bump, or anything that
   regenerates a lockfile. The cache key is a hash of the lockfiles, so *your* key
-  exists in no scope anything can read, and no nightly will ever create it (the
-  nightly builds `main`'s key, not yours). There are no `restore-keys` configured,
+  exists in no scope anything can read, and no job on `main` will ever create it
+  (those build `main`'s key, not yours). There are no `restore-keys` configured,
   so there is no partial fallback either. **Every push to this PR cold-installs,
-  for the life of the PR.** That is expected and is not worth working around.
+  for the life of the PR.** That is expected, is not worth working around, and no
+  amount of cache-warming on our side would change it.
 
-If you hit either case in a way that actually slows you down, please say so in
-your PR — it is the signal that a dedicated cache-warming job is worth adding, and
-the maintainer is watching for exactly that. The reasoning, the measurements
-behind it, and the job to add are written down in
+If you hit the first case, please say so in your PR — it means something on our
+side broke, and it is worth knowing. The reasoning, the measurements behind it,
+and the guards that are supposed to prevent it are written down in
 [`docs/decisions/2026-08-npm-cache-producer.md`](docs/decisions/2026-08-npm-cache-producer.md).
 
 ## Code Style

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,16 +93,25 @@ contributors require maintainer approval before they run.
 ### If your PR's CI looks slow
 
 PRs from a fork run on GitHub-hosted runners, which start with an empty `~/.npm`
-and rely on a restored npm cache. That cache is produced by a nightly job on
-`main`, so if a dependency change landed on `main` within roughly the last day,
-the entry your PR wants may not exist yet and each job will install the monorepo
-from scratch — a couple of extra minutes per job. **It does not fail, and it is
-not something you did.** It resolves itself after the next nightly.
+and rely on a restored npm cache. Each job may instead install the monorepo from
+scratch — a couple of extra minutes per job. **It does not fail, and it is not
+something you did.** Two different cases:
 
-If you hit this more than once, please say so in your PR: it is the signal that a
-dedicated cache-warming job is now worth adding, and the maintainer is watching
-for exactly that. The reasoning, the measurements behind it, and the job to add
-are written down in
+- **Your PR does not touch a `package-lock.json`.** The cache is produced by a
+  nightly job on `main`, so if a dependency change landed on `main` within roughly
+  the last day, the entry may not exist yet. This one does resolve itself after
+  the next nightly.
+- **Your PR changes a `package-lock.json`** — a dependency bump, or anything that
+  regenerates a lockfile. The cache key is a hash of the lockfiles, so *your* key
+  exists in no scope anything can read, and no nightly will ever create it (the
+  nightly builds `main`'s key, not yours). There are no `restore-keys` configured,
+  so there is no partial fallback either. **Every push to this PR cold-installs,
+  for the life of the PR.** That is expected and is not worth working around.
+
+If you hit either case in a way that actually slows you down, please say so in
+your PR — it is the signal that a dedicated cache-warming job is worth adding, and
+the maintainer is watching for exactly that. The reasoning, the measurements
+behind it, and the job to add are written down in
 [`docs/decisions/2026-08-npm-cache-producer.md`](docs/decisions/2026-08-npm-cache-producer.md).
 
 ## Code Style

--- a/docs/decisions/2026-08-npm-cache-producer.md
+++ b/docs/decisions/2026-08-npm-cache-producer.md
@@ -50,6 +50,15 @@ Put together, the exposure is not "every fork PR cold-installs". It is:
 > the new key and saves it. Fork PRs opened inside that window cold-install
 > across ~12 hosted jobs; fork PRs outside it hit the cache.
 
+**One case the window does not describe, and it is the likelier one.** A fork PR
+that *itself changes a lockfile* has a key that exists in no readable scope and
+that no nightly will ever create — the nightly builds `main`'s key, not the PR's.
+There are no `restore-keys`, so there is no partial fallback. Such a PR
+cold-installs on **every push, for its whole life**, and a warm job on `main`
+would not help it either. A dependency-bump PR from a contributor is exactly the
+shape that hits this, so do not read "up to ~24 h" as the worst case — it is the
+worst case only for PRs that leave the lockfiles alone.
+
 A cold `npm ci` of the monorepo costs a couple of minutes per job and **does not
 fail**. Fork PRs are currently rare (this is a solo-maintained project). Paying a
 hosted job on every push to `main` to shorten a rare window for a rare event is

--- a/docs/decisions/2026-08-npm-cache-producer.md
+++ b/docs/decisions/2026-08-npm-cache-producer.md
@@ -1,10 +1,11 @@
-# The hosted npm cache has no dedicated producer, deliberately
+# The hosted npm cache is produced by `dashboard-smoke`
 
 **Date**: 2026-08-26
 **Issue**: #7386 (follow-on from #7383 / #7385)
-**Status**: decided — accept, with a named escalation trigger (below)
-**Touches**: `.github/workflows/ci.yml` (`runner-target.outputs.npmcache`),
+**Status**: decided — adopt, at no cost
+**Touches**: `.github/workflows/ci.yml` (`dashboard-smoke`, `runner-target.outputs.npmcache`),
 `.github/workflows/nightly-k8s-integration.yml`, `.github/workflows/release.yml`
+**Pinned by**: `packages/server/tests/ci-npm-cache-routing.test.js`
 
 ## The question
 
@@ -17,118 +18,110 @@ burned its whole timeout, and the cancellation rendered as `fail`.
 The fix routed the cache on the same predicate as the runner: empty on the
 self-hosted pool, `npm` on GitHub-hosted runners (fork PRs). Correct — but
 `actions/setup-node` keys its cache on `RUNNER_OS`/`RUNNER_ARCH`, **not** on which
-pool the runner belongs to. The `node-cache-Linux-x64-npm-…` entry that fork PRs
-restore on `ubuntu-24.04` had been *produced* by the self-hosted `push`-to-`main`
-jobs. After #7385, no `push` job saves it.
+pool the runner belongs to. So who saves the `node-cache-Linux-x64-npm-*` entry
+that fork PRs restore?
 
-So: does the hosted cache need a job whose only purpose is to warm it?
+Only a job that is **GitHub-hosted** *and* runs on **`main`**. A fork PR cannot
+help the next one: GitHub scopes a PR's cache *writes* to that PR's own ref, so a
+fork that cold-installs and saves populates a scope nothing else can read. There
+is no self-healing here.
 
-## Decision: no. Accept it.
+## Decision: cache `dashboard-smoke`. It was already the job we would have added.
 
-## Why — the exposure is bounded, and something already closes it
+The first draft of this record accepted the gap, on the reasoning that closing it
+meant paying for a hosted job on every push to `main`. **That premise was wrong,
+and it is the whole reason this is a short document.** `ci.yml`'s
+`dashboard-smoke` already:
 
-Three facts, all measured rather than assumed (2026-08-26):
+- runs on `ubuntu-24.04` — GitHub-hosted, x86_64, deliberately pinned there for
+  Playwright and explicitly *not* routed through `runner-target`;
+- has no `if:` and no `needs:`, and `ci.yml` triggers on `push: branches: [main]`;
+- runs a root `npm ci`.
 
-1. **Nothing on `main` has produced a Linux-x64 entry since #7385.** The newest
-   `refs/heads/main` entry was *created* `2026-08-23T20:14Z`, before #7385 merged
-   (`2026-08-26T01:57Z`). Later timestamps on it are `last_accessed_at`, which
-   updates on a **restore**, not a save. The issue's premise is correct.
+It simply declared no `cache:`, so it **cold-installed the whole monorepo on every
+run and saved nothing**. Adding `cache: npm` with the three-lockfile key makes it
+the producer *and makes the job faster*. The cost is negative.
 
-2. **A fork PR can never help the next fork PR.** GitHub scopes a PR's cache
-   *writes* to that PR's own ref. A fork that cold-installs and saves populates a
-   scope nothing else can read. There is no self-healing here.
+`nightly-k8s-integration.yml` (hosted, `refs/heads/main`, 06:00 UTC) remains a
+second producer. It is the fallback: it re-saves after the 7-day eviction on a
+quiet week, and covers a run where the push producer is skipped.
 
-3. **But `nightly-k8s-integration.yml` is a producer.** It runs on `ubuntu-24.04`
-   — GitHub-hosted — on `refs/heads/main`, at 06:00 UTC, with `cache: npm` and the
-   correct `**/package-lock.json` key. On a key miss it *saves*. The issue named it
-   as "the only remaining producer" and treated that as the problem; it is also
-   the mitigation.
+## What this does NOT fix, and nothing can
 
-Put together, the exposure is not "every fork PR cold-installs". It is:
+A fork PR that **itself changes a `package-lock.json`** has a cache key that
+exists in no readable scope, and no producer will ever create it — a producer on
+`main` builds `main`'s key, not the PR's. No `restore-keys` are configured, so
+there is no partial fallback either. **Such a PR cold-installs on every push, for
+its whole life.** A dependency-bump PR from a contributor is exactly that shape.
 
-> a lockfile change lands on `main` → **up to ~24 h** → the 06:00 nightly misses
-> the new key and saves it. Fork PRs opened inside that window cold-install
-> across ~12 hosted jobs; fork PRs outside it hit the cache.
+This is expected, costs a couple of minutes per job, and does not fail. It is
+written up for contributors in `CONTRIBUTING.md` so nobody spends time hunting a
+bug that isn't there. Adding `restore-keys` would give partial hits, at the cost
+of restoring a stale tree over the correct one — not worth it for a
+`~/.npm` cache the subsequent `npm ci` reconciles anyway.
 
-**One case the window does not describe, and it is the likelier one.** A fork PR
-that *itself changes a lockfile* has a key that exists in no readable scope and
-that no nightly will ever create — the nightly builds `main`'s key, not the PR's.
-There are no `restore-keys`, so there is no partial fallback. Such a PR
-cold-installs on **every push, for its whole life**, and a warm job on `main`
-would not help it either. A dependency-bump PR from a contributor is exactly the
-shape that hits this, so do not read "up to ~24 h" as the worst case — it is the
-worst case only for PRs that leave the lockfiles alone.
+## The invariants, and why they are guards rather than prose
 
-A cold `npm ci` of the monorepo costs a couple of minutes per job and **does not
-fail**. Fork PRs are currently rare (this is a solo-maintained project). Paying a
-hosted job on every push to `main` to shorten a rare window for a rare event is
-the wrong trade today.
+Three comments used to carry "keep the producer hosted / scheduled / cached". That
+is the weakest possible form, and the trap here is sharper than "someone might
+edit it":
 
-## The escalation trigger — read this before deciding it is still fine
+> The all-workflows guard in `ci-npm-cache-routing.test.js` **requires** that a
+> self-hosted job not hardcode an npm cache — correctly, that is #7383. So moving
+> a producer to the self-hosted pool would make **CI itself demand** the removal
+> of its `cache: npm` line. The change would go green while deleting the producer.
 
-**This decision is a function of contributor volume, and that is the one input
-most likely to change.** Chroxy is open source; the reasoning above stops holding
-the moment fork PRs stop being rare.
+A guard that drives the defect next to it needs a counterpart. `ci-npm-cache-routing.test.js`
+now asserts, **scoped to the property rather than to a roster of filenames**:
 
-Adopt the deliberate producer when **any** of these becomes true:
+- at least one producer exists at all;
+- at least one runs on a **push to main** (not merely `on: push:` — `release.yml`
+  is `push: tags`, and its hosted jobs *do* carry `cache: npm`, so a loose check
+  let `release.yml` stand in for the real producer. Measured: with the loose
+  regex, deleting the real producer left the suite green);
+- at least one runs on a **schedule**;
+- no producer sits on a self-hosted runner — this fails *first*, and explains the
+  trap above.
 
-- **External fork PRs become routine** — say, more than one a week, or any week
-  where two land inside the same post-lockfile-change window.
-- **A contributor reports slow or timing-out CI** on a first PR, or you see a
-  hosted job spend minutes in `npm ci` where the cache should have hit.
-- **The nightly stops running, is disabled, or moves off `ubuntu-24.04`** — it is
-  load-bearing here and nothing states that inside its own workflow. Removing it
-  silently removes the only producer.
-- **Lockfile churn increases** (a Renovate cadence change, a dependency-heavy
-  epic), which widens the fraction of time spent inside the window.
+Swapping in an equivalent producer passes. Removing the last one fails.
 
-### The proper fix, when the trigger fires
+`dashboard-smoke` is also the first and only entry in `ALLOWED_HARDCODED_CACHE`,
+the named exception to "no setup-node step hardcodes `cache: npm`". That
+allowlist is name-based by necessity — an exception has to name what it excepts —
+and it carries a staleness check, so renaming the job fails the guard on purpose:
+renaming the one job allowed to hardcode the cache is exactly when someone should
+re-read why the exception exists.
 
-Add a small `push`-to-`main` job to `ci.yml` whose only purpose is to warm the
-hosted cache. It must run on a **GitHub-hosted** runner — a self-hosted one has
-`npmcache` empty by #7383's routing and would save nothing:
+## When to revisit
 
-```yaml
-  warm-hosted-npm-cache:
-    # NOT routed through runner-target: the point is to produce the entry that
-    # fork PRs on ubuntu-24.04 restore, and the self-hosted pool saves nothing.
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    runs-on: ubuntu-24.04
-    timeout-minutes: 15
-    steps:
-      - uses: actions/checkout@<pinned-sha>
-      - uses: actions/setup-node@<pinned-sha>
-        with:
-          node-version: 22
-          cache: npm
-          cache-dependency-path: '**/package-lock.json'
-      - run: npm ci
-```
-
-Two things that will bite whoever adds it:
-
-- `packages/server/tests/ci-npm-cache-routing.test.js` asserts that **no**
-  setup-node step hardcodes `cache: npm`, deliberately including unrouted jobs.
-  This job is the first legitimate exception; add it to that guard explicitly
-  rather than loosening the rule.
-- `cache-dependency-path` must stay `'**/package-lock.json'`. This repo has three
-  lockfiles and setup-node's default key is the root one alone — see
-  `packages/server/tests/ci-cache-key.test.js` and
-  `docs/false-safety-guards.md` entry 16.
+- **A contributor reports slow CI on a PR that does not touch a lockfile.** That
+  should not happen now; if it does, a producer has been lost in a way the guards
+  did not catch, and the guards need the missing assertion.
+- **Lockfile-changing fork PRs become common enough to be a real drag.** The only
+  remedy is `restore-keys`, with the stale-restore tradeoff above. Decide it
+  deliberately; do not add them reflexively.
+- **The 7-day eviction starts biting** — a week with no push to `main` and no
+  nightly. Currently impossible while the nightly runs daily.
 
 ## The Windows cache: kept, and it is not dead config
 
-There are **zero** `node-cache-Windows-*` entries in the repo's cache list, of any
-age. #7386 asked whether `release.yml`'s `desktop-windows` `cache: npm` should be
-dropped as a permanent no-op. It should not, for a reason the issue did not have:
+There are **zero** `node-cache-Windows-*` entries in the repo's cache list. #7386
+asked whether `release.yml`'s `desktop-windows` `cache: npm` should be dropped as
+a permanent no-op. It should not.
 
-- CI's `server-tests-windows` routes through `winrunner` to the self-hosted
-  `chroxy-win`, where `npmcache` is empty — so CI never produces one.
-- A fork PR resolving to `windows-latest` writes to its own isolated ref scope.
-- `release.yml` runs on **tag** refs, whose caches are not readable from a PR
-  branch — which is why no PR has ever seen one.
+The emptiness is explained, not contradictory. A tag-push run *does* save into
+that tag's scope; `actions/cache` evicts after 7 days without access, and releases
+here are months apart (v0.11.0 on 2026-08-15, v0.9.46 before it on 2026-06-21).
+Any entry the last release wrote aged out long before the list was taken.
+
+No *PR* has ever seen one because: CI's `server-tests-windows` routes through
+`winrunner` to the self-hosted `chroxy-win`, where `npmcache` is empty; a fork PR
+on `windows-latest` writes to its own isolated ref scope; and `release.yml` runs
+on tag refs, whose caches a PR branch cannot read.
 
 But a release **re-dispatched on an existing tag** (`gh workflow run release.yml
---ref vX.Y.Z`, a real workflow here) reads that same tag scope, and hits the entry
-the first run saved. The input earns its keep on the second run, not the first.
-The comment now in `release.yml` says so, so the next audit does not re-file it.
+--ref vX.Y.Z`, a real workflow here) reads that same tag scope and hits what the
+first run saved — provided the re-dispatch is inside the 7-day window, which is
+the realistic case, since you re-dispatch to fix a failed release rather than
+months later. Narrow value, not zero. The comment in `release.yml` says so, so the
+next audit does not re-file it as a no-op — which is nearly what happened here.

--- a/docs/decisions/2026-08-npm-cache-producer.md
+++ b/docs/decisions/2026-08-npm-cache-producer.md
@@ -119,9 +119,9 @@ No *PR* has ever seen one because: CI's `server-tests-windows` routes through
 on `windows-latest` writes to its own isolated ref scope; and `release.yml` runs
 on tag refs, whose caches a PR branch cannot read.
 
-But a release **re-dispatched on an existing tag** (`gh workflow run release.yml
---ref vX.Y.Z`, a real workflow here) reads that same tag scope and hits what the
-first run saved — provided the re-dispatch is inside the 7-day window, which is
+But a release **re-dispatched on an existing tag**
+(`gh workflow run release.yml --ref vX.Y.Z`, a real workflow here) reads that
+same tag scope and hits what the first run saved — provided the re-dispatch is inside the 7-day window, which is
 the realistic case, since you re-dispatch to fix a failed release rather than
 months later. Narrow value, not zero. The comment in `release.yml` says so, so the
 next audit does not re-file it as a no-op — which is nearly what happened here.

--- a/docs/decisions/2026-08-npm-cache-producer.md
+++ b/docs/decisions/2026-08-npm-cache-producer.md
@@ -1,0 +1,125 @@
+# The hosted npm cache has no dedicated producer, deliberately
+
+**Date**: 2026-08-26
+**Issue**: #7386 (follow-on from #7383 / #7385)
+**Status**: decided — accept, with a named escalation trigger (below)
+**Touches**: `.github/workflows/ci.yml` (`runner-target.outputs.npmcache`),
+`.github/workflows/nightly-k8s-integration.yml`, `.github/workflows/release.yml`
+
+## The question
+
+#7385 fixed a real blocker: `actions/setup-node`'s `cache: npm` was making every
+self-hosted job download and unpack a **521 MB** `actions/cache` tarball over a
+`~/.npm` that was **already 2.2 GB and warm**. On `chroxy-linux-winbox-01` that
+download stalled at `Received 0 of 521063625 (0.0%), 0.0 MBs/sec` until the job
+burned its whole timeout, and the cancellation rendered as `fail`.
+
+The fix routed the cache on the same predicate as the runner: empty on the
+self-hosted pool, `npm` on GitHub-hosted runners (fork PRs). Correct — but
+`actions/setup-node` keys its cache on `RUNNER_OS`/`RUNNER_ARCH`, **not** on which
+pool the runner belongs to. The `node-cache-Linux-x64-npm-…` entry that fork PRs
+restore on `ubuntu-24.04` had been *produced* by the self-hosted `push`-to-`main`
+jobs. After #7385, no `push` job saves it.
+
+So: does the hosted cache need a job whose only purpose is to warm it?
+
+## Decision: no. Accept it.
+
+## Why — the exposure is bounded, and something already closes it
+
+Three facts, all measured rather than assumed (2026-08-26):
+
+1. **Nothing on `main` has produced a Linux-x64 entry since #7385.** The newest
+   `refs/heads/main` entry was *created* `2026-08-23T20:14Z`, before #7385 merged
+   (`2026-08-26T01:57Z`). Later timestamps on it are `last_accessed_at`, which
+   updates on a **restore**, not a save. The issue's premise is correct.
+
+2. **A fork PR can never help the next fork PR.** GitHub scopes a PR's cache
+   *writes* to that PR's own ref. A fork that cold-installs and saves populates a
+   scope nothing else can read. There is no self-healing here.
+
+3. **But `nightly-k8s-integration.yml` is a producer.** It runs on `ubuntu-24.04`
+   — GitHub-hosted — on `refs/heads/main`, at 06:00 UTC, with `cache: npm` and the
+   correct `**/package-lock.json` key. On a key miss it *saves*. The issue named it
+   as "the only remaining producer" and treated that as the problem; it is also
+   the mitigation.
+
+Put together, the exposure is not "every fork PR cold-installs". It is:
+
+> a lockfile change lands on `main` → **up to ~24 h** → the 06:00 nightly misses
+> the new key and saves it. Fork PRs opened inside that window cold-install
+> across ~12 hosted jobs; fork PRs outside it hit the cache.
+
+A cold `npm ci` of the monorepo costs a couple of minutes per job and **does not
+fail**. Fork PRs are currently rare (this is a solo-maintained project). Paying a
+hosted job on every push to `main` to shorten a rare window for a rare event is
+the wrong trade today.
+
+## The escalation trigger — read this before deciding it is still fine
+
+**This decision is a function of contributor volume, and that is the one input
+most likely to change.** Chroxy is open source; the reasoning above stops holding
+the moment fork PRs stop being rare.
+
+Adopt the deliberate producer when **any** of these becomes true:
+
+- **External fork PRs become routine** — say, more than one a week, or any week
+  where two land inside the same post-lockfile-change window.
+- **A contributor reports slow or timing-out CI** on a first PR, or you see a
+  hosted job spend minutes in `npm ci` where the cache should have hit.
+- **The nightly stops running, is disabled, or moves off `ubuntu-24.04`** — it is
+  load-bearing here and nothing states that inside its own workflow. Removing it
+  silently removes the only producer.
+- **Lockfile churn increases** (a Renovate cadence change, a dependency-heavy
+  epic), which widens the fraction of time spent inside the window.
+
+### The proper fix, when the trigger fires
+
+Add a small `push`-to-`main` job to `ci.yml` whose only purpose is to warm the
+hosted cache. It must run on a **GitHub-hosted** runner — a self-hosted one has
+`npmcache` empty by #7383's routing and would save nothing:
+
+```yaml
+  warm-hosted-npm-cache:
+    # NOT routed through runner-target: the point is to produce the entry that
+    # fork PRs on ubuntu-24.04 restore, and the self-hosted pool saves nothing.
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@<pinned-sha>
+      - uses: actions/setup-node@<pinned-sha>
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: '**/package-lock.json'
+      - run: npm ci
+```
+
+Two things that will bite whoever adds it:
+
+- `packages/server/tests/ci-npm-cache-routing.test.js` asserts that **no**
+  setup-node step hardcodes `cache: npm`, deliberately including unrouted jobs.
+  This job is the first legitimate exception; add it to that guard explicitly
+  rather than loosening the rule.
+- `cache-dependency-path` must stay `'**/package-lock.json'`. This repo has three
+  lockfiles and setup-node's default key is the root one alone — see
+  `packages/server/tests/ci-cache-key.test.js` and
+  `docs/false-safety-guards.md` entry 16.
+
+## The Windows cache: kept, and it is not dead config
+
+There are **zero** `node-cache-Windows-*` entries in the repo's cache list, of any
+age. #7386 asked whether `release.yml`'s `desktop-windows` `cache: npm` should be
+dropped as a permanent no-op. It should not, for a reason the issue did not have:
+
+- CI's `server-tests-windows` routes through `winrunner` to the self-hosted
+  `chroxy-win`, where `npmcache` is empty — so CI never produces one.
+- A fork PR resolving to `windows-latest` writes to its own isolated ref scope.
+- `release.yml` runs on **tag** refs, whose caches are not readable from a PR
+  branch — which is why no PR has ever seen one.
+
+But a release **re-dispatched on an existing tag** (`gh workflow run release.yml
+--ref vX.Y.Z`, a real workflow here) reads that same tag scope, and hits the entry
+the first run saved. The input earns its keep on the second run, not the first.
+The comment now in `release.yml` says so, so the next audit does not re-file it.

--- a/docs/false-safety-guards.md
+++ b/docs/false-safety-guards.md
@@ -825,7 +825,7 @@ indistinguishable from a pattern that matched nothing.
 **returns**, not what it was asked for. And when auditing a floor, ask what the tool
 reads — not which of its fields the list happens to scan.
 
-### 16. The guard scoped to one file, and the value it could not spell — 
+### 16. The guard scoped to one file, and the value it could not spell — `#7386`
 
 Two instances, one PR, both in the same guard.
 

--- a/packages/server/tests/ci-npm-cache-routing.test.js
+++ b/packages/server/tests/ci-npm-cache-routing.test.js
@@ -393,8 +393,11 @@ describe('the hosted npm cache keeps a producer (#7386)', () => {
     workflows = await readWorkflows()
 
     // A PRODUCER: a setup-node step that really saves the hosted entry.
-    //   - hosted (a self-hosted runner has npmcache empty by #7383 and saves
-    //     nothing, while still looking cached),
+    //   - hosted AND x86_64 (a self-hosted runner has npmcache empty by #7383 and
+    //     saves nothing; an ubuntu-*-arm runner saves the arm64 entry, which no
+    //     hosted fork job reads),
+    //   - unconditionally reachable — a job-level `if:` can switch the producer
+    //     off without touching anything this file used to look at,
     //   - `cache: npm` literally — a routed expression resolves to empty on the
     //     self-hosted branch, so a routed job is not a dependable producer,
     //   - the three-lockfile key, or it produces an entry under the WRONG key.
@@ -402,7 +405,7 @@ describe('the hosted npm cache keeps a producer (#7386)', () => {
       w.jobs.flatMap(job =>
         job.steps
           .filter(st => st.some(l => l.includes(SETUP_NODE)))
-          .filter(st => !/self-hosted/.test(job.runsOn) && /ubuntu-/.test(job.runsOn))
+          .filter(() => isHostedX64Linux(job.runsOn) && isUnconditional(job))
           .filter(st => stepInput(st, 'cache') === 'npm')
           .filter(st => stepInput(st, 'cache-dependency-path') === LOCKFILE_GLOB)
           .map(() => ({ workflow: w, job }))
@@ -413,32 +416,81 @@ describe('the hosted npm cache keeps a producer (#7386)', () => {
   /** The `on:` block — everything above the jobs mapping. */
   const triggers = w => w.text.slice(0, w.text.indexOf('\njobs:'))
 
+  /** The lines strictly more indented than `lines[at]` (its YAML sub-block). */
+  const subBlock = (lines, at) => {
+    const indent = /^(\s*)/.exec(lines[at])[1].length
+    const out = []
+    for (let i = at + 1; i < lines.length; i++) {
+      if (/^\s*$/.test(lines[i]) || /^\s*#/.test(lines[i])) continue
+      if (/^(\s*)/.exec(lines[i])[1].length <= indent) break
+      out.push(lines[i])
+    }
+    return out
+  }
+
+  /** The sub-block under the first line matching `re`, plus that line's own tail. */
+  const blockFor = (lines, re) => {
+    const at = lines.findIndex(l => re.test(l))
+    if (at === -1) return null
+    return [lines[at], ...subBlock(lines, at)].join('\n')
+  }
+
   /**
-   * Does this workflow run on a push to the DEFAULT BRANCH?
+   * Does this workflow run on a push to the DEFAULT BRANCH, unfiltered?
    *
-   * Not `/push:/`. `release.yml` is `on: push: tags: ['v*']`, and its hosted
-   * `test` / `verify-artifacts` jobs do carry `cache: npm` with the right key —
-   * so a bare `push:` match counted them as producers. They are not: a tag push
-   * saves into that TAG's cache scope, which a PR branch cannot read. Measured:
-   * with the loose regex, deleting the real push producer left this suite GREEN
-   * because release.yml stood in for it.
+   * Three loose-match traps, each measured green before being closed:
    *
-   * So: find the `push:` key, take its indented sub-block, and require a
-   * `branches:` naming main. A tags-only push is explicitly not this.
+   * 1. Not `/push:/`. `release.yml` is `on: push: tags: ['v*']` with hosted jobs
+   *    that DO carry `cache: npm` and the right key, so a bare match let it stand
+   *    in for the real producer — deleting dashboard-smoke's cache left the suite
+   *    GREEN.
+   * 2. Not `branches:` and `main` tested INDEPENDENTLY over the push block. A
+   *    `paths: [packages/main-app/**]` alongside `branches: [release]` satisfies
+   *    both halves while the workflow never runs on main. The branch check now
+   *    reads the `branches:` sub-block only.
+   * 3. A `paths:`/`paths-ignore:` filter makes the push conditional on which
+   *    files changed — so a lockfile-only change could skip the producer, which
+   *    is precisely when the cache needs re-saving. Treated as not-a-producer.
    */
   const triggersOnPushToMain = w => {
     const lines = triggers(w).split('\n')
     const at = lines.findIndex(l => /^\s*push:\s*$/.test(l))
     if (at === -1) return false
-    const indent = /^(\s*)/.exec(lines[at])[1].length
-    const block = []
-    for (let i = at + 1; i < lines.length; i++) {
-      if (/^\s*$/.test(lines[i]) || /^\s*#/.test(lines[i])) continue
-      if (/^(\s*)/.exec(lines[i])[1].length <= indent) break
-      block.push(lines[i])
-    }
-    const text = block.join('\n')
-    return /^\s*branches:/m.test(text) && /\bmain\b/.test(text)
+    const push = subBlock(lines, at)
+    if (push.some(l => /^\s*paths(-ignore)?:/.test(l))) return false
+    const branches = blockFor(push, /^\s*branches:/)
+    return branches !== null && /\bmain\b/.test(branches)
+  }
+
+  /**
+   * A GitHub-hosted x86_64 Linux runner.
+   *
+   * `/ubuntu-/` alone was wrong on the one axis this whole record is built on:
+   * `ubuntu-24.04-arm` is a real GitHub label, and it saves
+   * `node-cache-Linux-arm64-*` — NOT the `Linux-x64` entry a fork PR on
+   * ubuntu-24.04 restores. Measured: moving the producer there left the suite
+   * green while the entry stopped being produced.
+   */
+  const isHostedX64Linux = runsOn =>
+    !/self-hosted/.test(runsOn) && /ubuntu-/.test(runsOn) && !/\barm\b|arm64/i.test(runsOn)
+
+  /**
+   * Is the job unconditionally reachable — no job-level `if:`?
+   *
+   * ci.yml's comment on the producer tells the reader not to "gate it behind an
+   * `if:`/`needs:`" and says this file pins that. It did not: adding
+   * `if: github.event_name == 'pull_request'` to dashboard-smoke left the suite
+   * at pass 15 / fail 0 with the producer gone. A comment claiming a stronger
+   * check than its code performs is this repo's entry-13 shape, so the code now
+   * matches the comment rather than the comment being softened.
+   *
+   * Job-level only: a step-level `if:` is normal and irrelevant here, so scan
+   * the job body ABOVE `steps:`.
+   */
+  const isUnconditional = job => {
+    const stepsAt = job.body.findIndex(l => /^\s*steps:\s*$/.test(l))
+    const head = stepsAt === -1 ? job.body : job.body.slice(0, stepsAt)
+    return !head.some(l => /^\s{2,}if:/.test(l))
   }
 
   it('finds at least one producer at all', () => {

--- a/packages/server/tests/ci-npm-cache-routing.test.js
+++ b/packages/server/tests/ci-npm-cache-routing.test.js
@@ -220,17 +220,44 @@ describe('CI npm cache routing (#7383)', () => {
     )
   })
 
-  it('no setup-node step hardcodes cache: npm', () => {
-    // Deliberately covers UNROUTED jobs too. A hosted-pinned job hardcoding the
-    // cache is defensible today, but the ones that exist (dashboard-smoke) do not
-    // set a cache at all, so there is no legitimate hardcode left in the file —
-    // and the moment one appears it is worth a deliberate look rather than a
-    // copy-paste. Anchored to step bodies, so ci.yml's comments about `cache: npm`
-    // do not trip it.
+  it('no setup-node step hardcodes cache: npm, except the named producer', () => {
+    // Deliberately covers UNROUTED jobs too: a routed job hardcoding the cache
+    // re-adds the 521 MB per-job download on the self-hosted pool, and an
+    // unrouted one is worth a deliberate look rather than a copy-paste.
+    //
+    // #7386 added the first — and so far only — legitimate hardcode, so this is
+    // an ALLOWLIST OF ONE rather than a relaxed rule. `dashboard-smoke` is
+    // GitHub-hosted, x86_64, unconditional, on push-to-main, and already ran a
+    // root `npm ci` with no cache: it cold-installed every run and saved nothing.
+    // Caching it makes the job faster AND produces the entry fork PRs restore.
+    // See docs/decisions/2026-08-npm-cache-producer.md.
+    //
+    // Keep this list exact. Widening it to "any hosted job may hardcode" would
+    // give back the copy-paste this guard exists to catch, and #7383's cost was
+    // nine cancelled jobs across four PRs.
+    const ALLOWED_HARDCODED_CACHE = new Set(['dashboard-smoke'])
+
     const offenders = setupNodeSteps
-      .filter(({ step }) => stepInput(step, 'cache') === 'npm')
+      .filter(({ job, step }) => stepInput(step, 'cache') === 'npm' && !ALLOWED_HARDCODED_CACHE.has(job.id))
       .map(({ job }) => `${job.id} (ci.yml:${job.line})`)
-    assert.deepEqual(offenders, [], `setup-node steps hardcoding 'cache: npm': ${offenders.join(', ')}`)
+    assert.deepEqual(
+      offenders,
+      [],
+      "setup-node steps hardcoding 'cache: npm'. Routed jobs must use " +
+        `'cache: ${ROUTED_CACHE}'; an unrouted job needs a deliberate entry in ` +
+        `ALLOWED_HARDCODED_CACHE with a reason: ${offenders.join(', ')}`
+    )
+
+    // The allowlist must not outlive its entries. A stale name here would silently
+    // permit a future job that happens to be called `dashboard-smoke`, and would
+    // hide the removal of the producer itself.
+    const present = new Set(setupNodeSteps.map(({ job }) => job.id))
+    const stale = [...ALLOWED_HARDCODED_CACHE].filter(id => !present.has(id))
+    assert.deepEqual(
+      stale,
+      [],
+      `ALLOWED_HARDCODED_CACHE names job(s) that no longer have a setup-node step: ${stale.join(', ')}`
+    )
   })
 
   it('every routed cache still declares cache-dependency-path for the hosted branch', () => {
@@ -320,93 +347,154 @@ describe('npm cache across all workflows (#7383)', () => {
 })
 
 /**
- * The hosted cache's ONLY producer, pinned (#7386).
+ * The hosted cache keeps a producer (#7386).
  *
- * `docs/decisions/2026-08-npm-cache-producer.md` accepts that no job exists
- * solely to warm the hosted `node-cache-Linux-x64-npm-*` entry that fork PRs
- * restore. That acceptance rests entirely on ONE job being a producer as a side
- * effect: `nightly-k8s-integration.yml`, GitHub-hosted, on a schedule, with
- * `cache: npm`. Until now that invariant existed only as prose in three
- * comments, which is the weakest form this repo has a whole document about.
+ * `docs/decisions/2026-08-npm-cache-producer.md`: the `node-cache-Linux-x64-npm-*`
+ * entry a FORK PR restores on ubuntu-24.04 can only be saved by a job that runs
+ * on a GitHub-hosted runner AND on `main` — a PR's cache writes are scoped to its
+ * own ref, so no fork ever helps the next one. #7385 emptied `npmcache` on the
+ * self-hosted pool, which was right for those runners and left nothing on `main`
+ * saving the entry.
  *
- * The trap is sharper than "someone might edit it". The all-workflows guard
- * above REQUIRES that a self-hosted job not hardcode an npm cache — correctly,
- * that is #7383. So moving this job to the self-hosted pool would make CI itself
- * demand the removal of `cache: npm`, and the change would go green while
- * silently deleting the last producer. A guard that drives the defect it is
- * adjacent to needs a counterpart, and this is it: move the job self-hosted and
- * THIS fails first, naming the decision record.
+ * Two jobs restore that: `dashboard-smoke` on every push to `main` (the primary —
+ * it was already hosted and already ran `npm ci` uncached), and the k8s nightly
+ * daily (the fallback). Until now the invariant was prose in three comments.
+ *
+ * The trap is sharper than "someone might edit it". The all-workflows guard above
+ * REQUIRES that a self-hosted job not hardcode an npm cache — correctly, that is
+ * #7383 — so moving a producer to the self-hosted pool would make CI itself demand
+ * the removal of `cache: npm`, going green while deleting the producer. A guard
+ * that drives the defect next to it needs a counterpart.
+ *
+ * SCOPED TO THE PROPERTY, NOT THE ROSTER. This asserts "some hosted job produces
+ * the entry on a push to main, and some producer runs on a schedule" — not
+ * "these two files exist". Naming files here would rebuild the hardcoded-roster
+ * defect that this whole PR and docs/false-safety-guards.md entry 16 are about.
+ * Swapping in an equivalent producer passes; removing the last one fails.
+ *
+ * The `ALLOWED_HARDCODED_CACHE` allowlist in the suite above is name-based, and
+ * necessarily so — an exception has to name what it excepts. Its staleness check
+ * therefore DOES fire when a producer job is renamed. That is intended: renaming
+ * the one job allowed to hardcode `cache: npm` is exactly when someone should
+ * re-read why the exception exists.
  */
 describe('the hosted npm cache keeps a producer (#7386)', () => {
-  let nightly
-  let job
-  let step
+  let workflows
+  let producers
 
   before(async () => {
-    // Load only. The positive control is an `it()` below, NOT an assertion here:
-    // a failed `before()` hook aborts its subtests and node:test still prints
-    // `# fail 0` in the aggregate TAP summary. The run does exit non-zero (and
+    // Load only — the positive control is an `it()` below, never an assertion in
+    // `before()`. A failed hook aborts its subtests while node:test still prints
+    // `# fail 0` in the aggregate summary; the run exits non-zero (and
     // assert-test-count.mjs propagates that), but anything reading the summary
-    // by eye — or by grep — sees a clean count. That is the reporting half of
-    // the very defect class this file guards, so don't create it here.
-    const workflows = await readWorkflows()
-    nightly = workflows.find(w => w.name === 'nightly-k8s-integration.yml') ?? null
-    job = nightly?.jobs.find(j => j.steps.some(st => st.some(l => l.includes(SETUP_NODE)))) ?? null
-    step = job?.steps.find(st => st.some(l => l.includes(SETUP_NODE))) ?? null
+    // sees a clean count. Measured: an earlier draft reported `pass 11, fail 0`
+    // on a mutation it had actually caught. Creating the reporting half of this
+    // file's own defect class inside it is not on.
+    workflows = await readWorkflows()
+
+    // A PRODUCER: a setup-node step that really saves the hosted entry.
+    //   - hosted (a self-hosted runner has npmcache empty by #7383 and saves
+    //     nothing, while still looking cached),
+    //   - `cache: npm` literally — a routed expression resolves to empty on the
+    //     self-hosted branch, so a routed job is not a dependable producer,
+    //   - the three-lockfile key, or it produces an entry under the WRONG key.
+    producers = workflows.flatMap(w =>
+      w.jobs.flatMap(job =>
+        job.steps
+          .filter(st => st.some(l => l.includes(SETUP_NODE)))
+          .filter(st => !/self-hosted/.test(job.runsOn) && /ubuntu-/.test(job.runsOn))
+          .filter(st => stepInput(st, 'cache') === 'npm')
+          .filter(st => stepInput(st, 'cache-dependency-path') === LOCKFILE_GLOB)
+          .map(() => ({ workflow: w, job }))
+      )
+    )
   })
 
-  it('finds the producer workflow and its setup-node step', async () => {
-    const workflows = await readWorkflows()
+  /** The `on:` block — everything above the jobs mapping. */
+  const triggers = w => w.text.slice(0, w.text.indexOf('\njobs:'))
+
+  /**
+   * Does this workflow run on a push to the DEFAULT BRANCH?
+   *
+   * Not `/push:/`. `release.yml` is `on: push: tags: ['v*']`, and its hosted
+   * `test` / `verify-artifacts` jobs do carry `cache: npm` with the right key —
+   * so a bare `push:` match counted them as producers. They are not: a tag push
+   * saves into that TAG's cache scope, which a PR branch cannot read. Measured:
+   * with the loose regex, deleting the real push producer left this suite GREEN
+   * because release.yml stood in for it.
+   *
+   * So: find the `push:` key, take its indented sub-block, and require a
+   * `branches:` naming main. A tags-only push is explicitly not this.
+   */
+  const triggersOnPushToMain = w => {
+    const lines = triggers(w).split('\n')
+    const at = lines.findIndex(l => /^\s*push:\s*$/.test(l))
+    if (at === -1) return false
+    const indent = /^(\s*)/.exec(lines[at])[1].length
+    const block = []
+    for (let i = at + 1; i < lines.length; i++) {
+      if (/^\s*$/.test(lines[i]) || /^\s*#/.test(lines[i])) continue
+      if (/^(\s*)/.exec(lines[i])[1].length <= indent) break
+      block.push(lines[i])
+    }
+    const text = block.join('\n')
+    return /^\s*branches:/m.test(text) && /\bmain\b/.test(text)
+  }
+
+  it('finds at least one producer at all', () => {
+    // Positive control AND the load-bearing assertion. If this reaches zero, every
+    // fork PR cold-installs the monorepo across ~12 jobs and nothing else notices.
     assert.ok(
-      nightly,
-      'nightly-k8s-integration.yml is the only producer of the hosted npm cache ' +
-        '(docs/decisions/2026-08-npm-cache-producer.md). If it was renamed, update this ' +
-        `guard; if it was deleted, the decision record must be revisited. Saw: ${
-          workflows.map(w => w.name).join(', ')
-        }`
+      producers.length > 0,
+      'NO job produces the hosted npm cache. A fork PR on ubuntu-24.04 restores ' +
+        '`node-cache-Linux-x64-npm-*`, and only a GitHub-hosted job running on `main` with ' +
+        '`cache: npm` + the three-lockfile key can save it. See ' +
+        'docs/decisions/2026-08-npm-cache-producer.md for what to restore and where.'
     )
-    assert.ok(job, 'expected a job with a setup-node step in nightly-k8s-integration.yml')
-    assert.ok(step, 'expected to locate that setup-node step')
   })
 
-  it('runs on a GitHub-HOSTED runner', () => {
-    // The whole point. A self-hosted runner has npmcache empty by #7383's
-    // routing and saves nothing, so this job would stop being a producer while
-    // still looking like one.
-    assert.ok(job, 'producer job not found (see the previous test)')
-    assert.doesNotMatch(
-      job.runsOn,
-      /self-hosted/,
-      'the producer must stay GitHub-hosted — a self-hosted runner saves no cache entry ' +
-        '(#7383), which would silently remove the last producer of the entry fork PRs ' +
-        'restore. See docs/decisions/2026-08-npm-cache-producer.md.'
+  it('at least one producer runs on every push to main', () => {
+    // The primary. A daily producer alone leaves a window after each lockfile
+    // change; a push-to-main producer closes it.
+    const onPush = producers.filter(p => triggersOnPushToMain(p.workflow))
+    assert.ok(
+      onPush.length > 0,
+      'no push-to-main producer. Something must save the hosted cache on every push, or a ' +
+        'lockfile change leaves fork PRs cold-installing until the next scheduled producer. ' +
+        `Producers found: ${producers.map(p => `${p.workflow.name}:${p.job.id}`).join(', ') || '(none)'}`
     )
-    assert.match(job.runsOn, /ubuntu-/, `expected an ubuntu- runner, got: ${job.runsOn.trim()}`)
   })
 
-  it('still declares the npm cache with the three-lockfile key', () => {
-    assert.ok(step, 'producer setup-node step not found (see the first test)')
-    assert.equal(
-      stepInput(step, 'cache'),
-      'npm',
-      'the producer must keep `cache: npm` — without it the job restores nothing AND saves ' +
-        'nothing. See docs/decisions/2026-08-npm-cache-producer.md.'
+  it('at least one producer runs on a schedule', () => {
+    // The fallback. Keeps the entry warm even if the push producer is skipped,
+    // and re-saves after the 7-day eviction on a quiet week.
+    const onSchedule = producers.filter(p => /^\s*schedule:/m.test(triggers(p.workflow)))
+    assert.ok(
+      onSchedule.length > 0,
+      'no scheduled producer. Producers found: ' +
+        `${producers.map(p => `${p.workflow.name}:${p.job.id}`).join(', ') || '(none)'}`
     )
-    assert.equal(stepInput(step, 'cache-dependency-path'), LOCKFILE_GLOB)
   })
 
-  it('still runs on a schedule', () => {
-    // A producer that only fires on workflow_dispatch is not a producer. Checked
-    // on the file text above the jobs mapping, so the reader's job-scoped view
-    // does not apply.
-    assert.ok(nightly, 'producer workflow not found (see the first test)')
-    const header = nightly.text.slice(0, nightly.text.indexOf('\njobs:'))
-    assert.match(
-      header,
-      /^\s*schedule:/m,
-      'the producer must stay scheduled — on workflow_dispatch alone it would only warm the ' +
-        'cache when someone remembers to. See docs/decisions/2026-08-npm-cache-producer.md.'
+  it('no producer sits on a self-hosted runner', () => {
+    // The counterpart to the all-workflows self-hosted rule above: that guard
+    // would DEMAND removing `cache: npm` from a producer moved to the self-hosted
+    // pool. This one fails first, and says why.
+    const stranded = workflows.flatMap(w =>
+      w.jobs
+        .filter(job => /self-hosted/.test(job.runsOn))
+        .filter(job =>
+          job.steps.some(st => st.some(l => l.includes(SETUP_NODE)) && stepInput(st, 'cache') === 'npm')
+        )
+        .map(job => `${w.name}:${job.id}`)
     )
-    assert.match(header, /cron:/, 'expected a cron entry under schedule:')
+    assert.deepEqual(
+      stranded,
+      [],
+      'a job on a self-hosted runner declares `cache: npm`. It saves nothing there (#7383), so ' +
+        'if this was a producer being moved, the move removed a producer — and the ' +
+        'all-workflows guard above will now demand you delete the `cache:` line, completing it ' +
+        `silently. See docs/decisions/2026-08-npm-cache-producer.md:\n  ${stranded.join('\n  ')}`
+    )
   })
 })

--- a/packages/server/tests/ci-npm-cache-routing.test.js
+++ b/packages/server/tests/ci-npm-cache-routing.test.js
@@ -318,3 +318,95 @@ describe('npm cache across all workflows (#7383)', () => {
     )
   })
 })
+
+/**
+ * The hosted cache's ONLY producer, pinned (#7386).
+ *
+ * `docs/decisions/2026-08-npm-cache-producer.md` accepts that no job exists
+ * solely to warm the hosted `node-cache-Linux-x64-npm-*` entry that fork PRs
+ * restore. That acceptance rests entirely on ONE job being a producer as a side
+ * effect: `nightly-k8s-integration.yml`, GitHub-hosted, on a schedule, with
+ * `cache: npm`. Until now that invariant existed only as prose in three
+ * comments, which is the weakest form this repo has a whole document about.
+ *
+ * The trap is sharper than "someone might edit it". The all-workflows guard
+ * above REQUIRES that a self-hosted job not hardcode an npm cache — correctly,
+ * that is #7383. So moving this job to the self-hosted pool would make CI itself
+ * demand the removal of `cache: npm`, and the change would go green while
+ * silently deleting the last producer. A guard that drives the defect it is
+ * adjacent to needs a counterpart, and this is it: move the job self-hosted and
+ * THIS fails first, naming the decision record.
+ */
+describe('the hosted npm cache keeps a producer (#7386)', () => {
+  let nightly
+  let job
+  let step
+
+  before(async () => {
+    // Load only. The positive control is an `it()` below, NOT an assertion here:
+    // a failed `before()` hook aborts its subtests and node:test still prints
+    // `# fail 0` in the aggregate TAP summary. The run does exit non-zero (and
+    // assert-test-count.mjs propagates that), but anything reading the summary
+    // by eye — or by grep — sees a clean count. That is the reporting half of
+    // the very defect class this file guards, so don't create it here.
+    const workflows = await readWorkflows()
+    nightly = workflows.find(w => w.name === 'nightly-k8s-integration.yml') ?? null
+    job = nightly?.jobs.find(j => j.steps.some(st => st.some(l => l.includes(SETUP_NODE)))) ?? null
+    step = job?.steps.find(st => st.some(l => l.includes(SETUP_NODE))) ?? null
+  })
+
+  it('finds the producer workflow and its setup-node step', async () => {
+    const workflows = await readWorkflows()
+    assert.ok(
+      nightly,
+      'nightly-k8s-integration.yml is the only producer of the hosted npm cache ' +
+        '(docs/decisions/2026-08-npm-cache-producer.md). If it was renamed, update this ' +
+        `guard; if it was deleted, the decision record must be revisited. Saw: ${
+          workflows.map(w => w.name).join(', ')
+        }`
+    )
+    assert.ok(job, 'expected a job with a setup-node step in nightly-k8s-integration.yml')
+    assert.ok(step, 'expected to locate that setup-node step')
+  })
+
+  it('runs on a GitHub-HOSTED runner', () => {
+    // The whole point. A self-hosted runner has npmcache empty by #7383's
+    // routing and saves nothing, so this job would stop being a producer while
+    // still looking like one.
+    assert.ok(job, 'producer job not found (see the previous test)')
+    assert.doesNotMatch(
+      job.runsOn,
+      /self-hosted/,
+      'the producer must stay GitHub-hosted — a self-hosted runner saves no cache entry ' +
+        '(#7383), which would silently remove the last producer of the entry fork PRs ' +
+        'restore. See docs/decisions/2026-08-npm-cache-producer.md.'
+    )
+    assert.match(job.runsOn, /ubuntu-/, `expected an ubuntu- runner, got: ${job.runsOn.trim()}`)
+  })
+
+  it('still declares the npm cache with the three-lockfile key', () => {
+    assert.ok(step, 'producer setup-node step not found (see the first test)')
+    assert.equal(
+      stepInput(step, 'cache'),
+      'npm',
+      'the producer must keep `cache: npm` — without it the job restores nothing AND saves ' +
+        'nothing. See docs/decisions/2026-08-npm-cache-producer.md.'
+    )
+    assert.equal(stepInput(step, 'cache-dependency-path'), LOCKFILE_GLOB)
+  })
+
+  it('still runs on a schedule', () => {
+    // A producer that only fires on workflow_dispatch is not a producer. Checked
+    // on the file text above the jobs mapping, so the reader's job-scoped view
+    // does not apply.
+    assert.ok(nightly, 'producer workflow not found (see the first test)')
+    const header = nightly.text.slice(0, nightly.text.indexOf('\njobs:'))
+    assert.match(
+      header,
+      /^\s*schedule:/m,
+      'the producer must stay scheduled — on workflow_dispatch alone it would only warm the ' +
+        'cache when someone remembers to. See docs/decisions/2026-08-npm-cache-producer.md.'
+    )
+    assert.match(header, /cron:/, 'expected a cron entry under schedule:')
+  })
+})


### PR DESCRIPTION
Closes #7386.

## Q1 — the Linux producer: **adopted, at no cost**

I originally recommended accepting the gap, on the reasoning that closing it meant paying for a hosted job on every push to `main`. **That premise was wrong — the job already exists.**

`ci.yml`'s `dashboard-smoke` is `ubuntu-24.04` (GitHub-hosted, x86_64, pinned there for Playwright and deliberately *not* routed through `runner-target`), has no `if:` or `needs:`, `ci.yml` triggers on `push: branches: [main]`, and it runs a root `npm ci`. It simply declared **no `cache:` at all** — so it cold-installed the whole monorepo every run *and* saved nothing.

Adding `cache: npm` + the three-lockfile key produces the entry fork PRs restore **and makes the job faster**. There was never a trade to weigh.

`nightly-k8s-integration.yml` stays as the scheduled fallback — it re-saves after the 7-day eviction on a quiet week, and covers a run where the primary is skipped.

## The guard is scoped to the property, not a roster

It asserts *"some hosted job produces the entry on a push to main, and some producer runs on a schedule"* — never *"these two files exist"*. Naming files would rebuild the hardcoded-roster defect this PR and `docs/false-safety-guards.md` entry 16 are about. Swapping in an equivalent producer passes; removing the last one fails.

**Writing it exposed a real bug in my first version — one a name-based guard would have hidden.** The push check was `/^\s*push:/m`, and `release.yml` is `on: push: tags: ['v*']` with hosted jobs that *do* carry `cache: npm` and the correct key. So `release.yml` silently stood in for the real producer: deleting `dashboard-smoke`'s cache left the suite **green**. Measured, then fixed to require a `push:` block whose `branches:` names `main`. Four of the six mutations below only go red because of that fix.

### Mutation matrix — each on its intended subtest

| mutation | subtest that went RED |
|---|---|
| drop the push producer (nightly remains) | `at least one producer runs on every push to main` |
| drop **both** producers | push **and** schedule |
| drop the scheduled producer | `at least one producer runs on a schedule` |
| break the producer's key to the bare lockfile | push producer (it stops qualifying) |
| move the producer to the self-hosted pool | 3 guards, incl. the counterpart one |
| rename the producer job | allowlist staleness — **intended** |

### The trap the counterpart guard exists for

The all-workflows guard **requires** that a self-hosted job not hardcode an npm cache — correctly, that is #7383. So moving a producer to the self-hosted pool would make **CI itself demand** deleting its `cache: npm` line, going green while removing the producer. A guard that drives the defect next to it needs a counterpart; `no producer sits on a self-hosted runner` fails first and says why.

### The exception is an allowlist of one

`cache: npm` on `dashboard-smoke` needs an exception to "no setup-node step hardcodes `cache: npm`". It is an allowlist of **one**, with a staleness check — not a relaxed rule. Widening it to "any hosted job may hardcode" gives back the copy-paste that guard exists to catch, and #7383 cost nine cancelled jobs across four PRs. It is name-based by necessity, so a rename fails it on purpose: that is exactly when someone should re-read why the exception exists.

## What this does not fix, said plainly

A fork PR that **itself changes a `package-lock.json`** has a key that exists in no readable scope, and no producer on `main` will ever create it — those build `main`'s key, not the PR's. No `restore-keys`, so no partial fallback. It cold-installs for its whole life. A dependency-bump PR from a contributor is exactly that shape. `CONTRIBUTING.md` now splits the two cases so nobody hunts a bug that isn't there, and a cold install on a *non*-lockfile PR is now framed as worth reporting, because it means a producer went missing.

## Q2 — the Windows input: **kept, not dropped**

Zero `node-cache-Windows-*` entries — but the emptiness is *explained*, not contradictory. A tag-push run does save into that tag's scope; entries evict after 7 days without access, and releases here are months apart (v0.11.0 `2026-08-15`; v0.9.46 before it `2026-06-21`). A release **re-dispatched on an existing tag** — a real workflow here — reads that same scope and hits what the first run saved, inside that window. Narrow value, not zero. Commented in place so the next audit doesn't re-file it as a no-op, which is nearly what happened.

## Also corrected in the record

- **`ci.yml` mixed-arch.** "The entry used to be saved by the self-hosted push jobs" was imprecise: the pool is deliberately mixed (ARM64 Docker members plus one x86_64 VM) and setup-node keys on `RUNNER_ARCH`, so only jobs landing on the single x86_64 member ever produced `Linux-x64` — as the repo's own cache list shows, carrying both arches. Sporadic, not systematic.
- **Positive control moved out of `before()`.** A failed hook aborts its subtests while node:test still prints `# fail 0` in the aggregate summary. Measured: an earlier draft reported `pass 11, fail 0` on a mutation it had actually caught. Creating the reporting half of this file's own defect class inside it isn't on.

## Gates

- 30/30 CI guards green; 9/9 server shell lints pass.
- Verified directly that the workflow reader still parses every setup-node step through the new in-step comments — the new `ci.yml` comment quotes `cache: npm` in prose, which is exactly the prose-as-config trap those guards resist.