### PR TITLE
fix(dashboard): let the user scroll up during a live stream

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -323,6 +323,10 @@ The recurring causes:
 - a guard that HANGS instead of failing — `assert.match` against a multi-KB
   source slice wedges `node --test` with an empty TAP stream, so its two states
   are green and "flake", never red (`#7340`)
+- a guard whose precondition a NEIGHBOURING loop falsifies — a per-frame re-pin
+  holds the "this scroll was ours" flag continuously and restores the position
+  the guard tests, so `programmatic && atBottom` is true by construction and the
+  user-scrolled-up branch is never reached (`#7399`)
 
 Check the **exit code**, not the output — and note `cmd | grep -c FAIL` reports
 `grep`'s status, not the script's. Then check the mutant went **red, legibly,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -304,6 +304,10 @@ The recurring causes:
 - a guard that HANGS instead of failing — `assert.match` against a multi-KB
   source slice wedges `node --test` with an empty TAP stream, so its two states
   are green and "flake", never red (`#7340`)
+- a guard whose precondition a NEIGHBOURING loop falsifies — a per-frame re-pin
+  holds the "this scroll was ours" flag continuously and restores the position
+  the guard tests, so `programmatic && atBottom` is true by construction and the
+  user-scrolled-up branch is never reached (`#7399`)
 
 Check the **exit code**, not the output — and note `cmd | grep -c FAIL` reports
 `grep`'s status, not the script's. Then check the mutant went **red, legibly,

--- a/docs/false-safety-guards.md
+++ b/docs/false-safety-guards.md
@@ -936,3 +936,63 @@ that the exit code was non-zero. The same applies to any wrapper that decides
 pass/fail from an exit status alone: `cmd | grep -c FAIL` reporting `grep`'s
 status is the identical defect one pipe further along, and it is already
 catalogued above.
+
+### 18. The guard falsified by the loop it was meant to interrupt — `#7399`
+
+The dashboard's chat view has, and had for months, a correct-looking guard
+against yanking a reader who has scrolled up to read history (`#4652` / AC3).
+It classifies each `scroll` event and bails out of the auto-follow when the
+viewport is no longer at the bottom:
+
+```js
+if (programmaticScrollRef.current && atBottom) return   // our own write — ignore
+setUserScrolledUp(!atBottom)
+```
+
+Nothing is wrong with those two lines. They were never reached.
+
+Twenty lines below sits a streaming re-pin loop that re-arms every frame for the
+whole duration of a stream. Each tick writes `scrollTop = scrollHeight` and marks
+the write programmatic until the *next* frame — so a loop that re-arms every
+frame holds that flag **continuously**. And the position it restores is the
+bottom. Both halves of `programmaticScrollRef.current && atBottom` are therefore
+true for the entire stream, by construction, and every scroll event is discarded
+as self-induced.
+
+The second half is the part worth internalising, because the flag alone would
+not have done it. `atBottom` is not "at the bottom" — it is "within 100px of the
+bottom". A trackpad flick moves 10-40px per frame. So the user's gesture had to
+clear 100px **in a single frame**, because the next tick threw away everything
+they had gained. Two individually reasonable choices — a wide "still following"
+band and a per-frame pin — composed into a guard whose precondition its
+neighbour falsified sixty times a second.
+
+**Tests could not see it, and neither could review.** The guard has unit tests
+and they pass; they scroll up while idle, when no loop is running. Reviewers read
+the two lines, which are correct in isolation. What was needed was to read them
+*against* the effect twenty lines down — and the comment above that effect
+actively discouraged it, ending with the claim that "a genuine user scroll-up
+(`atBottom` false) is still honored" when `atBottom false` is precisely the state
+the loop made unreachable. That is entry 13's shape (a comment describing a
+stronger property than the code delivers) sitting on top of this one, and it is
+why the bug survived a dogfooding report long enough to be filed against a
+specific line number.
+
+**What the fix had to change** is not the guard but the *evidence*: intent now
+comes from the gesture (`wheel` / `touchmove` / key, direction-checked), which is
+unambiguously the user whatever position the loop leaves behind. A position the
+loop itself controls cannot be evidence about the user, and no amount of
+threshold tuning changes that.
+
+Two of the fix's own first-cut tests then repeated the original mistake at
+one remove: they supplied *both* a gesture and a scroll event landing outside the
+threshold, so the position path satisfied them and they passed with the gesture
+handler unwired entirely. Mutation testing caught it. A test for a
+gesture-derived guard must withhold every other source of evidence.
+
+**Guard against it:** when a check reads shared mutable state, find every writer
+of that state and ask what value it holds *while the check runs* — not what it
+holds in the test. A flag set-and-cleared across frames is continuously set if
+anything re-arms it per frame. And a threshold band is a precondition too: a
+guard that needs N pixels of movement is unreachable if something else resets the
+movement more often than the user can produce N.

--- a/packages/dashboard/src/components/ChatView.test.tsx
+++ b/packages/dashboard/src/components/ChatView.test.tsx
@@ -536,6 +536,357 @@ describe('ChatView', () => {
     vi.useRealTimers()
   })
 
