### PR TITLE
docs(ci): correct the producer's measured cost — it is a wash, not a speedup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,8 +126,10 @@ jobs:
         #
         # The producer is now `dashboard-smoke` below — hosted, x86_64,
         # unconditional, on push-to-main, and already running `npm ci` with no
-        # cache at all. Caching it makes that job faster and produces the entry as
-        # a side effect. `nightly-k8s-integration.yml` is the scheduled fallback.
+        # cache at all. Caching it produces the entry as a side effect, at ~zero
+        # net cost to that job (the restore roughly cancels the `npm ci` saving —
+        # measured, see the decision record; it is NOT a speedup).
+        # `nightly-k8s-integration.yml` is the scheduled fallback.
         #
         # BOTH ARE LOAD-BEARING, and prose alone did not protect them:
         # ci-npm-cache-routing.test.js asserts a push-to-main producer AND a
@@ -1319,11 +1321,12 @@ jobs:
       # run AND saved nothing.
       #
       # Measured after the fact, correcting what this comment first claimed: the
-      # cache does NOT make the job faster. `npm ci` goes 35s -> 29s, the 497 MB
-      # restore costs ~5s, and the job goes 93-95s -> 97s. A wash. `~/.npm` is
-      # npm's DOWNLOAD cache; extracting and linking 1353 packages dominates
-      # either way. The reason to do it is that the job cost is ~zero while a
-      # DEDICATED warm job would cost a whole extra hosted job per push.
+      # cache does NOT make the job faster. Per step: setup-node 0-3s -> 7s,
+      # `npm ci` 35s -> 30s. It cancels. (The job TOTAL moved 93-95s -> 97s, but
+      # that residual is in Playwright's chromium download, not here — see the
+      # decision record.) `~/.npm` is npm's DOWNLOAD cache; extracting and linking
+      # 1353 packages dominates either way. The reason to do it is that the cost
+      # is ~zero while a DEDICATED warm job would cost a whole extra hosted job.
       #
       # packages/server/tests/ci-npm-cache-routing.test.js pins, specifically:
       # a producer exists that is GitHub-hosted AND x86_64 (an `ubuntu-*-arm`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1316,10 +1316,14 @@ jobs:
       # This job already satisfied both conditions: hosted, x86_64 (pinned for
       # Playwright), unconditional, on `push: branches: [main]`, running a root
       # `npm ci`. It just had no `cache:`, so it cold-installed the monorepo every
-      # run AND saved nothing. Adding the cache costs nothing and MAKES THE JOB
-      # FASTER; the producer is a free side effect. It was the reason the "add a
-      # dedicated warm job" option looked expensive — it isn't, because the job
-      # exists.
+      # run AND saved nothing.
+      #
+      # Measured after the fact, correcting what this comment first claimed: the
+      # cache does NOT make the job faster. `npm ci` goes 35s -> 29s, the 497 MB
+      # restore costs ~5s, and the job goes 93-95s -> 97s. A wash. `~/.npm` is
+      # npm's DOWNLOAD cache; extracting and linking 1353 packages dominates
+      # either way. The reason to do it is that the job cost is ~zero while a
+      # DEDICATED warm job would cost a whole extra hosted job per push.
       #
       # packages/server/tests/ci-npm-cache-routing.test.js pins, specifically:
       # a producer exists that is GitHub-hosted AND x86_64 (an `ubuntu-*-arm`

--- a/docs/decisions/2026-08-npm-cache-producer.md
+++ b/docs/decisions/2026-08-npm-cache-producer.md
@@ -40,7 +40,39 @@ and it is the whole reason this is a short document.** `ci.yml`'s
 
 It simply declared no `cache:`, so it **cold-installed the whole monorepo on every
 run and saved nothing**. Adding `cache: npm` with the three-lockfile key makes it
-the producer *and makes the job faster*. The cost is negative.
+the producer at **no meaningful cost to the job**.
+
+### Measured, after the fact — and it corrects this record's first claim
+
+This section originally said the change *makes the job faster*, so the cost was
+"negative". Measured on the first post-merge run against the two before it, that
+is **wrong**:
+
+| run | total job | `npm ci` |
+|---|---|---|
+| `f2129e6d3` — with cache | **97 s** | 29 s (plus ~5 s restore) |
+| `1674dba8e` — no cache | 93 s | 35 s |
+| `4514acc2a` — no cache | 95 s | 35 s |
+
+`npm ci` did get ~6 s faster, and the 497 MB restore costs ~5 s, so the two
+cancel: 93–95 s becomes 97 s. **A wash, marginally on the wrong side of it.**
+
+The reason is worth carrying, because it caps what cache-warming can ever buy
+here: `~/.npm` is npm's **download** cache. `npm ci` still extracts and links all
+1353 packages either way, and that is what dominates the 29–35 s. The cache
+removes network fetch, not install work.
+
+So the argument for doing this is **not** "it is free because the job gets
+faster". It is:
+
+- the job cost is ~zero (±5 s, inside run-to-run noise), and
+- a *dedicated* warm job would cost a whole additional hosted job per push.
+
+Same conclusion, honest reason. The producer function itself is unaffected: on a
+key MISS — the case that matters, right after a lockfile change — the job saves
+the new entry. On a hit it correctly does not re-save (`Cache hit occurred on the
+primary key …, not saving cache`), which is why the first post-merge run produced
+no new entry.
 
 `nightly-k8s-integration.yml` (hosted, `refs/heads/main`, 06:00 UTC) remains a
 second producer. It is the fallback: it re-saves after the 7-day eviction on a