+  // #7399 — scrolling up DURING a live stream.
+  //
+  // The streaming re-pin runs every frame, so two things are true for the whole
+  // duration of a stream: `programmaticScrollRef` is continuously held, and the
+  // view is back at the bottom before the user's next gesture. A trackpad flick
+  // moves ~10-40px per frame, well inside `SCROLL_THRESHOLD` (100px), so the
+  // scroll event the gesture produces reads `atBottom === true` AND
+  // `programmaticScrollRef === true` — and `handleScroll` discards it as
+  // self-induced. The user can never accumulate enough upward movement in a
+  // single frame to escape the threshold, which is the reported "I can't scroll
+  // up, it's forcing me to the bottom".
+  //
+  // The fix reads intent from the GESTURE (wheel / touchmove / key), which is
+  // unambiguously the user regardless of where the scroll lands.
+  //
+  // Prove-it-red shape: every case below streams (`isStreaming`) AND lets frames
+  // tick between gesture steps. A scroll-up while idle passes on the pre-fix
+  // code and proves nothing.
+  describe('user scroll-up during a live stream (#7399)', () => {
+    // A scroll shim that CLAMPS scrollTop to `scrollHeight - clientHeight` the
+    // way a real element does. The older tests here write an unclamped
+    // scrollTop, which makes `scrollHeight - scrollTop - clientHeight` land far
+    // below zero and hides the threshold arithmetic this bug lives in.
+    function installScroller(el: HTMLElement, contentHeight: number, viewport: number) {
+      let height = contentHeight
+      let top = 0
+      const clamp = (v: number) => Math.max(0, Math.min(v, height - viewport))
+      Object.defineProperty(el, 'scrollHeight', { get: () => height, configurable: true })
+      Object.defineProperty(el, 'clientHeight', { get: () => viewport, configurable: true })
+      Object.defineProperty(el, 'scrollTop', {
+        get: () => top,
+        set: (v: number) => { top = clamp(v) },
+        configurable: true,
+      })
+      return {
+        get bottom() { return height - viewport },
+        get top() { return top },
+        /** A stream_delta lands: the content gets taller. */
+        grow(by: number) { height += by },
+        /** The user's input device moves the viewport, then the frame ticks. */
+        drag(by: number) { top = clamp(top + by) },
+      }
+    }
+
+    function renderStreaming() {
+      render(<ChatView messages={makeMessages(3)} isStreaming />)
+      const container = screen.getByTestId('chat-messages')
+      const scroller = installScroller(container, 4000, 400)
+      return { container, scroller }
+    }
+
+    /**
+     * One frame of a real upward trackpad flick: the device moves the viewport
+     * up by `pixels`, the wheel event fires, the browser's scroll step
+     * dispatches the scroll event, and then the frame's RAF callbacks run.
+     */
+    async function wheelUpOneFrame(container: HTMLElement, scroller: ReturnType<typeof installScroller>, pixels: number) {
+      await act(() => {
+        scroller.drag(-pixels)
+        fireEvent.wheel(container, { deltaY: -pixels })
+        fireEvent.scroll(container)
+        vi.advanceTimersByTime(20)
+      })
+    }
+
+    it('holds the reader in place for the rest of the stream after a wheel-up (#7399)', async () => {
+      vi.useFakeTimers()
+      const { container, scroller } = renderStreaming()
+
+      // The stream is live and pinning every frame.
+      await act(() => { vi.advanceTimersByTime(50) })
+      expect(container.scrollTop).toBe(scroller.bottom)
+
+      // A trackpad flick: ten frames at 40px, each one well inside the 100px
+      // at-bottom threshold. Pre-fix the RAF re-pins after every step, so the
+      // user makes exactly zero progress.
+      const start = scroller.bottom
+      for (let i = 0; i < 10; i++) await wheelUpOneFrame(container, scroller, 40)
+      expect(container.scrollTop).toBe(start - 400)
+      expect(screen.getByTestId('scroll-to-bottom')).toBeInTheDocument()
+
+      // The turn keeps streaming for another few seconds — the reader stays put
+      // (the issue's "not just for one frame" control).
+      await act(() => { scroller.grow(1200); vi.advanceTimersByTime(1000) })
+      await act(() => { scroller.grow(1200); vi.advanceTimersByTime(1000) })
+      expect(container.scrollTop).toBe(start - 400)
+      expect(screen.getByTestId('scroll-to-bottom')).toBeInTheDocument()
+      vi.useRealTimers()
+    })
+
+    it('holds the reader in place after a touch drag downward (#7399)', async () => {
+      vi.useFakeTimers()
+      const { container, scroller } = renderStreaming()
+      await act(() => { vi.advanceTimersByTime(50) })
+      const start = scroller.bottom
+
+      // A finger dragging DOWN scrolls the content UP toward history.
+      await act(() => { fireEvent.touchStart(container, { touches: [{ clientX: 0, clientY: 100 }] }) })
+      for (let i = 1; i <= 5; i++) {
+        await act(() => {
+          scroller.drag(-40)
+          fireEvent.touchMove(container, { touches: [{ clientX: 0, clientY: 100 + i * 40 }] })
+          fireEvent.scroll(container)
+          vi.advanceTimersByTime(20)
+        })
+      }
+      expect(container.scrollTop).toBe(start - 200)
+
+      await act(() => { scroller.grow(1200); vi.advanceTimersByTime(1000) })
+      expect(container.scrollTop).toBe(start - 200)
+      vi.useRealTimers()
+    })
+
+    // NOTE the deliberate absence of a `scroll` event here. A page-sized jump
+    // lands well outside SCROLL_THRESHOLD, so firing one would let the POSITION
+    // path set `userScrolledUp` and the test would pass with the key handler
+    // unwired entirely (it did, until the mutation run caught it). In the
+    // browser that path is unreachable anyway: the next frame re-pins before the
+    // event is dispatched, so the event reports the bottom. The key press is the
+    // only evidence the fix is allowed to use, so it is the only one supplied.
+    for (const key of ['ArrowUp', 'PageUp', 'Home']) {
+      it(`holds the reader in place after a ${key} key (#7399)`, async () => {
+        vi.useFakeTimers()
+        const { container, scroller } = renderStreaming()
+        await act(() => { vi.advanceTimersByTime(50) })
+        const start = scroller.bottom
+
+        await act(() => {
+          scroller.drag(-360)
+          fireEvent.keyDown(container, { key })
+          vi.advanceTimersByTime(20)
+        })
+        expect(container.scrollTop).toBe(start - 360)
+
+        await act(() => { scroller.grow(1200); vi.advanceTimersByTime(1000) })
+        expect(container.scrollTop).toBe(start - 360)
+        vi.useRealTimers()
+      })
+    }
+
+    // Leaving the follow and resuming it cannot use the SAME threshold. A 40px
+    // nudge sits inside the 100px "still following" band, so the next scroll
+    // event to arrive with the programmatic flag clear would classify the
+    // reader as at-bottom and hand them straight back to the re-pin loop — the
+    // original bug at small scale, and they could never accumulate past the
+    // band. Resuming therefore requires actually reaching the bottom.
+    it('does not hand a small scroll-up back to the re-pin loop (#7399)', async () => {
+      vi.useFakeTimers()
+      const { container, scroller } = renderStreaming()
+      await act(() => { vi.advanceTimersByTime(50) })
+      const start = scroller.bottom
+
+      await act(() => {
+        scroller.drag(-40)
+        fireEvent.wheel(container, { deltaY: -40 })
+        vi.advanceTimersByTime(20)
+      })
+      // A later frame's scroll event, by which time the programmatic flag the
+      // last pin held has long since cleared.
+      await act(() => { vi.advanceTimersByTime(50) })
+      await act(() => { fireEvent.scroll(container); vi.advanceTimersByTime(50) })
+      expect(container.scrollTop).toBe(start - 40)
+
+      await act(() => { scroller.grow(2000); vi.advanceTimersByTime(200) })
+      expect(container.scrollTop).toBe(start - 40)
+      expect(screen.getByTestId('scroll-to-bottom')).toBeInTheDocument()
+      vi.useRealTimers()
+    })
+
+    // Reaching the bottom again DOES resume the follow — the hysteresis above
+    // must not strand a reader who scrolls back down by hand.
+    it('resumes following when the reader scrolls back to the bottom (#7399)', async () => {
+      vi.useFakeTimers()
+      const { container, scroller } = renderStreaming()
+      await act(() => { vi.advanceTimersByTime(50) })
+
+      for (let i = 0; i < 10; i++) await wheelUpOneFrame(container, scroller, 40)
+      expect(screen.getByTestId('scroll-to-bottom')).toBeInTheDocument()
+
+      await act(() => {
+        scroller.drag(400)
+        fireEvent.wheel(container, { deltaY: 400 })
+        fireEvent.scroll(container)
+        vi.advanceTimersByTime(50)
+      })
+      expect(screen.queryByTestId('scroll-to-bottom')).not.toBeInTheDocument()
+      await act(() => { scroller.grow(2000); vi.advanceTimersByTime(200) })
+      expect(container.scrollTop).toBe(scroller.bottom)
+      vi.useRealTimers()
+    })
+
+    // A native scrollbar-thumb drag emits no wheel/touch/key event at all, so
+    // the gesture handlers cannot see it — the pin has to yield to a held
+    // pointer instead. Without that, each 40px of drag is re-pinned before the
+    // next one lands and the drag never accumulates past SCROLL_THRESHOLD.
+    it('lets a scrollbar-thumb drag accumulate past the at-bottom threshold (#7399)', async () => {
+      vi.useFakeTimers()
+      const { container, scroller } = renderStreaming()
+      await act(() => { vi.advanceTimersByTime(50) })
+      const start = scroller.bottom
+
+      await act(() => { fireEvent.pointerDown(container) })
+      // Four 40px steps: the first three land inside the 100px threshold and are
+      // correctly read as still-at-bottom; the fourth crosses it.
+      for (let i = 0; i < 4; i++) {
+        await act(() => {
+          scroller.drag(-40)
+          fireEvent.scroll(container)
+          vi.advanceTimersByTime(20)
+        })
+      }
+      expect(container.scrollTop).toBe(start - 160)
+      expect(screen.getByTestId('scroll-to-bottom')).toBeInTheDocument()
+
+      // Releasing the thumb must not snap the reader back down.
+      await act(() => { fireEvent.pointerUp(window) })
+      await act(() => { scroller.grow(2000); vi.advanceTimersByTime(500) })
+      expect(container.scrollTop).toBe(start - 160)
+      vi.useRealTimers()
+    })
+
+    // The key path only counts keys that did not come from a text field inside
+    // the list — arrow-key caret movement in an inline input is not a scroll.
+    it('an ArrowUp inside a row text field does not stop the follow (#7399)', async () => {
+      vi.useFakeTimers()
+      render(
+        <ChatView
+          messages={makeMessages(3)}
+          isStreaming
+          renderMessage={(m) => (m.id === 'msg-1' ? <input data-testid="row-input" /> : undefined)}
+        />,
+      )
+      const container = screen.getByTestId('chat-messages')
+      const scroller = installScroller(container, 4000, 400)
+      await act(() => { vi.advanceTimersByTime(50) })
+
+      await act(() => { fireEvent.keyDown(screen.getByTestId('row-input'), { key: 'ArrowUp' }) })
+      await act(() => { scroller.grow(2000); vi.advanceTimersByTime(100) })
+      expect(container.scrollTop).toBe(scroller.bottom)
+      expect(screen.queryByTestId('scroll-to-bottom')).not.toBeInTheDocument()
+      vi.useRealTimers()
+    })
+
+    // Positive control #1 (#4652 / #5954): with no gesture, a stream must keep
+    // the tail in view. This is what the per-frame pin exists for and the fix
+    // must not weaken it.
+    it('still follows the tail while streaming when the user does not scroll (#4652)', async () => {
+      vi.useFakeTimers()
+      const { container, scroller } = renderStreaming()
+      await act(() => { vi.advanceTimersByTime(50) })
+      expect(container.scrollTop).toBe(scroller.bottom)
+
+      await act(() => { scroller.grow(2000); vi.advanceTimersByTime(100) })
+      expect(container.scrollTop).toBe(scroller.bottom)
+      // The pin's own write is what fires a scroll event (growing content does
+      // not move scrollTop, so it fires none) — and that event must still be
+      // recognised as self-induced rather than surfacing the button.
+      await act(() => { scroller.grow(2000); vi.advanceTimersByTime(20) })
+      await act(() => { fireEvent.scroll(container); vi.advanceTimersByTime(100) })
+      expect(container.scrollTop).toBe(scroller.bottom)
+      expect(screen.queryByTestId('scroll-to-bottom')).not.toBeInTheDocument()
+      vi.useRealTimers()
+    })
+
+    // Positive control #2: a DOWNWARD gesture is not a scroll-up. Wheeling down
+    // while already pinned must not stop the follow — otherwise any inertial
+    // tail-ward event would kill streaming auto-scroll.
+    it('a wheel-DOWN gesture does not stop the follow (#7399)', async () => {
+      vi.useFakeTimers()
+      const { container, scroller } = renderStreaming()
+      await act(() => { vi.advanceTimersByTime(50) })
+
+      // Wheeling down at the bottom moves nothing, so it fires NO scroll event —
+      // and that is what makes this control load-bearing: if the wheel handler
+      // ignored the sign, the follow would stop here and the growing tail would
+      // be left behind, with no scroll event to re-clear the flag.
+      for (let i = 0; i < 5; i++) {
+        await act(() => {
+          scroller.grow(200)
+          fireEvent.wheel(container, { deltaY: 40 })
+          vi.advanceTimersByTime(20)
+        })
+      }
+      await act(() => { scroller.grow(2000); vi.advanceTimersByTime(100) })
+      expect(container.scrollTop).toBe(scroller.bottom)
+      expect(screen.queryByTestId('scroll-to-bottom')).not.toBeInTheDocument()
+      vi.useRealTimers()
+    })
+
+    // The touch mirror of the control above: a finger dragging UP (toward the
+    // tail) is not a scroll-up, so it must not stop the follow.
+    it('a touch drag upward does not stop the follow (#7399)', async () => {
+      vi.useFakeTimers()
+      const { container, scroller } = renderStreaming()
+      await act(() => { vi.advanceTimersByTime(50) })
+
+      await act(() => { fireEvent.touchStart(container, { touches: [{ clientX: 0, clientY: 400 }] }) })
+      for (let i = 1; i <= 5; i++) {
+        await act(() => {
+          scroller.grow(200)
+          fireEvent.touchMove(container, { touches: [{ clientX: 0, clientY: 400 - i * 40 }] })
+          vi.advanceTimersByTime(20)
+        })
+      }
+      await act(() => { scroller.grow(2000); vi.advanceTimersByTime(100) })
+      expect(container.scrollTop).toBe(scroller.bottom)
+      expect(screen.queryByTestId('scroll-to-bottom')).not.toBeInTheDocument()
+      vi.useRealTimers()
+    })
+
+    // Positive control #3 (#5780 / #5957): an explicit user action (send,
+    // approve, answer) bumps `scrollToBottomSignal` and must snap back to the
+    // bottom AND resume following, even after a mid-stream scroll-up.
+    it('scrollToBottomSignal still overrides a mid-stream scroll-up and resumes following (#5780)', async () => {
+      vi.useFakeTimers()
+      const { rerender } = render(<ChatView messages={makeMessages(3)} isStreaming scrollToBottomSignal={0} />)
+      const container = screen.getByTestId('chat-messages')
+      const scroller = installScroller(container, 4000, 400)
+      await act(() => { vi.advanceTimersByTime(50) })
+
+      for (let i = 0; i < 5; i++) await wheelUpOneFrame(container, scroller, 40)
+      expect(screen.getByTestId('scroll-to-bottom')).toBeInTheDocument()
+
+      rerender(<ChatView messages={makeMessages(3)} isStreaming scrollToBottomSignal={1} />)
+      await act(() => { vi.advanceTimersByTime(50) })
+      expect(container.scrollTop).toBe(scroller.bottom)
+      expect(screen.queryByTestId('scroll-to-bottom')).not.toBeInTheDocument()
+
+      // ...and the follow is live again for the remainder of the turn.
+      await act(() => { scroller.grow(2000); vi.advanceTimersByTime(100) })
+      expect(container.scrollTop).toBe(scroller.bottom)
+      vi.useRealTimers()
+    })
+
+    // A gesture must only mean "stop following" while the user is reading
+    // history — the scroll-to-bottom button is the way back, and clicking it
+    // has to re-arm the follow even though the wheel handler ran moments ago.
+    it('the scroll-to-bottom button re-arms the follow after a wheel-up (#7399)', async () => {
+      vi.useFakeTimers()
+      const { container, scroller } = renderStreaming()
+      await act(() => { vi.advanceTimersByTime(50) })
+
+      for (let i = 0; i < 5; i++) await wheelUpOneFrame(container, scroller, 40)
+      await act(() => { fireEvent.click(screen.getByTestId('scroll-to-bottom')) })
+      await act(() => { scroller.grow(2000); vi.advanceTimersByTime(100) })
+      expect(container.scrollTop).toBe(scroller.bottom)
+      expect(screen.queryByTestId('scroll-to-bottom')).not.toBeInTheDocument()
+      vi.useRealTimers()
+    })
+  })
+
   // #5954 (occlusion) — when the input area grows (multi-line textarea,
   // attachments, the activity / check-in chips appearing) the `.chat-messages`
   // viewport shrinks, which fires the container's ResizeObserver. While the user

--- a/packages/dashboard/src/components/ChatView.test.tsx
+++ b/packages/dashboard/src/components/ChatView.test.tsx
@@ -649,23 +649,40 @@ describe('ChatView', () => {
       vi.useRealTimers()
     })
 
-    // NOTE the deliberate absence of a `scroll` event here. A page-sized jump
-    // lands well outside SCROLL_THRESHOLD, so firing one would let the POSITION
-    // path set `userScrolledUp` and the test would pass with the key handler
-    // unwired entirely (it did, until the mutation run caught it). In the
-    // browser that path is unreachable anyway: the next frame re-pins before the
-    // event is dispatched, so the event reports the bottom. The key press is the
-    // only evidence the fix is allowed to use, so it is the only one supplied.
+    // Two things about the key cases, both learned the hard way.
+    //
+    // (1) The keydown is dispatched from a FOCUSED DESCENDANT, not from the
+    // container. A keydown targets `document.activeElement`, and `.chat-messages`
+    // is not itself focusable — so firing one straight at the container tests a
+    // path the browser never takes. The path it DOES take is a reader who has
+    // clicked something inside the list (a row's copy button, an expandable tool
+    // row): focus is then inside the scroller, the browser scrolls the nearest
+    // scrollable ancestor — this container — and the keydown bubbles to the
+    // handler. That is the case this covers. Making the scroller itself
+    // focusable is a separate a11y gap, tracked on its own issue.
+    //
+    // (2) No `scroll` event is fired. A page-sized jump lands well outside
+    // SCROLL_THRESHOLD, so one would let the POSITION path set `userScrolledUp`
+    // and the test would pass with the key handler unwired entirely (it did,
+    // until the mutation run caught it). In the browser that path is unreachable
+    // anyway: the next frame re-pins before the event is dispatched, so the
+    // event reports the bottom. The key press is the only evidence the fix is
+    // allowed to use, so it is the only one supplied.
     for (const key of ['ArrowUp', 'PageUp', 'Home']) {
-      it(`holds the reader in place after a ${key} key (#7399)`, async () => {
+      it(`holds the reader in place after a ${key} key from a focused row control (#7399)`, async () => {
         vi.useFakeTimers()
         const { container, scroller } = renderStreaming()
         await act(() => { vi.advanceTimersByTime(50) })
         const start = scroller.bottom
 
+        const rowControl = screen.getAllByTestId('msg-copy-button')[0]
+        expect(container.contains(rowControl)).toBe(true)
+        await act(() => { rowControl.focus() })
+        expect(document.activeElement).toBe(rowControl)
+
         await act(() => {
           scroller.drag(-360)
-          fireEvent.keyDown(container, { key })
+          fireEvent.keyDown(rowControl, { key })
           vi.advanceTimersByTime(20)
         })
         expect(container.scrollTop).toBe(start - 360)

--- a/packages/dashboard/src/components/ChatView.test.tsx
+++ b/packages/dashboard/src/components/ChatView.test.tsx
@@ -675,7 +675,8 @@ describe('ChatView', () => {
         await act(() => { vi.advanceTimersByTime(50) })
         const start = scroller.bottom
 
-        const rowControl = screen.getAllByTestId('msg-copy-button')[0]
+        const [rowControl] = screen.getAllByTestId('msg-copy-button')
+        if (!rowControl) throw new Error('expected a finished response bubble to render a copy button')
         expect(container.contains(rowControl)).toBe(true)
         await act(() => { rowControl.focus() })
         expect(document.activeElement).toBe(rowControl)
@@ -771,6 +772,249 @@ describe('ChatView', () => {
       await act(() => { fireEvent.pointerUp(window) })
       await act(() => { scroller.grow(2000); vi.advanceTimersByTime(500) })
       expect(container.scrollTop).toBe(start - 160)
+      vi.useRealTimers()
+    })
+
+
+    // ---- review findings (#7404) -----------------------------------------
+    //
+    // Every case below is a way the ORIGINAL bug re-entered through a gesture
+    // the first cut did not model, or a way the fix broke the follow it
+    // promised to preserve. Each was reproduced before it was fixed.
+
+    // C1 — a slow drag delivers ~3px per `touchmove` on a 120Hz panel. A
+    // per-event slop rejected every one of them, so 180px of real finger travel
+    // moved nothing and the reader stayed pinned for the whole gesture: #7399
+    // verbatim, on touch.
+    it('a slow touch drag stops the follow even though no single move clears the slop (#7399)', async () => {
+      vi.useFakeTimers()
+      const { container, scroller } = renderStreaming()
+      await act(() => { vi.advanceTimersByTime(50) })
+      const start = scroller.bottom
+
+      await act(() => { fireEvent.touchStart(container, { touches: [{ clientX: 0, clientY: 100 }] }) })
+      for (let i = 1; i <= 60; i++) {
+        await act(() => {
+          scroller.drag(-3)
+          fireEvent.touchMove(container, { touches: [{ clientX: 0, clientY: 100 + i * 3 }] })
+          vi.advanceTimersByTime(8)
+        })
+      }
+      expect(container.scrollTop).toBe(start - 180)
+      expect(screen.getByTestId('scroll-to-bottom')).toBeInTheDocument()
+
+      await act(() => { scroller.grow(2000); vi.advanceTimersByTime(500) })
+      expect(container.scrollTop).toBe(start - 180)
+      vi.useRealTimers()
+    })
+
+    // T1 — the negative control the slop exists for, and which nothing covered:
+    // a finger resting on the list wobbles a few px either way and must never
+    // register. Without the reversal reset, an accumulator would let it creep.
+    it('a resting finger wobbling within the slop does not stop the follow (#7399)', async () => {
+      vi.useFakeTimers()
+      const { container, scroller } = renderStreaming()
+      await act(() => { vi.advanceTimersByTime(50) })
+
+      await act(() => { fireEvent.touchStart(container, { touches: [{ clientX: 0, clientY: 200 }] }) })
+      for (let i = 0; i < 40; i++) {
+        await act(() => {
+          scroller.grow(20)
+          fireEvent.touchMove(container, { touches: [{ clientX: 0, clientY: 200 + (i % 2 === 0 ? 3 : 0) }] })
+          vi.advanceTimersByTime(8)
+        })
+      }
+      expect(container.scrollTop).toBe(scroller.bottom)
+      expect(screen.queryByTestId('scroll-to-bottom')).not.toBeInTheDocument()
+      vi.useRealTimers()
+    })
+
+    // C2 — `.chat-messages` contains its own scrollers: `.question-prompt--multi`
+    // and ToolGroup's result `<pre>`. A wheel inside one moves THAT element, not
+    // the list, but still bubbles here. Reading it as list intent killed the
+    // follow while the list had not moved — and `overscroll-behavior: contain`
+    // means no outer scroll event ever arrives to correct it. Worst in #4652's
+    // own scenario: reading an AskUserQuestion form mid-stream.
+    function renderWithNestedScroller() {
+      render(
+        <ChatView
+          messages={makeMessages(3)}
+          isStreaming
+          renderMessage={(m) => (m.id === 'msg-1'
+            ? <div data-testid="nested-scroller" style={{ overflowY: 'auto', maxHeight: 100 }}>nested</div>
+            : undefined)}
+        />,
+      )
+      const container = screen.getByTestId('chat-messages')
+      const scroller = installScroller(container, 4000, 400)
+      const nested = screen.getByTestId('nested-scroller')
+      Object.defineProperty(nested, 'scrollHeight', { value: 600, configurable: true })
+      Object.defineProperty(nested, 'clientHeight', { value: 100, configurable: true })
+      Object.defineProperty(nested, 'scrollTop', { value: 300, writable: true, configurable: true })
+      return { container, scroller, nested }
+    }
+
+    it('a wheel inside a nested scroller does not stop the outer follow (#7399)', async () => {
+      vi.useFakeTimers()
+      const { container, scroller, nested } = renderWithNestedScroller()
+      await act(() => { vi.advanceTimersByTime(50) })
+
+      // The nested scroller has room above (scrollTop 300), so it consumes the
+      // gesture — the outer list never moves.
+      for (let i = 0; i < 5; i++) {
+        await act(() => { fireEvent.wheel(nested, { deltaY: -40 }); vi.advanceTimersByTime(20) })
+      }
+      await act(() => { scroller.grow(2000); vi.advanceTimersByTime(100) })
+      expect(container.scrollTop).toBe(scroller.bottom)
+      expect(screen.queryByTestId('scroll-to-bottom')).not.toBeInTheDocument()
+      vi.useRealTimers()
+    })
+
+    // ...and the other half of that guard: once the nested scroller is at its
+    // own top it has nothing left to consume, so the gesture belongs to the list
+    // again. A blanket "is there a scroller in the path" check would swallow it.
+    it('a wheel inside a nested scroller already at its top DOES stop the follow (#7399)', async () => {
+      vi.useFakeTimers()
+      const { container, scroller, nested } = renderWithNestedScroller()
+      await act(() => { vi.advanceTimersByTime(50) })
+      const start = scroller.bottom
+      nested.scrollTop = 0
+
+      await act(() => {
+        scroller.drag(-40)
+        fireEvent.wheel(nested, { deltaY: -40 })
+        vi.advanceTimersByTime(20)
+      })
+      expect(container.scrollTop).toBe(start - 40)
+      await act(() => { scroller.grow(2000); vi.advanceTimersByTime(100) })
+      expect(container.scrollTop).toBe(start - 40)
+      vi.useRealTimers()
+    })
+
+    // C3 — a conversation too short to scroll. The wheel moves nothing, but
+    // latching the flag killed the follow for the rest of the session with no
+    // scroll event able to clear it. Pre-fix this gesture was a plain no-op, so
+    // that would be a regression the fix invented.
+    it('a wheel on a list too short to scroll does not stop the follow (#7399)', async () => {
+      vi.useFakeTimers()
+      render(<ChatView messages={makeMessages(3)} isStreaming />)
+      const container = screen.getByTestId('chat-messages')
+      const scroller = installScroller(container, 200, 400)
+      await act(() => { vi.advanceTimersByTime(50) })
+
+      for (let i = 0; i < 5; i++) {
+        await act(() => { fireEvent.wheel(container, { deltaY: -40 }); vi.advanceTimersByTime(20) })
+      }
+      expect(screen.queryByTestId('scroll-to-bottom')).not.toBeInTheDocument()
+
+      // The assistant now streams a long answer — the tail must still be followed.
+      await act(() => { scroller.grow(4000); vi.advanceTimersByTime(200) })
+      expect(container.scrollTop).toBe(scroller.bottom)
+      vi.useRealTimers()
+    })
+
+    // C4 — the pin pause must not be able to latch. A `pointerdown` whose
+    // `pointerup` never arrives (a context menu running a nested event loop, a
+    // release outside the window) would otherwise freeze the view silently:
+    // `userScrolledUp` stays false, so not even the scroll-to-bottom button
+    // appears. The release listeners cover the ordinary endings; the timeout
+    // covers the ones nobody enumerated.
+    it('a pointerdown with no pointerup cannot pause the pin forever (#7399)', async () => {
+      vi.useFakeTimers()
+      const { container, scroller } = renderStreaming()
+      await act(() => { vi.advanceTimersByTime(50) })
+
+      await act(() => { fireEvent.pointerDown(container) })
+      await act(() => { scroller.grow(2000); vi.advanceTimersByTime(500) })
+      // Paused, as designed, while the pointer is (as far as we know) held.
+      expect(container.scrollTop).not.toBe(scroller.bottom)
+
+      // No pointerup ever arrives. The pause still has to end.
+      await act(() => { vi.advanceTimersByTime(11_000) })
+      await act(() => { scroller.grow(200); vi.advanceTimersByTime(100) })
+      expect(container.scrollTop).toBe(scroller.bottom)
+      vi.useRealTimers()
+    })
+
+    // T2 — the load-bearing release test. The thumb-drag case above crosses
+    // SCROLL_THRESHOLD, so `userScrolledUp` is true and the loop is dead
+    // whatever the release does; a mutant that no-oped the release listener
+    // survived it. Here the drag stays INSIDE the band, so the follow is only
+    // paused — and resuming it on release is the whole contract.
+    for (const [label, fire] of [
+      ['pointerup', () => fireEvent.pointerUp(window)],
+      ['pointercancel', () => fireEvent.pointerCancel(window)],
+      ['mouseup', () => fireEvent.mouseUp(window)],
+    ] as const) {
+      it(`${label} resumes the pin after a sub-threshold pointer drag (#7399)`, async () => {
+        vi.useFakeTimers()
+        const { container, scroller } = renderStreaming()
+        await act(() => { vi.advanceTimersByTime(50) })
+
+        await act(() => { fireEvent.pointerDown(container) })
+        await act(() => {
+          scroller.drag(-40)
+          fireEvent.scroll(container)
+          vi.advanceTimersByTime(20)
+        })
+        // Inside the 100px band, so the reader is NOT classified as scrolled up —
+        // the pin is merely paused.
+        expect(screen.queryByTestId('scroll-to-bottom')).not.toBeInTheDocument()
+        expect(container.scrollTop).toBe(scroller.bottom - 40)
+
+        await act(() => { fire() })
+        await act(() => { scroller.grow(2000); vi.advanceTimersByTime(100) })
+        expect(container.scrollTop).toBe(scroller.bottom)
+        vi.useRealTimers()
+      })
+    }
+
+    // S1 — the resume window cannot be position-only. A reader who scrolls hard
+    // to the bottom lands there, but the stream appends before the handler runs,
+    // so the position reports "30px short of a bottom that moved" and they are
+    // stranded for the rest of the turn with no further event coming.
+    it('resumes the follow when a tail-ward gesture lands short of a bottom that moved (#7399)', async () => {
+      vi.useFakeTimers()
+      const { container, scroller } = renderStreaming()
+      await act(() => { vi.advanceTimersByTime(50) })
+
+      for (let i = 0; i < 10; i++) await wheelUpOneFrame(container, scroller, 40)
+      expect(screen.getByTestId('scroll-to-bottom')).toBeInTheDocument()
+
+      // The reader wheels hard back to the tail and lands on the bottom — but a
+      // stream_delta commits 30px of new content before the handler runs.
+      await act(() => {
+        scroller.drag(1000)
+        fireEvent.wheel(container, { deltaY: 1000 })
+        scroller.grow(30)
+        fireEvent.scroll(container)
+        vi.advanceTimersByTime(50)
+      })
+      expect(screen.queryByTestId('scroll-to-bottom')).not.toBeInTheDocument()
+      await act(() => { scroller.grow(2000); vi.advanceTimersByTime(200) })
+      expect(container.scrollTop).toBe(scroller.bottom)
+      vi.useRealTimers()
+    })
+
+    // ...and the intent must not override the position wholesale: a tail-ward
+    // gesture that leaves the reader far from the bottom is still not following.
+    it('a tail-ward gesture far from the bottom does not resume the follow (#7399)', async () => {
+      vi.useFakeTimers()
+      const { container, scroller } = renderStreaming()
+      await act(() => { vi.advanceTimersByTime(50) })
+
+      for (let i = 0; i < 20; i++) await wheelUpOneFrame(container, scroller, 40)
+      const parked = container.scrollTop
+
+      await act(() => {
+        scroller.drag(100)
+        fireEvent.wheel(container, { deltaY: 100 })
+        fireEvent.scroll(container)
+        vi.advanceTimersByTime(50)
+      })
+      expect(screen.getByTestId('scroll-to-bottom')).toBeInTheDocument()
+      await act(() => { scroller.grow(2000); vi.advanceTimersByTime(200) })
+      expect(container.scrollTop).toBe(parked + 100)
       vi.useRealTimers()
     })
 

--- a/packages/dashboard/src/components/ChatView.tsx
+++ b/packages/dashboard/src/components/ChatView.tsx
@@ -253,6 +253,34 @@ const TYPE_CLASS: Record<string, string> = {
 const SCROLL_THRESHOLD = 100
 
 /**
+ * #7399 — minimum per-event finger travel (px) that counts as a deliberate
+ * touch drag rather than the jitter of a finger resting on the list.
+ */
+const TOUCH_INTENT_SLOP = 4
+
+/**
+ * #7399 — keys that scroll the list toward history. A key press is read as
+ * scroll INTENT directly, because the position it produces is not usable
+ * evidence while the streaming re-pin loop is running (see `handleWheel`).
+ */
+const SCROLL_UP_KEYS = new Set(['ArrowUp', 'PageUp', 'Home'])
+
+/**
+ * #7399 — how close to the bottom (px) the viewport must get before a reader
+ * who scrolled up is considered to be FOLLOWING again.
+ *
+ * Deliberately much tighter than SCROLL_THRESHOLD: the two directions cannot
+ * share a threshold. Leaving the follow uses the wide band (a small nudge off
+ * the bottom is still "following the conversation"), but resuming it on the
+ * same band re-opens this bug at small scale — a 40px scroll-up lands INSIDE
+ * the band, so the next scroll event would classify the reader as at-bottom,
+ * hand them back to the re-pin loop, and they could never accumulate enough
+ * movement to escape. A few px of slack absorbs sub-pixel scrollTop rounding;
+ * anything more is a user who has not actually returned to the bottom.
+ */
+const RESUME_FOLLOW_THRESHOLD = 8
+
+/**
  * #6788 — headroom (px) left above a search match when the list scrolls to it,
  * so the matched row lands just below the top edge rather than flush against it
  * (mirrors the mobile `y - 80` headroom / `viewPosition: 0` landing).
@@ -531,12 +559,22 @@ function ChatViewImpl({ messages, isStreaming, isBusy, chatActivityState, inFlig
     return positions
   }, [messages, queuedIds])
 
-  const [userScrolledUp, setUserScrolledUp] = useState(false)
+  const [userScrolledUp, setUserScrolledUpState] = useState(false)
   const programmaticScrollRef = useRef(false)
   // #5954 — a ref mirror of `userScrolledUp` so the ResizeObserver callback can
   // read the live follow-state without re-subscribing the observer every time
-  // the user crosses the bottom threshold. Kept in sync by the effect below.
+  // the user crosses the bottom threshold.
+  //
+  // #7399 — the mirror is now also the SYNCHRONOUS source of truth for the
+  // streaming re-pin loop, which has to stop within the same tick the user's
+  // gesture arrives: a `setState` only lands a render later, and the loop pins
+  // to the bottom on every frame in between. `setScrolledUp` below is the ONLY
+  // writer of either — a write to one without the other is how the two drift.
   const userScrolledUpRef = useRef(false)
+  const setScrolledUp = useCallback((next: boolean) => {
+    userScrolledUpRef.current = next
+    setUserScrolledUpState(next)
+  }, [])
 
   // #5561 — scroll-anchor compensation state. WKWebView (the Tauri desktop's
   // engine, and the dashboard's PRIMARY consumer) does NOT implement default
@@ -683,10 +721,91 @@ function ChatViewImpl({ messages, isStreaming, isBusy, chatActivityState, inFlig
     // layout change.
     setScrollTop(el.scrollTop)
     setViewportHeight(el.clientHeight)
-    const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < SCROLL_THRESHOLD
+    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight
+    const atBottom = distanceFromBottom < SCROLL_THRESHOLD
     // During programmatic scrolls, only update if we're at bottom (don't falsely set scrolledUp)
     if (programmaticScrollRef.current && atBottom) return
-    setUserScrolledUp(!atBottom)
+    // #7399 — asymmetric thresholds (see RESUME_FOLLOW_THRESHOLD). A reader who
+    // has already left the bottom only rejoins the follow by actually reaching
+    // it; the wide band decides the leaving direction only.
+    if (userScrolledUpRef.current) {
+      if (distanceFromBottom <= RESUME_FOLLOW_THRESHOLD) setScrolledUp(false)
+      return
+    }
+    setScrolledUp(!atBottom)
+  }, [setScrolledUp])
+
+  // #7399 — read the user's scroll INTENT from the input gesture, not from the
+  // scroll position the gesture produced.
+  //
+  // Position is not usable evidence while streaming. The re-pin loop below runs
+  // every frame, so by the time a gesture's `scroll` event is dispatched the
+  // view is already back at the bottom and `programmaticScrollRef` is still
+  // held — and a trackpad flick only moves ~10-40px per frame, an order of
+  // magnitude inside SCROLL_THRESHOLD. `handleScroll` therefore reads
+  // `programmatic && atBottom` and discards a genuine user gesture, and the
+  // user can never accumulate enough movement in a single frame to escape the
+  // threshold. That is the reported "I can't scroll up, it's forcing me to the
+  // bottom": the guard is not wrong, it is unreachable.
+  //
+  // A wheel / touch / key event with an upward delta is unambiguously the user
+  // whatever position it lands on, so it is the ground truth. It writes through
+  // `setScrolledUp`, which stops the loop in the SAME tick via the ref — a
+  // render later would be too late, because the frames in between would pin the
+  // reader's position away before the effect could tear the loop down.
+  const markScrolledUpByGesture = useCallback(() => {
+    if (userScrolledUpRef.current) return
+    setScrolledUp(true)
+  }, [setScrolledUp])
+
+  const handleWheel = useCallback((e: React.WheelEvent<HTMLDivElement>) => {
+    if (e.deltaY < 0) markScrolledUpByGesture()
+  }, [markScrolledUpByGesture])
+
+  // A finger dragging DOWN the screen scrolls the content UP toward history.
+  // Compared against the PREVIOUS move (not the touch's origin) so a direction
+  // reversal mid-drag is seen immediately; TOUCH_INTENT_SLOP keeps a resting
+  // finger's jitter from registering as a deliberate drag.
+  const touchYRef = useRef<number | null>(null)
+  const handleTouchStart = useCallback((e: React.TouchEvent<HTMLDivElement>) => {
+    touchYRef.current = e.touches[0]?.clientY ?? null
+  }, [])
+  const handleTouchMove = useCallback((e: React.TouchEvent<HTMLDivElement>) => {
+    const y = e.touches[0]?.clientY
+    if (y === undefined) return
+    const last = touchYRef.current
+    touchYRef.current = y
+    if (last !== null && y - last > TOUCH_INTENT_SLOP) markScrolledUpByGesture()
+  }, [markScrolledUpByGesture])
+
+  // Keys only count when they did not come from a text field inside the list —
+  // an inline input's arrow-key caret movement is not a scroll.
+  const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (!SCROLL_UP_KEYS.has(e.key)) return
+    const target = e.target as HTMLElement | null
+    if (target && (target.isContentEditable || /^(?:INPUT|TEXTAREA|SELECT)$/.test(target.tagName))) return
+    markScrolledUpByGesture()
+  }, [markScrolledUpByGesture])
+
+  // #7399 — a native scrollbar-thumb drag emits no wheel/touch/key event, so
+  // the handlers above cannot see it; the loop and the user just fight over
+  // `scrollTop` every frame and the user loses. While a pointer is held down on
+  // the scroller we therefore PAUSE the pin instead of classifying anything.
+  // With no writes in flight `programmaticScrollRef` clears, `handleScroll`'s
+  // position logic becomes reachable again, and the drag accumulates until it
+  // crosses SCROLL_THRESHOLD and registers normally. Deliberately not a
+  // classification: a plain click that moves nothing simply resumes following
+  // when the button comes back up.
+  const pointerDownRef = useRef(false)
+  const handlePointerDown = useCallback(() => { pointerDownRef.current = true }, [])
+  useEffect(() => {
+    const release = () => { pointerDownRef.current = false }
+    window.addEventListener('pointerup', release)
+    window.addEventListener('pointercancel', release)
+    return () => {
+      window.removeEventListener('pointerup', release)
+      window.removeEventListener('pointercancel', release)
+    }
   }, [])
 
   // The bare "snap to bottom" primitive shared by the mount, count-follow, and
@@ -708,8 +827,8 @@ function ChatViewImpl({ messages, isStreaming, isBusy, chatActivityState, inFlig
 
   const scrollToBottom = useCallback(() => {
     scrollToBottomNow()
-    setUserScrolledUp(false)
-  }, [scrollToBottomNow])
+    setScrolledUp(false)
+  }, [scrollToBottomNow, setScrolledUp])
 
   // Scroll to the bottom on initial mount so switching back to the chat
   // tab always lands on the most-recent message above the input bar.
@@ -723,13 +842,6 @@ function ChatViewImpl({ messages, isStreaming, isBusy, chatActivityState, inFlig
     // so the first render after layout has an accurate viewport height.
     syncGeometry()
   }, [syncGeometry, scrollToBottomNow])
-
-  // #5954 — mirror `userScrolledUp` into a ref so the ResizeObserver callback
-  // (which we don't want to re-subscribe on every threshold crossing) reads the
-  // current follow-state.
-  useEffect(() => {
-    userScrolledUpRef.current = userScrolledUp
-  }, [userScrolledUp])
 
   // #5561 — keep the windowed range correct when the container resizes (panel
   // split drag, window resize, sidebar toggle) without a scroll event firing.
@@ -871,9 +983,9 @@ function ChatViewImpl({ messages, isStreaming, isBusy, chatActivityState, inFlig
   useEffect(() => {
     if (scrollToBottomSignal === lastScrollSignalRef.current) return
     lastScrollSignalRef.current = scrollToBottomSignal
-    setUserScrolledUp(false)
+    setScrolledUp(false)
     requestAnimationFrame(() => { scrollToBottomNow() })
-  }, [scrollToBottomSignal, scrollToBottomNow])
+  }, [scrollToBottomSignal, scrollToBottomNow, setScrolledUp])
 
   // During streaming, continuously re-pin to the bottom via RAF so the growing
   // tail stays in view. #5954: reuse `scrollToBottomNow()` rather than an inline
@@ -887,13 +999,25 @@ function ChatViewImpl({ messages, isStreaming, isBusy, chatActivityState, inFlig
   // below the fold ("doesn't consistently stay at the bottom"). `scrollToBottomNow`
   // holds the flag until the next frame, so `handleScroll`'s
   // `programmaticScrollRef.current && atBottom` guard reliably ignores the
-  // self-induced events while a genuine user scroll-up (atBottom false) is still
-  // honored.
+  // self-induced events.
+  //
+  // #7399 — this comment used to end by claiming "a genuine user scroll-up
+  // (atBottom false) is still honored". It was exactly backwards: because the
+  // loop re-pins every frame, `atBottom false` is the state it makes
+  // unreachable, and a user scrolling up during a long turn was pinned to the
+  // bottom for the whole stream. User intent now comes from the GESTURE
+  // handlers above, not from the position, and the tick re-reads the REF so a
+  // gesture stops the pinning in the same tick rather than a render later.
   useEffect(() => {
     if (!isStreaming || userScrolledUp) return
     let rafId: number
     const tick = () => {
-      scrollToBottomNow()
+      // Stop for good: a gesture flipped the ref, and the state update that
+      // tears this effect down is still a render away.
+      if (userScrolledUpRef.current) return
+      // Yield to a pointer the user is holding on the scroller (thumb drag) —
+      // keep the loop alive so following resumes on release.
+      if (!pointerDownRef.current) scrollToBottomNow()
       rafId = requestAnimationFrame(tick)
     }
     rafId = requestAnimationFrame(tick)
@@ -948,7 +1072,7 @@ function ChatViewImpl({ messages, isStreaming, isBusy, chatActivityState, inFlig
   useEffect(() => {
     if (!searchMatchId) return
     if (!containerRef.current) return
-    setUserScrolledUp(true)
+    setScrolledUp(true)
     const index = dedupRef.current.findIndex((m) => m.id === searchMatchId)
     if (index < 0) return
     scrollToRowIndex(index)
@@ -966,7 +1090,7 @@ function ChatViewImpl({ messages, isStreaming, isBusy, chatActivityState, inFlig
         programmaticScrollRef.current = false
       }
     }
-  }, [searchMatchId, scrollToRowIndex])
+  }, [searchMatchId, scrollToRowIndex, setScrolledUp])
 
   // #5561 — the windowed slice. Only rows in [startIndex, endIndex) mount; the
   // top/bottom spacers reserve the height of the skipped rows so the scrollbar
@@ -1000,6 +1124,11 @@ function ChatViewImpl({ messages, isStreaming, isBusy, chatActivityState, inFlig
           className="chat-messages"
           data-testid="chat-messages"
           onScroll={handleScroll}
+          onWheel={handleWheel}
+          onTouchStart={handleTouchStart}
+          onTouchMove={handleTouchMove}
+          onKeyDown={handleKeyDown}
+          onPointerDown={handlePointerDown}
         >
           {/* Top spacer — reserves the height of windowed-out leading rows. The
               `flex: 0 0 auto` style keeps it from being squeezed by the flex

--- a/packages/dashboard/src/components/ChatView.tsx
+++ b/packages/dashboard/src/components/ChatView.tsx
@@ -780,6 +780,18 @@ function ChatViewImpl({ messages, isStreaming, isBusy, chatActivityState, inFlig
 
   // Keys only count when they did not come from a text field inside the list —
   // an inline input's arrow-key caret movement is not a scroll.
+  //
+  // PRECONDITION, and it is a narrow one: a keydown targets
+  // `document.activeElement`, and this container is not itself focusable, so
+  // this handler is only reached when focus is already INSIDE the list — a
+  // reader who clicked a row's copy button or an expandable tool row
+  // (`ToolBubble` carries role=button + tabIndex=0). That is also exactly the
+  // state in which the browser scrolls this container rather than the document,
+  // so the handler is useful precisely where it is reachable. With focus on
+  // `body` the keys do not scroll the conversation at all today — a real
+  // keyboard-access gap, but a pre-existing one that wants the whole scroller in
+  // the tab order, so it is tracked separately in #7406 rather than smuggled
+  // into a scroll-behaviour fix.
   const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
     if (!SCROLL_UP_KEYS.has(e.key)) return
     const target = e.target as HTMLElement | null

--- a/packages/dashboard/src/components/ChatView.tsx
+++ b/packages/dashboard/src/components/ChatView.tsx
@@ -253,17 +253,47 @@ const TYPE_CLASS: Record<string, string> = {
 const SCROLL_THRESHOLD = 100
 
 /**
- * #7399 — minimum per-event finger travel (px) that counts as a deliberate
+ * #7399 — minimum ACCUMULATED finger travel (px) that counts as a deliberate
  * touch drag rather than the jitter of a finger resting on the list.
+ *
+ * Accumulated, not per-event: a slow drag on a 120Hz panel delivers ~3px per
+ * `touchmove`, so a per-event comparison rejected every one of them and the
+ * reader stayed pinned for the whole gesture — this bug, unfixed, on touch.
+ *
+ * The accumulator is plain NET signed travel since `touchstart`, with no
+ * reversal reset. A reset was written first and then removed: a symmetric
+ * wobble nets ~zero with or without it, and an asymmetric one is real travel
+ * that should register — so no test could tell the two implementations apart,
+ * and a mutant that deleted the reset survived the whole suite. An untestable
+ * refinement is not a guard.
  */
 const TOUCH_INTENT_SLOP = 4
 
 /**
- * #7399 — keys that scroll the list toward history. A key press is read as
- * scroll INTENT directly, because the position it produces is not usable
- * evidence while the streaming re-pin loop is running (see `handleWheel`).
+ * #7399 — keys that scroll the list toward history, and toward the tail. A key
+ * press is read as INTENT directly, because the position it produces is not
+ * usable evidence while the streaming re-pin loop is running (see
+ * `handleWheel`). `Space`/`Shift+Space` are deliberately absent: Space
+ * activates a focused control, and every reachable target here (a row's copy
+ * button, an expandable tool row) is one.
  */
 const SCROLL_UP_KEYS = new Set(['ArrowUp', 'PageUp', 'Home'])
+const SCROLL_DOWN_KEYS = new Set(['ArrowDown', 'PageDown', 'End'])
+
+/** Sub-pixel slack when comparing scroll geometry. */
+const SCROLL_EPSILON = 1
+
+/**
+ * #7399 review — hard ceiling on the pin pause a held pointer opens. The
+ * release listeners below cover every ordinary ending, but a `pointerdown`
+ * whose `pointerup` never arrives (a context menu that runs a nested event
+ * loop, a drag released outside the window, an engine that dispatches the
+ * press but not the release) would otherwise pause the pin FOREVER — and
+ * silently, since `userScrolledUp` stays false so no scroll-to-bottom button
+ * appears. A pause that cannot latch is worth more than one that is merely
+ * unlikely to.
+ */
+const POINTER_PAUSE_MAX_MS = 10_000
 
 /**
  * #7399 — how close to the bottom (px) the viewport must get before a reader
@@ -279,6 +309,53 @@ const SCROLL_UP_KEYS = new Set(['ArrowUp', 'PageUp', 'Home'])
  * anything more is a user who has not actually returned to the bottom.
  */
 const RESUME_FOLLOW_THRESHOLD = 8
+
+/**
+ * #7399 review — did a scroller INSIDE the list consume this gesture?
+ *
+ * `.chat-messages` contains scrollable descendants: `.question-prompt--multi`
+ * (`max-height: 60vh; overflow-y: auto; overscroll-behavior: contain`) and
+ * `ToolGroup`'s result `<pre>` (`max-height: 180px; overflow: auto`). A wheel
+ * or touch inside one of those moves that element, not the list — but the
+ * event still bubbles to the list's handlers. Reading it as list-scroll intent
+ * killed the auto-follow while the list had not moved a pixel, and
+ * `overscroll-behavior: contain` means no outer `scroll` event ever arrives to
+ * correct the mistake. That is worst in exactly the #4652 scenario: reading an
+ * AskUserQuestion form mid-stream.
+ *
+ * A nested scroller only consumes the gesture while it can still move in that
+ * direction; once it is at its own end the event legitimately belongs to the
+ * list, which is why the check is direction-aware rather than a blanket
+ * "is there a scroller in the path".
+ */
+function consumedByNestedScroller(target: EventTarget | null, container: HTMLElement, up: boolean): boolean {
+  let node = target instanceof Element ? target : null
+  while (node && node !== container) {
+    if (node.scrollHeight - node.clientHeight > SCROLL_EPSILON) {
+      const overflowY = getComputedStyle(node).overflowY
+      if (overflowY === 'auto' || overflowY === 'scroll') {
+        const room = up
+          ? node.scrollTop > SCROLL_EPSILON
+          : node.scrollTop < node.scrollHeight - node.clientHeight - SCROLL_EPSILON
+        if (room) return true
+      }
+    }
+    node = node.parentElement
+  }
+  return false
+}
+
+/**
+ * #7399 review — ArrowUp is caret movement, not scrolling, inside a text entry
+ * or a widget that owns arrow-key navigation.
+ */
+function isTextEntryTarget(el: HTMLElement | null): boolean {
+  if (!el) return false
+  if (el.isContentEditable) return true
+  if (/^(?:INPUT|TEXTAREA|SELECT)$/.test(el.tagName)) return true
+  const role = el.getAttribute('role')
+  return role === 'textbox' || role === 'combobox' || role === 'listbox' || role === 'menu' || role === 'menuitem'
+}
 
 /**
  * #6788 — headroom (px) left above a search match when the list scrolls to it,
@@ -729,7 +806,16 @@ function ChatViewImpl({ messages, isStreaming, isBusy, chatActivityState, inFlig
     // has already left the bottom only rejoins the follow by actually reaching
     // it; the wide band decides the leaving direction only.
     if (userScrolledUpRef.current) {
-      if (distanceFromBottom <= RESUME_FOLLOW_THRESHOLD) setScrolledUp(false)
+      // Two ways back into the follow, and the second one is why gestures are
+      // tracked in both directions. Reaching the bottom is the position proof;
+      // a deliberate tail-ward gesture that lands inside the follow band is the
+      // INTENT proof, and it is needed because the stream can append content
+      // between the reader's gesture and this event — leaving them a few px
+      // short of a bottom that moved, and stranded for the rest of the turn.
+      if (distanceFromBottom <= RESUME_FOLLOW_THRESHOLD || (followIntentRef.current && atBottom)) {
+        followIntentRef.current = false
+        setScrolledUp(false)
+      }
       return
     }
     setScrolledUp(!atBottom)
@@ -753,33 +839,69 @@ function ChatViewImpl({ messages, isStreaming, isBusy, chatActivityState, inFlig
   // `setScrolledUp`, which stops the loop in the SAME tick via the ref — a
   // render later would be too late, because the frames in between would pin the
   // reader's position away before the effect could tear the loop down.
+  // #7399 review — the mirror image, and the reason it exists: a reader who
+  // deliberately scrolls back toward the tail is ASKING to follow again.
+  // Position alone cannot tell "stopped 8px short" from "reached the bottom and
+  // the stream appended 30px between the gesture and this event", and the
+  // second case stranded them for the rest of the turn. Recorded as intent and
+  // consumed by `handleScroll`, which still requires the position to be inside
+  // the follow band before it acts on it.
+  const followIntentRef = useRef(false)
+  const markFollowIntentByGesture = useCallback(() => {
+    followIntentRef.current = true
+  }, [])
+
+  // #7399 review — a gesture only means "stop following" on a list that can
+  // actually scroll. On a short conversation the wheel moves nothing, but
+  // latching the flag would kill the follow for the rest of the session with no
+  // scroll event able to clear it — and pre-fix these gestures were plain
+  // no-ops, so that would be a regression invented by the fix.
   const markScrolledUpByGesture = useCallback(() => {
+    const el = containerRef.current
+    if (!el || el.scrollHeight - el.clientHeight <= SCROLL_EPSILON) return
+    followIntentRef.current = false
     if (userScrolledUpRef.current) return
     setScrolledUp(true)
   }, [setScrolledUp])
 
   const handleWheel = useCallback((e: React.WheelEvent<HTMLDivElement>) => {
-    if (e.deltaY < 0) markScrolledUpByGesture()
-  }, [markScrolledUpByGesture])
+    if (e.deltaY === 0) return
+    const el = containerRef.current
+    if (!el) return
+    const up = e.deltaY < 0
+    if (consumedByNestedScroller(e.target, el, up)) return
+    if (up) markScrolledUpByGesture()
+    else markFollowIntentByGesture()
+  }, [markScrolledUpByGesture, markFollowIntentByGesture])
 
   // A finger dragging DOWN the screen scrolls the content UP toward history.
-  // Compared against the PREVIOUS move (not the touch's origin) so a direction
-  // reversal mid-drag is seen immediately; TOUCH_INTENT_SLOP keeps a resting
-  // finger's jitter from registering as a deliberate drag.
+  // Travel is ACCUMULATED across moves (see TOUCH_INTENT_SLOP), so a slow
+  // deliberate drag registers while a resting finger's wobble never does.
   const touchYRef = useRef<number | null>(null)
+  const touchTravelRef = useRef(0)
   const handleTouchStart = useCallback((e: React.TouchEvent<HTMLDivElement>) => {
     touchYRef.current = e.touches[0]?.clientY ?? null
+    touchTravelRef.current = 0
   }, [])
   const handleTouchMove = useCallback((e: React.TouchEvent<HTMLDivElement>) => {
     const y = e.touches[0]?.clientY
     if (y === undefined) return
     const last = touchYRef.current
     touchYRef.current = y
-    if (last !== null && y - last > TOUCH_INTENT_SLOP) markScrolledUpByGesture()
-  }, [markScrolledUpByGesture])
+    if (last === null) return
+    const dy = y - last
+    if (dy === 0) return
+    touchTravelRef.current += dy
+    const el = containerRef.current
+    if (!el) return
+    const up = touchTravelRef.current > 0
+    if (consumedByNestedScroller(e.target, el, up)) return
+    if (touchTravelRef.current > TOUCH_INTENT_SLOP) markScrolledUpByGesture()
+    else if (touchTravelRef.current < -TOUCH_INTENT_SLOP) markFollowIntentByGesture()
+  }, [markScrolledUpByGesture, markFollowIntentByGesture])
 
-  // Keys only count when they did not come from a text field inside the list —
-  // an inline input's arrow-key caret movement is not a scroll.
+  // Keys only count when they did not come from a text entry or an arrow-key
+  // widget inside the list — that is caret movement, not scrolling.
   //
   // PRECONDITION, and it is a narrow one: a keydown targets
   // `document.activeElement`, and this container is not itself focusable, so
@@ -793,11 +915,16 @@ function ChatViewImpl({ messages, isStreaming, isBusy, chatActivityState, inFlig
   // the tab order, so it is tracked separately in #7406 rather than smuggled
   // into a scroll-behaviour fix.
   const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
-    if (!SCROLL_UP_KEYS.has(e.key)) return
+    const up = SCROLL_UP_KEYS.has(e.key)
+    if (!up && !SCROLL_DOWN_KEYS.has(e.key)) return
     const target = e.target as HTMLElement | null
-    if (target && (target.isContentEditable || /^(?:INPUT|TEXTAREA|SELECT)$/.test(target.tagName))) return
-    markScrolledUpByGesture()
-  }, [markScrolledUpByGesture])
+    if (isTextEntryTarget(target)) return
+    const el = containerRef.current
+    if (!el) return
+    if (consumedByNestedScroller(e.target, el, up)) return
+    if (up) markScrolledUpByGesture()
+    else markFollowIntentByGesture()
+  }, [markScrolledUpByGesture, markFollowIntentByGesture])
 
   // #7399 — a native scrollbar-thumb drag emits no wheel/touch/key event, so
   // the handlers above cannot see it; the loop and the user just fight over
@@ -808,17 +935,45 @@ function ChatViewImpl({ messages, isStreaming, isBusy, chatActivityState, inFlig
   // crosses SCROLL_THRESHOLD and registers normally. Deliberately not a
   // classification: a plain click that moves nothing simply resumes following
   // when the button comes back up.
+  //
+  // This is BEST EFFORT and is written down as such rather than asserted:
+  // whether an engine dispatches pointer events for a press on a native
+  // scrollbar is engine-specific, and WKWebView — the Tauri desktop's engine —
+  // is the one this is least certain of. Where it does not fire, the thumb drag
+  // falls back to the pre-existing position path (a drag crossing
+  // SCROLL_THRESHOLD in one frame still registers), exactly as it did before
+  // this PR. It can only add coverage; it cannot take any away. The bounded
+  // pause (POINTER_PAUSE_MAX_MS) is what makes "can only add" true.
   const pointerDownRef = useRef(false)
-  const handlePointerDown = useCallback(() => { pointerDownRef.current = true }, [])
-  useEffect(() => {
-    const release = () => { pointerDownRef.current = false }
-    window.addEventListener('pointerup', release)
-    window.addEventListener('pointercancel', release)
-    return () => {
-      window.removeEventListener('pointerup', release)
-      window.removeEventListener('pointercancel', release)
+  const pointerPauseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const releasePointerPause = useCallback(() => {
+    pointerDownRef.current = false
+    if (pointerPauseTimerRef.current !== null) {
+      clearTimeout(pointerPauseTimerRef.current)
+      pointerPauseTimerRef.current = null
     }
   }, [])
+  const handlePointerDown = useCallback(() => {
+    pointerDownRef.current = true
+    if (pointerPauseTimerRef.current !== null) clearTimeout(pointerPauseTimerRef.current)
+    pointerPauseTimerRef.current = setTimeout(releasePointerPause, POINTER_PAUSE_MAX_MS)
+  }, [releasePointerPause])
+  useEffect(() => {
+    const release = () => { releasePointerPause() }
+    const onVisibility = () => { if (document.visibilityState === 'hidden') releasePointerPause() }
+    // Capture phase: a `stopPropagation` anywhere in the app must not be able to
+    // hide the release from us — that is precisely how the pause would latch.
+    // `mouseup` is listed alongside `pointerup` as the fallback for an engine
+    // that dispatches the compatibility mouse event but not the pointer one.
+    const events = ['pointerup', 'pointercancel', 'mouseup', 'blur', 'contextmenu'] as const
+    for (const type of events) window.addEventListener(type, release, true)
+    document.addEventListener('visibilitychange', onVisibility, true)
+    return () => {
+      for (const type of events) window.removeEventListener(type, release, true)
+      document.removeEventListener('visibilitychange', onVisibility, true)
+      releasePointerPause()
+    }
+  }, [releasePointerPause])
 
   // The bare "snap to bottom" primitive shared by the mount, count-follow, and
   // scrollToBottomSignal effects: flag the write as programmatic (so the
@@ -878,7 +1033,11 @@ function ChatViewImpl({ messages, isStreaming, isBusy, chatActivityState, inFlig
     if (!el || typeof ResizeObserver === 'undefined') return
     const ro = new ResizeObserver(() => {
       syncGeometry()
-      if (!userScrolledUpRef.current) scrollToBottomNow()
+      // #7399 review — yield to a held pointer for the same reason the streaming
+      // tick does: a thumb drag held while the input area grows would otherwise
+      // be yanked to the bottom mid-drag, which is the one case the pause exists
+      // to prevent.
+      if (!userScrolledUpRef.current && !pointerDownRef.current) scrollToBottomNow()
     })
     ro.observe(el)
     return () => ro.disconnect()


### PR DESCRIPTION
Closes #7399

## The bug

The streaming re-pin loop (`ChatView.tsx`) ran unconditionally every frame for the whole duration of a stream. That made the existing "don't yank a reader who scrolled up" guard (#4652 / AC3) **unreachable**, not wrong:

- `scrollToBottomNow()` sets `programmaticScrollRef` and clears it on the *next* frame, so a loop that re-arms every frame holds it continuously.
- A trackpad flick moves ~10–40px per frame — an order of magnitude inside `SCROLL_THRESHOLD` (100px).
- So every gesture reached `handleScroll` as `programmatic && atBottom` and was discarded as self-induced. The user could never accumulate enough movement in a *single* frame to escape the threshold, because each frame's pin threw the previous frame's progress away.

That is the reported "because the streaming is coming in… I can't scroll up. It's forcing me to the bottom", and it scales with turn length.

## The fix — option 2 from the issue

Intent is read from the **gesture**, not from a position the loop itself controls:

| | |
|---|---|
| `onWheel` | `deltaY < 0` → scrolled up. Direction-checked, so wheeling down never stops the follow. |
| `onTouchStart`/`onTouchMove` | a finger dragging *down* scrolls content up; compared against the previous move with a 4px slop so a resting finger's jitter doesn't count. |
| `onKeyDown` | `ArrowUp` / `PageUp` / `Home`, ignored when the event came from a text field inside the list. |
| `onPointerDown` | a native scrollbar-thumb drag emits none of the above, so a held pointer **pauses** the pin (it does not classify). With no writes in flight `programmaticScrollRef` clears, the position path becomes reachable again, and the drag accumulates. |

Two supporting changes the fix does not work without:

- **One setter for the flag.** `setScrolledUp` writes the ref *and* the state, and the RAF tick re-reads the **ref** — so a gesture stops the pinning in the same tick. A `setState` alone lands a render later, and the frames in between pin the reader's position away before the effect can tear the loop down. The old ref-mirroring effect is gone; two writers is how a mirror drifts.
- **Asymmetric thresholds.** Resuming the follow now requires actually reaching the bottom (`RESUME_FOLLOW_THRESHOLD = 8`), while *leaving* it keeps the wide 100px band. Symmetric thresholds re-open the bug at small scale — a 40px nudge sits inside the band, so the next scroll event classified the reader as at-bottom and handed them straight back to the loop. This one was found by a test that was passing for the wrong reason.

## The comment that asserted the opposite of the bug

The block above the loop ended by claiming *"a genuine user scroll-up (atBottom false) is still honored"* — and `atBottom false` is precisely the state the loop made unreachable. That is the #7290/#7291 shape (a comment describing a stronger property than the code delivers), so it is rewritten alongside the code rather than left to re-seed the same false confidence.

## Verification

15 new tests, **each proven red before the fix**. The shape that matters: every case streams (`isStreaming`) *and* lets frames tick between gesture steps — a scroll-up while idle passes on the pre-fix code and proves nothing. The jsdom scroll shim **clamps** `scrollTop` to `scrollHeight - clientHeight`, unlike the older tests here, because the unclamped writes hide the threshold arithmetic this bug lives in.

**12 mutants of the new guards, all killed** (each kills ≥1 test; restored from a backup copy, not `git checkout`):

| mutant | |
|---|---|
| M1 RAF tick loses the synchronous ref bail | RED |
| M2 `setScrolledUp` stops writing the ref | RED |
| M3/M4/M5 `onWheel`/`onTouchMove`/`onKeyDown` unwired | RED |
| M6 pin no longer yields to a held pointer | RED |
| M7 wheel treats any delta as scroll-up | RED |
| M8 touch slop ignores direction | RED |
| M9 keydown loses the text-field guard | RED |
| M10 `SCROLL_UP_KEYS` drops `PageUp` | RED |
| M11 resume uses the wide leaving band | RED |
| M12 scrolled-up readers can never resume | RED |

Four of those survived the first mutation round and the *tests* were fixed, not the mutants: the key test was firing a page-sized scroll event, so the position path satisfied it with `onKeyDown` unwired entirely; the wheel-down and touch-up controls let a follow-up scroll event re-clear the flag. Both now supply the gesture as the only available evidence.

Positive controls (kept green throughout):

- with no gesture, a stream still keeps the tail in view — #4652's original requirement;
- `scrollToBottomSignal` still overrides a mid-stream scroll-up **and** resumes following — #5780 / #5957's contract;
- the scroll-to-bottom button re-arms the follow;
- a reader who scrolls back to the bottom by hand resumes following (the hysteresis must not strand them).

Full dashboard suite **5236 passed (301 files)**, `tsc --noEmit` clean, `vite build` clean.

## Scope

The per-frame pin itself is left in place. The issue calls it "both expensive and self-defeating" and lists option 1 (pin on content change) first, but replacing the pin driver risks the tail-follow regression #5954 was filed for, and option 2 removes the race outright — it stops inferring intent from a position the loop controls, so no amount of tuning can reintroduce it. The remaining 60fps cost is a separate perf concern; filed as a follow-on rather than folded in silently.

The mobile app was checked for the same class and does not have it: it pins on `onContentSizeChange`, not per frame.