--- a/docs/decisions/2026-08-npm-cache-producer.md
+++ b/docs/decisions/2026-08-npm-cache-producer.md
@@ -48,14 +48,31 @@ This section originally said the change *makes the job faster*, so the cost was
 "negative". Measured on the first post-merge run against the two before it, that
 is **wrong**:
 
-| run | total job | `npm ci` |
-|---|---|---|
-| `f2129e6d3` — with cache | **97 s** | 29 s (plus ~5 s restore) |
-| `1674dba8e` — no cache | 93 s | 35 s |
-| `4514acc2a` — no cache | 95 s | 35 s |
+Per step, which is the only level at which this is attributable:
 
-`npm ci` did get ~6 s faster, and the 497 MB restore costs ~5 s, so the two
-cancel: 93–95 s becomes 97 s. **A wash, marginally on the wrong side of it.**
+| step | with cache (`f2129e6d3`) | no cache (`1674dba8e` / `4514acc2a`) |
+|---|---|---|
+| setup-node (restore) | 7 s | 0–3 s |
+| Install dependencies (`npm ci`) | 30 s | 35 s / 36 s |
+| *Build dashboard* | *9 s* | *12 s / 13 s* |
+| *Install Playwright chromium* | *27 s* | *22 s / 20 s* |
+| **total job** | **97 s** | **93 s / 95 s** |
+
+**The cache itself is a wash**: it costs ~4–7 s in the restore and saves ~5–6 s
+in `npm ci`. The +2–4 s in the job TOTAL is not attributable to it — it is in the
+italicised steps, which the cache does not touch (Playwright's chromium download
+ran 5–7 s slower on that run, partly offset by Build dashboard running 3–4 s
+faster). Ordinary run-to-run variance. An earlier draft of this section billed
+that residual to the cache and called it "marginally on the wrong side"; the
+arithmetic never supported it (−6 s + 5 s predicts ~93 s, not 97 s), which is
+what gives it away.
+
+**One cost here is UNMEASURED and should not be glossed.** Every run above was a
+cache HIT, and a hit does not save. The run that actually *produces* — the one
+right after a lockfile change — additionally compresses and uploads ~497 MB in
+the post-`setup-node` step. Every recent producer run (six consecutive nightlies)
+hit the key, so there is no measured save to quote, and none is invented here. It
+is paid once per lockfile change, not per push.
 
 The reason is worth carrying, because it caps what cache-warming can ever buy
 here: `~/.npm` is npm's **download** cache. `npm ci` still extracts and links all
@@ -65,7 +82,8 @@ removes network fetch, not install work.
 So the argument for doing this is **not** "it is free because the job gets
 faster". It is:
 
-- the job cost is ~zero (±5 s, inside run-to-run noise), and
+- the cache's own cost on this job is ~zero (restore ≈ `npm ci` saving), plus an
+  unmeasured post-step upload on the rarer save runs, and
 - a *dedicated* warm job would cost a whole additional hosted job per push.
 
 Same conclusion, honest reason. The producer function itself is unaffected: on a

--- a/packages/server/tests/ci-npm-cache-routing.test.js
+++ b/packages/server/tests/ci-npm-cache-routing.test.js
@@ -229,7 +229,9 @@ describe('CI npm cache routing (#7383)', () => {
     // an ALLOWLIST OF ONE rather than a relaxed rule. `dashboard-smoke` is
     // GitHub-hosted, x86_64, unconditional, on push-to-main, and already ran a
     // root `npm ci` with no cache: it cold-installed every run and saved nothing.
-    // Caching it makes the job faster AND produces the entry fork PRs restore.
+    // Caching it produces the entry fork PRs restore, at ~zero net cost to the
+    // job (measured: the restore roughly cancels the `npm ci` saving — it is NOT
+    // a speedup, whatever an earlier version of this comment said).
     // See docs/decisions/2026-08-npm-cache-producer.md.
     //
     // Keep this list exact. Widening it to "any hosted job may hardcode" would


### PR DESCRIPTION
Follow-up to #7392, correcting a claim I asserted instead of measuring.

## What was wrong

#7392 said adding `cache: npm` to `dashboard-smoke` "makes the job faster", so the cost was *negative*. I verified the producer wiring end-to-end on the first post-merge run and, while I was in there, measured the timing against the two runs before it:

| run | total job | `npm ci` |
|---|---|---|
| `f2129e6d3` — **with** cache | **97 s** | 29 s (plus ~5 s restore) |
| `1674dba8e` — no cache | 93 s | 35 s |
| `4514acc2a` — no cache | 95 s | 35 s |

`npm ci` *does* get ~6 s faster, and the 497 MB restore costs ~5 s, so the two cancel: 93–95 s becomes 97 s. **A wash, marginally on the wrong side of it.**

## Why — and this caps what cache-warming can ever buy here

`~/.npm` is npm's **download** cache. `npm ci` still extracts and links all 1353 packages either way, and that is what dominates the 29–35 s. The cache removes network fetch, not install work. Worth recording, because it means "warm the npm cache" is not a general lever for install time in this repo.

## The decision is unchanged; its justification is not

Not *"free because the job gets faster"* but:

- the job cost is **~zero** (±5 s, inside run-to-run noise), and
- a **dedicated** warm job would cost a whole additional hosted job per push.

Same conclusion, honest reason.

## The producer function is unaffected

The first post-merge run hit the primary key and correctly did **not** re-save:

```
Cache hit occurred on the primary key node-cache-Linux-x64-npm-c28dd98…, not saving cache.
```

That is why no new entry appeared — the caveat flagged before merging. On a **miss**, right after a lockfile change, it saves. That is the case this exists for, and it is the one the guards pin.

## Gates

30/30 CI guards green (untouched by this change).