### PR TITLE
fix(ci): refuse `--test-force-exit` — it drops test results, not tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1215,6 +1215,13 @@ jobs:
         # (scripts/lib, packages/server/src/utils, sidecar/agent.js) — #7222.
         run: node scripts/__tests__/is-entry-point.test.mjs
 
+      - name: Run no-test-force-exit.mjs tests
+        # #7400 — `--test-force-exit` made the runner report 154-192 of
+        # base-session.test.js's 192 tests, exit 0, and print `# fail 0`. Both
+        # tests/_setup.mjs files refuse it now; this pins the shared refusal.
+        # The CALL SITES have their own coverage inside each package's suite.
+        run: node scripts/__tests__/no-test-force-exit.test.mjs
+
       - name: Run lint-no-raw-color-literals golden test
         run: bash scripts/__tests__/lint-no-raw-color-literals.test.sh
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -327,6 +327,23 @@ The recurring causes:
   holds the "this scroll was ours" flag continuously and restores the position
   the guard tests, so `programmatic && atBottom` is true by construction and the
   user-scrolled-up branch is never reached (`#7399`)
+- the TEST RUNNER itself dropping results — `--test-force-exit` reported 154 to
+  192 of one file's 192 tests across five runs, every run `# fail 0` and exit 0,
+  while a side-channel proved all 192 had executed (`#7400`)
+
+**Never pass `--test-force-exit`, and run what CI runs.** Both `tests/_setup.mjs`
+files refuse it now (`scripts/lib/no-test-force-exit.mjs`) because it drops test
+RESULTS — the tests run, up to a fifth of them never report, and the run still
+exits 0 with `# fail 0` (`#7400`, catalogue entry 19). Nothing needs it: the
+leaks that once required it were fixed in `#6027`/`#6042`, and it saves no wall
+clock. A targeted local run is:
+
+```bash
+cd packages/server && node --import ./tests/_setup.mjs --experimental-test-module-mocks --test tests/<file>.test.js
+```
+
+If that hangs after printing its summary, the file leaks a handle — tear it down
+in the test. That is the same leak CI will hit, and force-exiting hides it.
 
 Check the **exit code**, not the output — and note `cmd | grep -c FAIL` reports
 `grep`'s status, not the script's. Then check the mutant went **red, legibly,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -331,8 +331,9 @@ The recurring causes:
   192 of one file's 192 tests across five runs, every run `# fail 0` and exit 0,
   while a side-channel proved all 192 had executed (`#7400`)
 
-**Never pass `--test-force-exit`, and run what CI runs.** Both `tests/_setup.mjs`
-files refuse it now (`scripts/lib/no-test-force-exit.mjs`) because it drops test
+**Never pass `--test-force-exit`, and run what CI runs.** Every package that runs
+`node --test` refuses it now (`scripts/lib/no-test-force-exit.mjs`, installed via
+each `tests/_setup.mjs` or the `--import` hook) because it drops test
 RESULTS — the tests run, up to a fifth of them never report, and the run still
 exits 0 with `# fail 0` (`#7400`, catalogue entry 19). Nothing needs it: the
 leaks that once required it were fixed in `#6027`/`#6042`, and it saves no wall

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -312,8 +312,9 @@ The recurring causes:
   192 of one file's 192 tests across five runs, every run `# fail 0` and exit 0,
   while a side-channel proved all 192 had executed (`#7400`)
 
-**Never pass `--test-force-exit`, and run what CI runs.** Both `tests/_setup.mjs`
-files refuse it now (`scripts/lib/no-test-force-exit.mjs`) because it drops test
+**Never pass `--test-force-exit`, and run what CI runs.** Every package that runs
+`node --test` refuses it now (`scripts/lib/no-test-force-exit.mjs`, installed via
+each `tests/_setup.mjs` or the `--import` hook) because it drops test
 RESULTS — the tests run, up to a fifth of them never report, and the run still
 exits 0 with `# fail 0` (`#7400`, catalogue entry 19). Nothing needs it: the
 leaks that once required it were fixed in `#6027`/`#6042`, and it saves no wall

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -308,6 +308,23 @@ The recurring causes:
   holds the "this scroll was ours" flag continuously and restores the position
   the guard tests, so `programmatic && atBottom` is true by construction and the
   user-scrolled-up branch is never reached (`#7399`)
+- the TEST RUNNER itself dropping results — `--test-force-exit` reported 154 to
+  192 of one file's 192 tests across five runs, every run `# fail 0` and exit 0,
+  while a side-channel proved all 192 had executed (`#7400`)
+
+**Never pass `--test-force-exit`, and run what CI runs.** Both `tests/_setup.mjs`
+files refuse it now (`scripts/lib/no-test-force-exit.mjs`) because it drops test
+RESULTS — the tests run, up to a fifth of them never report, and the run still
+exits 0 with `# fail 0` (`#7400`, catalogue entry 19). Nothing needs it: the
+leaks that once required it were fixed in `#6027`/`#6042`, and it saves no wall
+clock. A targeted local run is:
+
+```bash
+cd packages/server && node --import ./tests/_setup.mjs --experimental-test-module-mocks --test tests/<file>.test.js
+```
+
+If that hangs after printing its summary, the file leaks a handle — tear it down
+in the test. That is the same leak CI will hit, and force-exiting hides it.
 
 Check the **exit code**, not the output — and note `cmd | grep -c FAIL` reports
 `grep`'s status, not the script's. Then check the mutant went **red, legibly,

--- a/docs/false-safety-guards.md
+++ b/docs/false-safety-guards.md
@@ -1046,8 +1046,11 @@ happened to its output. So RED was always trustworthy. It is GREEN that was
 worth less than it looked — which is the shape of every entry above.
 
 **The fix is refusal, not a louder green.** `scripts/lib/no-test-force-exit.mjs`
-throws from both `tests/_setup.mjs` files, so the run dies before a single test
-executes. Nothing needed the flag any more: the leaked handles it papered over
+is installed in every package that runs `node --test` — server and claude-hooks
+call it from `tests/_setup.mjs`, protocol and design-tokens `--import` the hook
+next door — so every file fails before a single test in it executes. (`--import` loads in the per-file children, not in the
+runner parent — measured — so the red comes from the files, and the exit code is
+what to trust.) Nothing needed the flag any more: the leaked handles it papered over
 were fixed in `#6027`/`#6042`, all eight files on that leak map now exit on
 their own, and the flag buys no wall clock (byok-session 66.5s → 63.9s,
 byok-mcp-client 74.9s → 74.9s). A file that hangs after its summary is a leaked

--- a/docs/false-safety-guards.md
+++ b/docs/false-safety-guards.md
@@ -1064,6 +1064,16 @@ have been satisfied by a child that never ran, for a reason having nothing to do
 with the guard. The positive control is what named it: the same spawn without
 the flag has to go green *with the probe reported*, and it did not.
 
+The Windows job then produced the same shape a second time, from a different
+cause: `--import` takes a module *specifier*, so the absolute path
+`A:\runners\...\_setup.mjs` parses as protocol `a:` and node refuses to load it
+(`ERR_UNSUPPORTED_ESM_URL_SCHEME`). Every child died before running anything —
+and "refuses before the probe runs" passed, because a child that never loads
+satisfies a negative assertion perfectly. The control failed, as it should have.
+Twice in one change, a negative assertion was satisfied by a child that did
+nothing; the fix is `pathToFileURL()`, and a case pinning the specifier's shape
+so the next occurrence is caught on Linux instead of only on Windows.
+
 **Guard against it:** a green that comes from the tooling is still a green you
 have to earn. When a run reports a count, pin the count — and when a comment
 tells you which flags a command carries, check the command. Both halves here

--- a/docs/false-safety-guards.md
+++ b/docs/false-safety-guards.md
@@ -996,3 +996,72 @@ holds in the test. A flag set-and-cleared across frames is continuously set if
 anything re-arms it per frame. And a threshold band is a precondition too: a
 guard that needs N pixels of movement is unreachable if something else resets the
 movement more often than the user can produce N.
+
+### 19. The test runner that reported fewer tests than it ran — `#7400`
+
+Every other entry here is a guard inside the repo. This one is the *instrument*:
+`--test-force-exit`, the flag the local test command carried for a year.
+
+Same file, same command, five consecutive runs of `base-session.test.js`
+(192 tests):
+
+```
+WITH --test-force-exit:   192 / 165 / 173 / 162 / 154   (every run `# fail 0`, exit 0)
+WITHOUT:                  192 / 192 / 192               (exit 0)
+```
+
+Up to 38 tests missing from the summary, non-deterministically, with nothing in
+the output saying so. And the tests were not skipped — a root `beforeEach`
+appending one line per test to a side file recorded **all 192** on a run whose
+summary said 168. What the flag drops is the *results*, on their way from the
+child process to the runner: under the default process isolation the child
+inherits the flag, `process.exit()`s the moment its own root test settles, and
+whatever it had queued for the parent goes with it. Run the same file
+in-process (`--experimental-test-isolation=none`) and the flag is harmless —
+192, three times out of three.
+
+**What makes it the worst instance in this catalogue** is not the size of the
+drop, it is *what* it corrupts. This document's own answer to false safety is
+mutation testing: break the thing, confirm the test goes red. Do that through a
+runner that silently omits a fifth of its results and "the mutant survived" and
+"the test that kills it never reported" become the same reading — the exact
+equivalence the whole document is about, now sitting underneath the method used
+to detect it.
+
+Two things kept it invisible for a year, and both are entries in their own right:
+
+- **The floor could not see a targeted run.** `assert-test-count.mjs` does floor
+  the total — but only for the whole suite, in CI, which never passed the flag.
+  The runs that carried the flag were the local, single-file ones, which have no
+  floor at all.
+- **The docblock said the flag was in use.** It had not been since `#6042`, and
+  the stale sentence was load-bearing in the wrong direction: it is what
+  re-derived, for the next reader, that typing the flag locally was normal and
+  safe.
+
+The honest limit of the damage: a *failing* test still turns the run red. A
+deliberate failure planted mid-file and at the tail exited 1 on 14 of 14 runs,
+truncated or not, because the child's non-zero exit reaches the parent whatever
+happened to its output. So RED was always trustworthy. It is GREEN that was
+worth less than it looked — which is the shape of every entry above.
+
+**The fix is refusal, not a louder green.** `scripts/lib/no-test-force-exit.mjs`
+throws from both `tests/_setup.mjs` files, so the run dies before a single test
+executes. Nothing needed the flag any more: the leaked handles it papered over
+were fixed in `#6027`/`#6042`, all eight files on that leak map now exit on
+their own, and the flag buys no wall clock (byok-session 66.5s → 63.9s,
+byok-mcp-client 74.9s → 74.9s). A file that hangs after its summary is a leaked
+handle to tear down — the same leak CI will hit, which force-exiting locally
+hides.
+
+**Its own tests nearly repeated the pattern.** The call-site tests spawn a real
+`node --test` from inside a test, and a child that inherits `NODE_TEST_CONTEXT`
+refuses to run files at all — exits 0, reports nothing. The refusal cases would
+have been satisfied by a child that never ran, for a reason having nothing to do
+with the guard. The positive control is what named it: the same spawn without
+the flag has to go green *with the probe reported*, and it did not.
+
+**Guard against it:** a green that comes from the tooling is still a green you
+have to earn. When a run reports a count, pin the count — and when a comment
+tells you which flags a command carries, check the command. Both halves here
+were readable in ten seconds by anyone who thought to look.

--- a/packages/claude-hooks/tests/_setup.mjs
+++ b/packages/claude-hooks/tests/_setup.mjs
@@ -75,6 +75,11 @@ import { join, resolve } from 'node:path'
 import { createRequire } from 'node:module'
 
 import { installFsWriteSandbox } from '../../../scripts/lib/test-fs-sandbox.mjs'
+import { assertNoTestForceExit } from '../../../scripts/lib/no-test-force-exit.mjs'
+
+// Same refusal the server installs (#7400): `--test-force-exit` drops test
+// RESULTS, not tests, and still exits 0 with `# fail 0`.
+assertNoTestForceExit()
 
 const require = createRequire(import.meta.url)
 const fs = require('node:fs')

--- a/packages/claude-hooks/tests/setup-no-force-exit.test.js
+++ b/packages/claude-hooks/tests/setup-no-force-exit.test.js
@@ -15,10 +15,15 @@ import { spawnSync } from 'node:child_process'
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 
 const HERE = dirname(fileURLToPath(import.meta.url))
-const SETUP = resolve(HERE, '_setup.mjs')
+// A file URL, never a bare Windows path: `--import` takes a module SPECIFIER,
+// so `A:\\runners\\...\\_setup.mjs` parses as protocol "a:" and node refuses it
+// with ERR_UNSUPPORTED_ESM_URL_SCHEME. Measured on the Windows runner — and the
+// refusal cases still "passed" there, because a child that dies before loading
+// anything satisfies "no test ran" perfectly. The control is what went red.
+const SETUP = pathToFileURL(resolve(HERE, '_setup.mjs')).href
 
 const dir = mkdtempSync(join(tmpdir(), 'chroxy-hooks-force-exit-'))
 const probe = join(dir, 'probe.test.js')
@@ -45,6 +50,13 @@ const run = (extraArgs = []) => {
 }
 
 describe('tests/_setup.mjs refuses --test-force-exit (#7400)', () => {
+  it('passes --import a file:// URL, not a bare path (Windows)', () => {
+    // Pins the shape that broke the Windows job: an absolute path is not a valid
+    // ESM specifier there. This runs on every platform, so the regression is
+    // caught on Linux/macOS too rather than only where it hurts.
+    assert.ok(SETUP.startsWith('file://'), `--import specifier must be a file URL, got: ${SETUP}`)
+  })
+
   it('CONTROL: green without the flag, probe reported', () => {
     const r = run()
     assert.equal(r.status, 0, `expected exit 0, got ${r.status}\n${r.all.slice(0, 2000)}`)

--- a/packages/claude-hooks/tests/setup-no-force-exit.test.js
+++ b/packages/claude-hooks/tests/setup-no-force-exit.test.js
@@ -1,0 +1,60 @@
+/**
+ * CALL-SITE coverage for the `--test-force-exit` refusal in THIS package's
+ * `tests/_setup.mjs` (#7400).
+ *
+ * The module and its behaviour are covered once, in
+ * `scripts/__tests__/no-test-force-exit.test.mjs`. What is package-local — and
+ * what silently rots if nobody asserts it — is whether this package's setup
+ * still calls it. Same reasoning as the server's copy: spawn the real command,
+ * and keep a control so an unrelated spawn failure cannot pass for a guard.
+ */
+
+import { describe, it, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const SETUP = resolve(HERE, '_setup.mjs')
+
+const dir = mkdtempSync(join(tmpdir(), 'chroxy-hooks-force-exit-'))
+const probe = join(dir, 'probe.test.js')
+writeFileSync(probe, "import { test } from 'node:test'\ntest('probe ran', () => {})\n")
+
+after(() => { rmSync(dir, { recursive: true, force: true }) })
+
+// NODE_TEST_CONTEXT is set on this process by the runner; a child that
+// inherits it skips running files entirely and exits 0 — a false pass for the
+// refusal cases. Strip it. (Same reasoning as the server's copy.)
+const childEnv = () => {
+  const env = { ...process.env }
+  delete env.NODE_TEST_CONTEXT
+  return env
+}
+
+const run = (extraArgs = []) => {
+  const r = spawnSync(
+    process.execPath,
+    ['--import', SETUP, '--test', ...extraArgs, probe],
+    { encoding: 'utf8', cwd: dir, env: childEnv() },
+  )
+  return { ...r, all: (r.stdout || '') + (r.stderr || '') }
+}
+
+describe('tests/_setup.mjs refuses --test-force-exit (#7400)', () => {
+  it('CONTROL: green without the flag, probe reported', () => {
+    const r = run()
+    assert.equal(r.status, 0, `expected exit 0, got ${r.status}\n${r.all.slice(0, 2000)}`)
+    assert.ok(r.stdout.includes('# pass 1'), `probe should have run:\n${r.stdout.slice(0, 2000)}`)
+  })
+
+  it('refuses with the flag, non-zero, and runs nothing', () => {
+    const r = run(['--test-force-exit'])
+    assert.notEqual(r.status, 0, `expected a non-zero exit:\n${r.all.slice(0, 2000)}`)
+    assert.ok(r.all.includes('CHROXY_TEST_FORCE_EXIT'), `expected the refusal:\n${r.all.slice(0, 2000)}`)
+    assert.ok(!r.stdout.includes('# pass 1'), `no test should have passed:\n${r.stdout.slice(0, 2000)}`)
+  })
+})

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -16,7 +16,7 @@
     "index.d.ts"
   ],
   "scripts": {
-    "test": "node --test"
+    "test": "node --import ../../scripts/lib/no-test-force-exit-hook.mjs --test"
   },
   "license": "MIT"
 }

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -29,7 +29,7 @@
   "scripts": {
     "build": "tsc",
     "prepare": "tsc",
-    "test": "node --import tsx/esm --test tests/*.test.js"
+    "test": "node --import tsx/esm --import ../../scripts/lib/no-test-force-exit-hook.mjs --test tests/*.test.js"
   },
   "dependencies": {
     "zod": "^4.3.6"

--- a/packages/server/scripts/assert-test-count.mjs
+++ b/packages/server/scripts/assert-test-count.mjs
@@ -1,46 +1,57 @@
 #!/usr/bin/env node
 /**
- * Truncation guard for `--test-force-exit` (#5480).
+ * Truncation guard for the server suite (#5480, corrected in #7400).
  *
- * The server test command runs the Node test runner with `--test-force-exit`,
- * which `process.exit()`s the moment the runner *appears* idle. On a large
- * file this can fire while trailing suites are still queued, so the file runs
- * only a subset of its tests — yet exit code stays 0. A truncated run is then
- * indistinguishable from a green one (confirmed reproducible on current main:
- * `discord-webhook-sink.test.js` ran anywhere from 79 to 114 of its 114 tests
- * across 20 runs, always exiting 0).
+ * A test run that dies, aborts, or silently drops whole files still prints a
+ * clean-looking TAP summary and exits 0. "Ran and passed" and "never ran" are
+ * the same observable outcome — the defect class `docs/false-safety-guards.md`
+ * exists for — so this wrapper adds the one thing the runner's own exit code
+ * cannot give you: a floor on how much of the suite reported back.
  *
- * `--test-force-exit` cannot simply be removed: WITHOUT it the full suite hangs
- * past the 10-minute CI budget on leaked handles (tunnel-recovery timers and
- * friends — see follow-up issue). So instead of trading one silent failure
- * mode for a loud hang, this wrapper makes a *truncated* run go RED:
+ * ── What this docblock used to say, and why it was wrong ───────────────────
+ *
+ * It said "the server test command runs the Node test runner with
+ * `--test-force-exit`". It has not since #6042/#6100, and CI never did. The
+ * stale claim mattered: #7400 was filed only after someone re-derived, from
+ * this comment, that the flag was in use and therefore safe to type locally.
+ * It is not safe — measured on `base-session.test.js` (192 tests), the flag
+ * reported 154-192 of them across five runs, every run `# fail 0`, exit 0. The
+ * tests all RAN; their results were dropped on the way from the child process
+ * to the runner. Both `tests/_setup.mjs` files now REFUSE the flag outright
+ * (`scripts/lib/no-test-force-exit.mjs`), so no run this wrapper sees can be
+ * truncated that way any more.
+ *
+ * ── What it still catches ──────────────────────────────────────────────────
  *
  *   1. It runs the underlying test command (passed as argv), streaming all
  *      output through unchanged so coverage + TAP land on the terminal/CI log.
  *   2. From the aggregate TAP summary it reads `# tests N` and `# fail M`.
  *   3. It exits non-zero if:
  *        - the summary is missing (the runner died before reporting), OR
+ *        - the run was killed by a signal, OR
  *        - `M > 0` (real test failures — mirrors the runner's own exit), OR
- *        - `N < EXPECTED_MIN_TESTS` (a truncation dropped enough tests to fall
- *          below the documented floor).
+ *        - `N < EXPECTED_MIN_TESTS` (enough of the suite went missing to fall
+ *          below the documented floor — a glob that stopped matching, a file
+ *          that failed to load, a bad merge that deleted a directory).
  *
- * EXPECTED_MIN_TESTS is a *lower bound*, not the exact count. The full suite
- * reports ~10040 tests today; the floor sits below that with headroom so it
- * does not break every time a test is added, but high enough that a meaningful
- * truncation trips it. When the suite grows well past the floor, bump the floor
- * (the script prints the live count + a nudge when headroom gets large). When
- * tests are deliberately removed below the floor, lower it in the same PR.
+ * EXPECTED_MIN_TESTS is a *lower bound*, not the exact count. The floor sits
+ * below the live count with headroom so it does not break every time a test is
+ * added, but high enough that a meaningful loss trips it. When the suite grows
+ * well past the floor, bump the floor (the script prints the live count + a
+ * nudge when headroom gets large). When tests are deliberately removed below
+ * the floor, lower it in the same PR.
  */
-
 import { spawn } from 'node:child_process'
 
 // --- The documented floor -----------------------------------------------------
-// Set below the observed full-suite count (~10040 tests, three clean runs on
-// 2026-06-18: 10040 / 10044 / 10048) with deliberate headroom for honest growth
-// AND shrinkage, while still catching a truncation that drops more than a couple
-// hundred tests. Override per-invocation with CHROXY_MIN_TEST_COUNT for targeted
-// runs of a subset (e.g. a single large file in local repro).
-const DEFAULT_MIN_TESTS = 9700
+// Set below the observed full-suite count with deliberate headroom for honest
+// growth AND shrinkage, while still catching a loss of more than a few hundred
+// tests. Measured 2026-08-27: 14049 on the CI Linux runner (`# tests` from the
+// Server Tests job on main @ 1028ee8e3) and 14059 locally on macOS — the two
+// platforms differ by ten tests, so one floor covers both. Override
+// per-invocation with CHROXY_MIN_TEST_COUNT for targeted runs of a subset
+// (e.g. a single large file in local repro).
+const DEFAULT_MIN_TESTS = 13500
 // Validate the override: an invalid value (typo, empty, non-numeric) must NOT
 // silently disable the floor. `Number('abc')` is NaN and `total < NaN` is always
 // false, which would quietly turn the guard off — so fall back to the default and
@@ -129,9 +140,10 @@ child.on('close', (code, signal) => {
   if (total < EXPECTED_MIN_TESTS) {
     console.error(
       `\n[assert-test-count] FAIL: only ${total} tests ran, below the floor of ${EXPECTED_MIN_TESTS}.\n` +
-      '  This is the --test-force-exit truncation guard (#5480): a large test file very likely\n' +
-      '  had trailing suites skipped before the forced exit. Re-run; if it persists, a file\n' +
-      '  grew large enough to truncate reliably (split it, or move suites earlier). If you\n' +
+      '  Part of the suite did not report (#5480). Something stopped whole files from\n' +
+      '  running or reporting: a glob that no longer matches, a file that threw while\n' +
+      '  loading, a deleted directory. Look for a file the TAP output never mentions —\n' +
+      '  the count is the only symptom, because the run still exited 0. If you\n' +
       '  intentionally removed tests below the floor, lower EXPECTED_MIN_TESTS in this script.',
     )
     return fail()

--- a/packages/server/tests/_setup.mjs
+++ b/packages/server/tests/_setup.mjs
@@ -80,9 +80,12 @@ import { assertNoTestForceExit } from '../../../scripts/lib/no-test-force-exit.m
 // First thing in the body, before any temp dir exists: the flag makes this
 // runner report fewer tests than it ran (154-192 of 192 across five runs of
 // base-session.test.js) while still exiting 0 with `# fail 0`. `--import` puts
-// this file ahead of the test graph in the runner AND in every child it spawns,
-// so the throw lands before a single test executes. See the module for the
-// measurements and for why nothing needs the flag any more.
+// this file ahead of the test graph in the per-file child processes, so the
+// throw lands before a single test in the file executes and the file is
+// reported as failed. (Under the default isolation the runner PARENT does not
+// load --import at all — measured — so it keeps force-exiting while it
+// aggregates; the non-zero exit is the authoritative signal, not the message.)
+// See the module for the measurements and for why nothing needs the flag.
 assertNoTestForceExit()
 
 // CRITICAL: Patch `node:fs` via the CJS object obtained from `createRequire`,

--- a/packages/server/tests/_setup.mjs
+++ b/packages/server/tests/_setup.mjs
@@ -74,6 +74,16 @@ import { homedir, tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 
 import { installFsWriteSandbox } from '../../../scripts/lib/test-fs-sandbox.mjs'
+import { assertNoTestForceExit } from '../../../scripts/lib/no-test-force-exit.mjs'
+
+// --- Refuse `--test-force-exit` (#7400) --------------------------------------
+// First thing in the body, before any temp dir exists: the flag makes this
+// runner report fewer tests than it ran (154-192 of 192 across five runs of
+// base-session.test.js) while still exiting 0 with `# fail 0`. `--import` puts
+// this file ahead of the test graph in the runner AND in every child it spawns,
+// so the throw lands before a single test executes. See the module for the
+// measurements and for why nothing needs the flag any more.
+assertNoTestForceExit()
 
 // CRITICAL: Patch `node:fs` via the CJS object obtained from `createRequire`,
 // NOT via an ESM default import. ESM `import fs from 'node:fs'` returns a

--- a/packages/server/tests/setup-no-force-exit.test.js
+++ b/packages/server/tests/setup-no-force-exit.test.js
@@ -24,10 +24,15 @@ import { spawnSync } from 'node:child_process'
 import { mkdtempSync, rmSync, writeFileSync } from 'fs'
 import { tmpdir } from 'os'
 import { dirname, join, resolve } from 'path'
-import { fileURLToPath } from 'url'
+import { fileURLToPath, pathToFileURL } from 'url'
 
 const HERE = dirname(fileURLToPath(import.meta.url))
-const SETUP = resolve(HERE, '_setup.mjs')
+// A file URL, never a bare Windows path: `--import` takes a module SPECIFIER,
+// so `A:\\runners\\...\\_setup.mjs` parses as protocol "a:" and node refuses it
+// with ERR_UNSUPPORTED_ESM_URL_SCHEME. Measured on the Windows runner — and the
+// refusal cases still "passed" there, because a child that dies before loading
+// anything satisfies "no test ran" perfectly. The control is what went red.
+const SETUP = pathToFileURL(resolve(HERE, '_setup.mjs')).href
 
 const dir = mkdtempSync(join(tmpdir(), 'chroxy-force-exit-callsite-'))
 const probe = join(dir, 'probe.test.js')
@@ -56,6 +61,13 @@ const run = (extraArgs = [], env = {}) => {
 }
 
 describe('tests/_setup.mjs refuses --test-force-exit (#7400)', () => {
+  it('passes --import a file:// URL, not a bare path (Windows)', () => {
+    // Pins the shape that broke the Windows job: an absolute path is not a valid
+    // ESM specifier there. This runs on every platform, so the regression is
+    // caught on Linux/macOS too rather than only where it hurts.
+    assert.ok(SETUP.startsWith('file://'), `--import specifier must be a file URL, got: ${SETUP}`)
+  })
+
   it('CONTROL: the same command without the flag is green and reports the probe', () => {
     const r = run()
     assert.equal(r.status, 0, `expected exit 0, got ${r.status}\n${r.all.slice(0, 2000)}`)

--- a/packages/server/tests/setup-no-force-exit.test.js
+++ b/packages/server/tests/setup-no-force-exit.test.js
@@ -1,0 +1,91 @@
+/**
+ * CALL-SITE coverage for the `--test-force-exit` refusal (#7400).
+ *
+ * `scripts/__tests__/no-test-force-exit.test.mjs` proves the MODULE works.
+ * This file proves this package's `tests/_setup.mjs` actually installs it —
+ * the asymmetry #7236 is about, and the reason a shared guard needs a test per
+ * entry point rather than one test for the library.
+ *
+ * Every case spawns a real `node --import ./tests/_setup.mjs --test` at the
+ * exact shape a developer types. Nothing here imports `_setup.mjs`: this
+ * process was already started by it, so an in-process assertion would be
+ * testing a module that has ALREADY run, and would keep passing if the call
+ * were deleted from the file.
+ *
+ * The control case matters as much as the refusal. A spawn that fails to load
+ * for an unrelated reason (a bad path, a missing flag) exits non-zero and
+ * prints something — which reads exactly like a working guard. So the same
+ * command, minus the flag, must go green with the probe reported.
+ */
+
+import { describe, it, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { dirname, join, resolve } from 'path'
+import { fileURLToPath } from 'url'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const SETUP = resolve(HERE, '_setup.mjs')
+
+const dir = mkdtempSync(join(tmpdir(), 'chroxy-force-exit-callsite-'))
+const probe = join(dir, 'probe.test.js')
+writeFileSync(probe, "import { test } from 'node:test'\ntest('probe ran', () => {})\n")
+
+after(() => { rmSync(dir, { recursive: true, force: true }) })
+
+// This file is itself running under `node --test`, which sets NODE_TEST_CONTEXT
+// in the environment. A child that inherits it refuses to run files at all
+// ("run() is being called recursively"), exits 0, and reports nothing — which
+// would make the refusal cases pass for entirely the wrong reason and the
+// control case fail. Strip it.
+const childEnv = (extra) => {
+  const env = { ...process.env, ...extra }
+  delete env.NODE_TEST_CONTEXT
+  return env
+}
+
+const run = (extraArgs = [], env = {}) => {
+  const r = spawnSync(
+    process.execPath,
+    ['--import', SETUP, '--experimental-test-module-mocks', '--test', ...extraArgs, probe],
+    { encoding: 'utf8', env: childEnv(env), cwd: dir },
+  )
+  return { ...r, all: (r.stdout || '') + (r.stderr || '') }
+}
+
+describe('tests/_setup.mjs refuses --test-force-exit (#7400)', () => {
+  it('CONTROL: the same command without the flag is green and reports the probe', () => {
+    const r = run()
+    assert.equal(r.status, 0, `expected exit 0, got ${r.status}\n${r.all.slice(0, 2000)}`)
+    assert.ok(r.stdout.includes('# pass 1'), `probe should have run:\n${r.stdout.slice(0, 2000)}`)
+  })
+
+  it('refuses, non-zero, naming the code', () => {
+    const r = run(['--test-force-exit'])
+    assert.notEqual(r.status, 0, `expected a non-zero exit:\n${r.all.slice(0, 2000)}`)
+    assert.ok(
+      r.all.includes('CHROXY_TEST_FORCE_EXIT'),
+      `expected the refusal code in the output:\n${r.all.slice(0, 2000)}`,
+    )
+  })
+
+  it('refuses before the probe runs — no half-run to interpret', () => {
+    const r = run(['--test-force-exit'])
+    assert.ok(!r.stdout.includes('# pass 1'), `no test should have passed:\n${r.stdout.slice(0, 2000)}`)
+  })
+
+  it('catches the underscore spelling node also accepts', () => {
+    const r = run(['--test_force_exit'])
+    assert.notEqual(r.status, 0, `expected a non-zero exit:\n${r.all.slice(0, 2000)}`)
+    assert.ok(r.all.includes('CHROXY_TEST_FORCE_EXIT'), `expected the refusal:\n${r.all.slice(0, 2000)}`)
+  })
+
+  it('CHROXY_ALLOW_TEST_FORCE_EXIT waives it, loudly', () => {
+    const r = run(['--test-force-exit'], { CHROXY_ALLOW_TEST_FORCE_EXIT: '1' })
+    assert.equal(r.status, 0, `expected exit 0, got ${r.status}\n${r.all.slice(0, 2000)}`)
+    assert.ok(r.all.includes('WARNING'), `expected a warning:\n${r.all.slice(0, 2000)}`)
+    assert.ok(r.stdout.includes('# pass 1'), `probe should still run:\n${r.stdout.slice(0, 2000)}`)
+  })
+})

--- a/scripts/__tests__/no-test-force-exit.test.mjs
+++ b/scripts/__tests__/no-test-force-exit.test.mjs
@@ -29,7 +29,7 @@
  */
 
 import { spawnSync } from 'node:child_process'
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -51,7 +51,7 @@ const HOOK_PATH = resolve(REPO_ROOT, 'scripts/lib/no-test-force-exit-hook.mjs')
 // A floor on the number of cases accounted for, so a run that loses cases
 // (an early `return`, a bad refactor) goes red instead of printing a small
 // tidy "all passed".
-const MIN_CASES = 22
+const MIN_CASES = 30
 
 let pass = 0
 let fail = 0
@@ -193,6 +193,31 @@ test('the escape hatch waives the refusal AND warns', () => {
   assert(warnings[0].includes('not trustworthy'), 'the warning must say what is wrong with the run')
 })
 
+for (const value of ['0', 'false', 'off', 'no', '', 'maybe']) {
+  test(`${FORCE_EXIT_ALLOW_ENV}=${JSON.stringify(value)} does NOT waive the refusal`, () => {
+    // Plain truthiness would waive on '0' and 'false' — values whose author
+    // plainly meant "leave the guard on". The hatch takes an affirmative.
+    let threw = false
+    try {
+      assertNoTestForceExit({ execArgv: [FORCE_EXIT_OPTION], env: { [FORCE_EXIT_ALLOW_ENV]: value }, warn: () => {} })
+    } catch {
+      threw = true
+    }
+    assert(threw, `expected a refusal for ${JSON.stringify(value)}`)
+  })
+}
+
+for (const value of ['1', 'true', 'TRUE', ' yes ', 'on']) {
+  test(`${FORCE_EXIT_ALLOW_ENV}=${JSON.stringify(value)} waives it`, () => {
+    const got = assertNoTestForceExit({
+      execArgv: [FORCE_EXIT_OPTION],
+      env: { [FORCE_EXIT_ALLOW_ENV]: value },
+      warn: () => {},
+    })
+    assert(got?.allowed === true, `expected the waiver for ${JSON.stringify(value)}`)
+  })
+}
+
 test('an empty escape hatch is not an escape hatch', () => {
   // `CHROXY_ALLOW_TEST_FORCE_EXIT=` (unset-by-assignment) must still refuse,
   // so a stale empty export cannot silently disarm the guard.
@@ -204,6 +229,60 @@ test('an empty escape hatch is not an escape hatch', () => {
   }
   assert(threw, 'expected a refusal')
 })
+
+// ── Is the refusal wired into every package that runs `node --test`? ────────
+//
+// The server and claude-hooks call sites have behavioural tests inside their
+// own suites. packages/protocol and packages/design-tokens have no suite of
+// their own to hold one, and their wiring is a STRING in package.json: delete
+// the `--import` and every test in the repo still passes.
+//
+// So this walks packages/* and derives the list rather than naming it — a
+// hardcoded list beside a set that grows is the first cause in
+// docs/false-safety-guards.md. A NEW package that adds a `node --test` script
+// without the refusal fails here, by name.
+//
+// The limit, stated rather than papered over: this checks the wiring is
+// PRESENT, not that it fires. What it fires is covered above (the hook) and in
+// each package's own call-site file (the setup modules).
+
+const packagesDir = resolve(REPO_ROOT, 'packages')
+const nodeTestPackages = []
+for (const name of readdirSync(packagesDir)) {
+  const manifest = join(packagesDir, name, 'package.json')
+  if (!existsSync(manifest)) continue
+  const script = JSON.parse(readFileSync(manifest, 'utf8')).scripts?.test ?? ''
+  // `node ... --test` — vitest ("vitest run") and jest ("jest --coverage")
+  // never match, and `--test-force-exit` does not match `--test` because of
+  // the trailing boundary.
+  if (/\bnode\b/.test(script) && /--test(\s|$)/.test(script)) nodeTestPackages.push({ name, script })
+}
+
+// A floor, because an empty walk would otherwise report "all wired" — the
+// silent-pass shape this file exists to prevent. Four packages run node --test
+// today: server, claude-hooks, protocol, design-tokens.
+test('the walk found every package that runs node --test', () => {
+  assert(
+    nodeTestPackages.length >= 4,
+    `only ${nodeTestPackages.length} package(s) matched: ${nodeTestPackages.map((p) => p.name).join(', ') || 'none'}`,
+  )
+})
+
+for (const { name, script } of nodeTestPackages) {
+  test(`packages/${name} installs the refusal in its test script`, () => {
+    const imports = [...script.matchAll(/--import\s+(\S+)/g)].map((m) => m[1].replace(/^['"]|['"]$/g, ''))
+    const installs = imports.some((spec) => {
+      if (!spec.startsWith('.')) return false // bare specifier (tsx/esm) — not ours
+      const file = resolve(packagesDir, name, spec)
+      if (!existsSync(file)) return false
+      return readFileSync(file, 'utf8').includes('assertNoTestForceExit(')
+    })
+    assert(
+      installs,
+      `packages/${name}'s test script --imports nothing that calls assertNoTestForceExit():\n  ${script}`,
+    )
+  })
+}
 
 // ── The mechanism: does a throw from --import stop a real `node --test` run? ─
 

--- a/scripts/__tests__/no-test-force-exit.test.mjs
+++ b/scripts/__tests__/no-test-force-exit.test.mjs
@@ -1,0 +1,292 @@
+#!/usr/bin/env node
+/**
+ * no-test-force-exit.test.mjs — pins scripts/lib/no-test-force-exit.mjs (#7400).
+ *
+ * The refusal exists because `--test-force-exit` makes a run report fewer tests
+ * than it ran while still exiting 0 — so the guard's own failure mode is the
+ * one it is guarding against: a guard that never fires and a suite that is
+ * green anyway. Two things follow, and both shape this file.
+ *
+ * FIRST: every detection case asserts the returned object, never a downstream
+ * side effect. `findTestForceExit` returning `null` when it should have found
+ * something is invisible from the outside.
+ *
+ * SECOND: detection is not the claim that matters. The claim is that a throw
+ * from an `--import` module actually STOPS a `node --test` run — the whole
+ * mechanism the guard leans on. So the last cases spawn a real runner against a
+ * throwaway shim, in both directions: with the flag it must exit non-zero and
+ * name the code, and WITHOUT it the very same spawn must exit 0 with its test
+ * reported. Without that positive control, a shim that fails to load for some
+ * unrelated reason reads as a working guard.
+ *
+ * The call sites in the two real `tests/_setup.mjs` files have their own
+ * coverage — packages/server/tests/setup-no-force-exit.test.js and
+ * packages/claude-hooks/tests/setup-no-force-exit.test.js — because this file
+ * can only prove the module works, not that anything installed it.
+ *
+ * No external test framework. Run from repo root:
+ *   node scripts/__tests__/no-test-force-exit.test.mjs
+ */
+
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import {
+  FORCE_EXIT_ALLOW_ENV,
+  FORCE_EXIT_ERROR_CODE,
+  FORCE_EXIT_OPTION,
+  assertNoTestForceExit,
+  findTestForceExit,
+  normalizeNodeOptionName,
+} from '../lib/no-test-force-exit.mjs'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const REPO_ROOT = resolve(HERE, '..', '..')
+const MODULE_PATH = resolve(REPO_ROOT, 'scripts/lib/no-test-force-exit.mjs')
+const HOOK_PATH = resolve(REPO_ROOT, 'scripts/lib/no-test-force-exit-hook.mjs')
+
+// A floor on the number of cases accounted for, so a run that loses cases
+// (an early `return`, a bad refactor) goes red instead of printing a small
+// tidy "all passed".
+const MIN_CASES = 22
+
+let pass = 0
+let fail = 0
+const failures = []
+
+const test = (name, fn) => {
+  try {
+    fn()
+    pass++
+    process.stdout.write(`  ok ${name}\n`)
+  } catch (err) {
+    fail++
+    failures.push({ name, err })
+    process.stdout.write(`  FAIL ${name}: ${err.message}\n`)
+  }
+}
+
+const assert = (cond, msg) => {
+  if (!cond) throw new Error(msg || 'assertion failed')
+}
+
+// ── normalizeNodeOptionName ─────────────────────────────────────────────────
+
+test('normalizes underscores in an option name', () => {
+  assert(normalizeNodeOptionName('--test_force_exit') === FORCE_EXIT_OPTION)
+})
+
+test('strips an =value before comparing', () => {
+  assert(normalizeNodeOptionName('--test-force-exit=false') === FORCE_EXIT_OPTION)
+})
+
+test('leaves a non-option argument alone', () => {
+  // A bare word must never be folded into an option name — a test file called
+  // `test_force_exit.js` is not the flag.
+  assert(normalizeNodeOptionName('test_force_exit') === 'test_force_exit')
+})
+
+// ── findTestForceExit ───────────────────────────────────────────────────────
+
+const find = (execArgv, env = {}) => findTestForceExit({ execArgv, env })
+
+test('clean execArgv reports nothing', () => {
+  assert(find(['--experimental-test-module-mocks', '--test']) === null)
+})
+
+test('finds the plain flag in execArgv', () => {
+  const hit = find(['--test', FORCE_EXIT_OPTION])
+  assert(hit !== null, 'expected a hit')
+  assert(hit.source === 'execArgv', `source was ${hit?.source}`)
+  assert(hit.arg === FORCE_EXIT_OPTION, `arg was ${hit?.arg}`)
+})
+
+test('finds the underscore spelling node itself accepts', () => {
+  // Measured: `node --test_force_exit` is accepted and lands in execArgv
+  // spelled with underscores.
+  const hit = find(['--test_force_exit'])
+  assert(hit !== null, 'expected a hit')
+  assert(hit.arg === '--test_force_exit', `arg was ${hit?.arg}`)
+})
+
+test('finds =true', () => {
+  assert(find(['--test-force-exit=true']) !== null)
+})
+
+test('finds =false — node ignores the value and still force-exits', () => {
+  // Not a hypothetical: with `--test-force-exit=false`, base-session.test.js
+  // reported 164 / 155 / 159 of its 192 tests.
+  assert(find(['--test-force-exit=false']) !== null)
+})
+
+test('finds the flag in NODE_OPTIONS', () => {
+  const hit = find([], { NODE_OPTIONS: `--enable-source-maps ${FORCE_EXIT_OPTION}` })
+  assert(hit !== null, 'expected a hit')
+  assert(hit.source === 'NODE_OPTIONS', `source was ${hit?.source}`)
+})
+
+test('ignores an unrelated NODE_OPTIONS', () => {
+  assert(find([], { NODE_OPTIONS: '--enable-source-maps --max-old-space-size=4096' }) === null)
+})
+
+test('ignores an absent NODE_OPTIONS', () => {
+  assert(find([], {}) === null)
+})
+
+test('does not fire on a longer option that merely starts the same', () => {
+  assert(find(['--test-force-exit-later']) === null)
+})
+
+test('does not fire on a shorter prefix', () => {
+  assert(find(['--test-force']) === null)
+})
+
+test('does not fire on a script path that happens to contain the name', () => {
+  assert(find(['/tmp/test-force-exit/setup.mjs']) === null)
+})
+
+// ── assertNoTestForceExit ───────────────────────────────────────────────────
+
+test('returns null and warns nothing on a clean process', () => {
+  let warned = 0
+  const got = assertNoTestForceExit({ execArgv: ['--test'], env: {}, warn: () => { warned++ } })
+  assert(got === null, 'expected null')
+  assert(warned === 0, 'must not warn on a clean run')
+})
+
+test('throws with the documented code when the flag is present', () => {
+  let err = null
+  try {
+    assertNoTestForceExit({ execArgv: [FORCE_EXIT_OPTION], env: {}, warn: () => {} })
+  } catch (e) {
+    err = e
+  }
+  assert(err !== null, 'expected a throw')
+  assert(err.code === FORCE_EXIT_ERROR_CODE, `code was ${err?.code}`)
+})
+
+test('the refusal message names the flag, the escape hatch and the issue', () => {
+  let err = null
+  try {
+    assertNoTestForceExit({ execArgv: ['--test_force_exit'], env: {}, warn: () => {} })
+  } catch (e) {
+    err = e
+  }
+  // Whoever hits this has to be able to act on it without reading the source.
+  assert(err.message.includes('--test_force_exit'), 'must echo the arg as spelled')
+  assert(err.message.includes(FORCE_EXIT_ALLOW_ENV), 'must name the escape hatch')
+  assert(err.message.includes('#7400'), 'must name the issue')
+})
+
+test('the escape hatch waives the refusal AND warns', () => {
+  const warnings = []
+  const got = assertNoTestForceExit({
+    execArgv: [FORCE_EXIT_OPTION],
+    env: { [FORCE_EXIT_ALLOW_ENV]: '1' },
+    warn: (m) => warnings.push(m),
+  })
+  assert(got?.allowed === true, 'expected the waiver')
+  assert(warnings.length === 1, `expected one warning, got ${warnings.length}`)
+  assert(warnings[0].includes('not trustworthy'), 'the warning must say what is wrong with the run')
+})
+
+test('an empty escape hatch is not an escape hatch', () => {
+  // `CHROXY_ALLOW_TEST_FORCE_EXIT=` (unset-by-assignment) must still refuse,
+  // so a stale empty export cannot silently disarm the guard.
+  let threw = false
+  try {
+    assertNoTestForceExit({ execArgv: [FORCE_EXIT_OPTION], env: { [FORCE_EXIT_ALLOW_ENV]: '' }, warn: () => {} })
+  } catch {
+    threw = true
+  }
+  assert(threw, 'expected a refusal')
+})
+
+// ── The mechanism: does a throw from --import stop a real `node --test` run? ─
+
+const dir = mkdtempSync(join(tmpdir(), 'chroxy-force-exit-'))
+try {
+  const shim = join(dir, 'shim.mjs')
+  writeFileSync(
+    shim,
+    `import { assertNoTestForceExit } from ${JSON.stringify(MODULE_PATH)}\nassertNoTestForceExit()\n`,
+  )
+  const probe = join(dir, 'probe.test.js')
+  writeFileSync(
+    probe,
+    "import { test } from 'node:test'\ntest('probe ran', () => {})\n",
+  )
+
+  const run = (extraArgs, env) => spawnSync(
+    process.execPath,
+    ['--import', shim, '--test', ...extraArgs, probe],
+    { encoding: 'utf8', env: { ...process.env, ...env }, cwd: dir },
+  )
+
+  test('POSITIVE CONTROL: the same spawn is green without the flag', () => {
+    const r = run([], {})
+    assert(r.status === 0, `expected exit 0, got ${r.status}\n${r.stdout}\n${r.stderr}`)
+    assert(r.stdout.includes('# pass 1'), `expected the probe to be reported:\n${r.stdout}`)
+  })
+
+  test('a real `node --test` run refuses when the flag is passed', () => {
+    const r = run([FORCE_EXIT_OPTION], {})
+    assert(r.status !== 0, `expected a non-zero exit, got ${r.status}\n${r.stdout}`)
+    const all = r.stdout + r.stderr
+    assert(all.includes(FORCE_EXIT_ERROR_CODE), `expected ${FORCE_EXIT_ERROR_CODE} in the output:\n${all.slice(0, 2000)}`)
+  })
+
+  test('the refusal reaches the runner BEFORE any test runs', () => {
+    // The point of refusing at `--import` time rather than reporting afterwards:
+    // nothing in the file executes, so no half-run is left to interpret.
+    const r = run([FORCE_EXIT_OPTION], {})
+    assert(!r.stdout.includes('# pass 1'), `no test should have passed:\n${r.stdout}`)
+  })
+
+  // The hook is what packages/protocol and packages/design-tokens --import;
+  // they have no setup module, so nothing else would prove it fires.
+  test('the --import hook refuses on its own', () => {
+    const r = spawnSync(process.execPath, ['--import', HOOK_PATH, '--test-force-exit', '-e', "console.log('RAN')"], { encoding: 'utf8' })
+    assert(r.status !== 0, `expected a non-zero exit, got ${r.status}`)
+    assert(!`${r.stdout}`.includes('RAN'), 'the program must not have run')
+    assert(`${r.stderr}`.includes(FORCE_EXIT_ERROR_CODE), `expected the refusal:\n${r.stderr.slice(0, 1000)}`)
+  })
+
+  test('POSITIVE CONTROL: the hook is inert without the flag', () => {
+    const r = spawnSync(process.execPath, ['--import', HOOK_PATH, '-e', "console.log('RAN')"], { encoding: 'utf8' })
+    assert(r.status === 0, `expected exit 0, got ${r.status}\n${r.stderr}`)
+    assert(`${r.stdout}`.includes('RAN'), 'the program must have run')
+  })
+
+  test('the escape hatch lets the same spawn through', () => {
+    const r = run([FORCE_EXIT_OPTION], { [FORCE_EXIT_ALLOW_ENV]: '1' })
+    assert(r.status === 0, `expected exit 0, got ${r.status}\n${r.stdout}\n${r.stderr}`)
+    // stdout, not stderr: under process isolation the child's stderr is folded
+    // into the runner's TAP diagnostics, so the operator sees it on stdout.
+    const all = r.stdout + r.stderr
+    assert(all.includes('WARNING'), `expected the warning in the output:\n${all.slice(0, 2000)}`)
+    assert(all.includes('# pass 1'), `the probe must still run:\n${r.stdout}`)
+  })
+} finally {
+  rmSync(dir, { recursive: true, force: true })
+}
+
+const ACCOUNTED = pass + fail
+if (ACCOUNTED < MIN_CASES) {
+  process.stderr.write(
+    `\nERROR: only ${ACCOUNTED} case(s) accounted for, expected at least ${MIN_CASES}. ` +
+    'Cases went missing rather than failing.\n',
+  )
+  process.exit(1)
+}
+process.stdout.write(`\n${pass} passed, ${fail} failed\n`)
+if (fail > 0) {
+  for (const f of failures) {
+    process.stderr.write(`\n[FAIL] ${f.name}\n${f.err.stack || f.err.message}\n`)
+  }
+  process.exit(1)
+}
+process.exit(0)

--- a/scripts/__tests__/no-test-force-exit.test.mjs
+++ b/scripts/__tests__/no-test-force-exit.test.mjs
@@ -32,7 +32,7 @@ import { spawnSync } from 'node:child_process'
 import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 
 import {
   FORCE_EXIT_ALLOW_ENV,
@@ -45,13 +45,16 @@ import {
 
 const HERE = dirname(fileURLToPath(import.meta.url))
 const REPO_ROOT = resolve(HERE, '..', '..')
-const MODULE_PATH = resolve(REPO_ROOT, 'scripts/lib/no-test-force-exit.mjs')
-const HOOK_PATH = resolve(REPO_ROOT, 'scripts/lib/no-test-force-exit-hook.mjs')
+// File URLs, not bare paths: an absolute Windows path is not a valid ESM
+// specifier for `--import` (or for an `import` statement), and node rejects it
+// with ERR_UNSUPPORTED_ESM_URL_SCHEME on protocol "a:"/"c:".
+const MODULE_URL = pathToFileURL(resolve(REPO_ROOT, 'scripts/lib/no-test-force-exit.mjs')).href
+const HOOK_URL = pathToFileURL(resolve(REPO_ROOT, 'scripts/lib/no-test-force-exit-hook.mjs')).href
 
 // A floor on the number of cases accounted for, so a run that loses cases
 // (an early `return`, a bad refactor) goes red instead of printing a small
 // tidy "all passed".
-const MIN_CASES = 30
+const MIN_CASES = 31
 
 let pass = 0
 let fail = 0
@@ -291,7 +294,7 @@ try {
   const shim = join(dir, 'shim.mjs')
   writeFileSync(
     shim,
-    `import { assertNoTestForceExit } from ${JSON.stringify(MODULE_PATH)}\nassertNoTestForceExit()\n`,
+    `import { assertNoTestForceExit } from ${JSON.stringify(MODULE_URL)}\nassertNoTestForceExit()\n`,
   )
   const probe = join(dir, 'probe.test.js')
   writeFileSync(
@@ -301,9 +304,18 @@ try {
 
   const run = (extraArgs, env) => spawnSync(
     process.execPath,
-    ['--import', shim, '--test', ...extraArgs, probe],
+    ['--import', pathToFileURL(shim).href, '--test', ...extraArgs, probe],
     { encoding: 'utf8', env: { ...process.env, ...env }, cwd: dir },
   )
+
+  test('every --import specifier is a file:// URL, not a bare path (Windows)', () => {
+    // Pins the shape that broke the Windows job: an absolute path is not a valid
+    // ESM specifier there. This runs on every platform, so the regression is
+    // caught on Linux/macOS too rather than only where it hurts.
+    for (const [name, url] of [['module', MODULE_URL], ['hook', HOOK_URL], ['shim', pathToFileURL(shim).href]]) {
+      assert(url.startsWith('file://'), `${name} specifier must be a file URL, got: ${url}`)
+    }
+  })
 
   test('POSITIVE CONTROL: the same spawn is green without the flag', () => {
     const r = run([], {})
@@ -328,14 +340,14 @@ try {
   // The hook is what packages/protocol and packages/design-tokens --import;
   // they have no setup module, so nothing else would prove it fires.
   test('the --import hook refuses on its own', () => {
-    const r = spawnSync(process.execPath, ['--import', HOOK_PATH, '--test-force-exit', '-e', "console.log('RAN')"], { encoding: 'utf8' })
+    const r = spawnSync(process.execPath, ['--import', HOOK_URL, '--test-force-exit', '-e', "console.log('RAN')"], { encoding: 'utf8' })
     assert(r.status !== 0, `expected a non-zero exit, got ${r.status}`)
     assert(!`${r.stdout}`.includes('RAN'), 'the program must not have run')
     assert(`${r.stderr}`.includes(FORCE_EXIT_ERROR_CODE), `expected the refusal:\n${r.stderr.slice(0, 1000)}`)
   })
 
   test('POSITIVE CONTROL: the hook is inert without the flag', () => {
-    const r = spawnSync(process.execPath, ['--import', HOOK_PATH, '-e', "console.log('RAN')"], { encoding: 'utf8' })
+    const r = spawnSync(process.execPath, ['--import', HOOK_URL, '-e', "console.log('RAN')"], { encoding: 'utf8' })
     assert(r.status === 0, `expected exit 0, got ${r.status}\n${r.stderr}`)
     assert(`${r.stdout}`.includes('RAN'), 'the program must have run')
   })

--- a/scripts/lib/no-test-force-exit-hook.mjs
+++ b/scripts/lib/no-test-force-exit-hook.mjs
@@ -1,0 +1,14 @@
+// no-test-force-exit-hook.mjs — the side-effecting form of the refusal, for
+// packages whose test command has no `tests/_setup.mjs` to hang it on (#7400).
+//
+// `packages/server` and `packages/claude-hooks` call `assertNoTestForceExit()`
+// from their own setup module. `packages/protocol` and `packages/design-tokens`
+// have no setup module, so they `--import` this file instead. Same refusal,
+// same measurements, same escape hatch — see `./no-test-force-exit.mjs`.
+//
+// This exists as a separate file because the library module must NOT fire on
+// import: its own tests import it, and a module that refuses at link time
+// cannot be tested.
+import { assertNoTestForceExit } from './no-test-force-exit.mjs'
+
+assertNoTestForceExit()

--- a/scripts/lib/no-test-force-exit.mjs
+++ b/scripts/lib/no-test-force-exit.mjs
@@ -1,0 +1,154 @@
+// no-test-force-exit.mjs — the ONE refusal both test harnesses install.
+//
+// #7400: `--test-force-exit` makes the Node test runner report FEWER TESTS
+// THAN IT RAN, non-deterministically, while exiting 0 with `# fail 0`. It is
+// the false-safety shape `docs/false-safety-guards.md` catalogues: "ran and
+// passed" and "never reported" are the same observable outcome, so every green
+// run is worth less than it looks.
+//
+// ── Measured on this repo, 2026-08-27, node v22.22.3 ────────────────────────
+//
+// `node --import ./tests/_setup.mjs --experimental-test-module-mocks --test
+// tests/base-session.test.js`, a file with 192 tests:
+//
+//   WITH --test-force-exit:   192 / 165 / 173 / 162 / 154   (all `# fail 0`, exit 0)
+//   WITHOUT:                  192 / 192 / 192               (exit 0)
+//
+// The tests are not skipped — their RESULTS are lost. A root `beforeEach`
+// appending one line per test to a side file recorded all 192 on a run whose
+// summary said 168.
+//
+// The mechanism is the process boundary, not the reporter: with
+// `--experimental-test-isolation=none` (or running the file in-process, no
+// `--test`) the flag reported 192 three times out of three. Under the default
+// process isolation the child INHERITS the flag — `process.execArgv` in a child
+// reads `["--test-force-exit","--test-force-exit"]` — so the child
+// `process.exit()`s as soon as its own root test settles, and whatever it had
+// queued for the parent goes with it.
+//
+// What survives: a real failure. A deliberately failing test placed mid-file
+// and at the tail exited 1 on 14 of 14 runs, truncated or not, because the
+// child's non-zero exit code reaches the parent regardless. So RED stays
+// trustworthy; it is the COUNT, and therefore every GREEN, that does not.
+//
+// ── Why refusing costs nothing ──────────────────────────────────────────────
+//
+// The flag existed to paper over leaked handles that kept the runner alive
+// (#5480 lore). Those leaks were fixed — #6027 / #6042 / #6100 — and the repo
+// has passed the flag nowhere since. Re-measured 2026-08-27, every one of the
+// eight files on the #6027 leak map exits on its own without it, and the flag
+// buys no wall clock: byok-session 66.5s -> 63.9s, byok-mcp-client 74.9s ->
+// 74.9s, tunnel/cloudflare 27.3s -> 27.3s. A file that hangs today is a leak to
+// fix, not a flag to add — and CI runs without the flag, so force-exiting
+// locally hides exactly the leak CI will hit.
+//
+// ── Spellings this has to catch ─────────────────────────────────────────────
+//
+// Node normalises `_` to `-` in option names, so `--test_force_exit` is the
+// same flag and lands in `execArgv` spelled with underscores. And node does NOT
+// read the value of this boolean: `--test-force-exit=false` still truncates
+// (measured 164 / 155 / 159 of 192), so any `=value` form is a hit.
+//
+// NODE_OPTIONS is scanned too. Node currently rejects the flag there outright
+// ("--test-force-exit is not allowed in NODE_OPTIONS"), which means the scan is
+// expected to find nothing — but "it cannot happen" silently treated as
+// "nothing to check" is its own entry in the catalogue, and an allowlist can
+// change under us in a Node upgrade.
+
+// ── Where this is installed ─────────────────────────────────────────────────
+//
+// Every package whose tests run on `node --test`:
+//
+//   packages/server        tests/_setup.mjs        (already --import'd)
+//   packages/claude-hooks  tests/_setup.mjs        (already --import'd)
+//   packages/protocol      --import ./no-test-force-exit-hook.mjs
+//   packages/design-tokens --import ./no-test-force-exit-hook.mjs
+//
+// The first two have a setup module and call `assertNoTestForceExit()` from it;
+// the other two have none, so they import the side-effecting hook next door.
+// `packages/dashboard` and `packages/store-core` run vitest and `packages/app`
+// runs jest — none of them accepts this flag, so there is nothing to refuse.
+
+export const FORCE_EXIT_OPTION = '--test-force-exit'
+export const FORCE_EXIT_ERROR_CODE = 'CHROXY_TEST_FORCE_EXIT'
+export const FORCE_EXIT_ALLOW_ENV = 'CHROXY_ALLOW_TEST_FORCE_EXIT'
+
+/**
+ * Reduce one node CLI argument to its canonical option name: drop any `=value`
+ * and fold `_` to `-`, the two transformations node itself applies. Returns the
+ * argument unchanged if it is not an option.
+ */
+export function normalizeNodeOptionName (arg) {
+  if (typeof arg !== 'string' || !arg.startsWith('-')) return arg
+  const eq = arg.indexOf('=')
+  const name = eq === -1 ? arg : arg.slice(0, eq)
+  return name.replaceAll('_', '-')
+}
+
+/**
+ * Find `--test-force-exit` in this process's node options.
+ *
+ * @returns {{ source: 'execArgv' | 'NODE_OPTIONS', arg: string } | null}
+ */
+export function findTestForceExit ({ execArgv = process.execArgv, env = process.env } = {}) {
+  for (const arg of execArgv ?? []) {
+    if (normalizeNodeOptionName(arg) === FORCE_EXIT_OPTION) return { source: 'execArgv', arg }
+  }
+  // NODE_OPTIONS is whitespace-separated; the flag itself contains no spaces,
+  // so a plain split is enough to spot it.
+  for (const arg of String(env?.NODE_OPTIONS ?? '').split(/\s+/)) {
+    if (arg && normalizeNodeOptionName(arg) === FORCE_EXIT_OPTION) return { source: 'NODE_OPTIONS', arg }
+  }
+  return null
+}
+
+export function forceExitRefusalMessage ({ source, arg }) {
+  return (
+    `${FORCE_EXIT_ERROR_CODE}: refusing to run the test suite with \`${arg}\` (via ${source}).\n` +
+    '\n' +
+    '  It does not skip tests — it drops their RESULTS. Measured on\n' +
+    '  base-session.test.js (192 tests): 154-192 reported across five runs, every\n' +
+    '  one of them `# fail 0`, exit 0. A green run therefore proves nothing about\n' +
+    '  which tests ran, which is fatal for mutation testing (#7400).\n' +
+    '\n' +
+    '  Drop the flag. The leaked handles it worked around were fixed in #6027 /\n' +
+    '  #6042, CI has never passed it, and it saves no wall clock. If a file hangs\n' +
+    '  after its summary, that is a leaked handle to tear down in the test — the\n' +
+    '  same leak CI will hit, which this flag would hide.\n' +
+    '\n' +
+    `  Deliberately debugging the flag itself? Set ${FORCE_EXIT_ALLOW_ENV}=1 and the\n` +
+    '  run proceeds with a warning instead.'
+  )
+}
+
+/**
+ * Throw unless this process was started without `--test-force-exit`.
+ *
+ * Installed from each package's `tests/_setup.mjs`, which `--import` puts ahead
+ * of the test graph — so the refusal lands before a single test runs, in the
+ * runner's own process and in every child it spawns.
+ *
+ * @returns {{ allowed: true, found: object } | null} `null` when clean; the
+ *   found flag when the escape hatch waived it (a warning is printed).
+ */
+export function assertNoTestForceExit ({
+  execArgv = process.execArgv,
+  env = process.env,
+  warn = (msg) => process.stderr.write(msg + '\n'),
+} = {}) {
+  const found = findTestForceExit({ execArgv, env })
+  if (!found) return null
+
+  if (env?.[FORCE_EXIT_ALLOW_ENV]) {
+    warn(
+      `WARNING: running with \`${found.arg}\` because ${FORCE_EXIT_ALLOW_ENV} is set.\n` +
+      '  Test COUNTS from this run are not trustworthy — up to 20% of results are\n' +
+      '  dropped silently while the run still exits 0 (#7400).',
+    )
+    return { allowed: true, found }
+  }
+
+  const err = new Error(forceExitRefusalMessage(found))
+  err.code = FORCE_EXIT_ERROR_CODE
+  throw err
+}

--- a/scripts/lib/no-test-force-exit.mjs
+++ b/scripts/lib/no-test-force-exit.mjs
@@ -68,6 +68,11 @@
 // the other two have none, so they import the side-effecting hook next door.
 // `packages/dashboard` and `packages/store-core` run vitest and `packages/app`
 // runs jest — none of them accepts this flag, so there is nothing to refuse.
+//
+// The limit, stated rather than left to be discovered: a run that skips
+// `--import` altogether (`node --test tests/foo.test.js`, no setup module) is
+// not reachable from here. Such a run also has no fs write sandbox, which is
+// the larger reason not to do it — see `tests/_setup.mjs` and #4633.
 
 export const FORCE_EXIT_OPTION = '--test-force-exit'
 export const FORCE_EXIT_ERROR_CODE = 'CHROXY_TEST_FORCE_EXIT'

--- a/scripts/lib/no-test-force-exit.mjs
+++ b/scripts/lib/no-test-force-exit.mjs
@@ -73,6 +73,17 @@ export const FORCE_EXIT_OPTION = '--test-force-exit'
 export const FORCE_EXIT_ERROR_CODE = 'CHROXY_TEST_FORCE_EXIT'
 export const FORCE_EXIT_ALLOW_ENV = 'CHROXY_ALLOW_TEST_FORCE_EXIT'
 
+// The escape hatch takes an explicit AFFIRMATIVE value, not any truthy string.
+// `CHROXY_ALLOW_TEST_FORCE_EXIT=0` and `=false` read, to anyone who exported
+// them, as "guard on" — and under plain truthiness they turn it off, silently,
+// which is the failure this whole module is about.
+const ALLOW_VALUES = new Set(['1', 'true', 'yes', 'on'])
+
+/** Is this env value an explicit "yes, waive the refusal"? */
+export function isAllowValue (raw) {
+  return ALLOW_VALUES.has(String(raw ?? '').trim().toLowerCase())
+}
+
 /**
  * Reduce one node CLI argument to its canonical option name: drop any `=value`
  * and fold `_` to `-`, the two transformations node itself applies. Returns the
@@ -117,7 +128,8 @@ export function forceExitRefusalMessage ({ source, arg }) {
     '  same leak CI will hit, which this flag would hide.\n' +
     '\n' +
     `  Deliberately debugging the flag itself? Set ${FORCE_EXIT_ALLOW_ENV}=1 and the\n` +
-    '  run proceeds with a warning instead.'
+    '  run proceeds with a warning instead. Only 1/true/yes/on waive it — anything\n' +
+    '  else, including 0 and false, still refuses.'
   )
 }
 
@@ -125,8 +137,18 @@ export function forceExitRefusalMessage ({ source, arg }) {
  * Throw unless this process was started without `--test-force-exit`.
  *
  * Installed from each package's `tests/_setup.mjs`, which `--import` puts ahead
- * of the test graph — so the refusal lands before a single test runs, in the
- * runner's own process and in every child it spawns.
+ * of the test graph — so the refusal lands before a single test in that file
+ * runs.
+ *
+ * WHICH process, precisely, because it is not the obvious one: under the
+ * default process isolation `--import` runs in the per-file CHILDREN only. The
+ * runner parent never loads it (measured: two children logged the hook, the
+ * parent did not), so the parent keeps its own `--test-force-exit` and still
+ * force-exits while it aggregates. That is fine — every file fails, the run is
+ * red, and the refusals are small enough to survive the parent's exit — but the
+ * authoritative signal is the non-zero exit, not the message. With
+ * `--experimental-test-isolation=none` it is the other way round: one process,
+ * which does load the hook, and where the flag was harmless anyway.
  *
  * @returns {{ allowed: true, found: object } | null} `null` when clean; the
  *   found flag when the escape hatch waived it (a warning is printed).
@@ -139,7 +161,7 @@ export function assertNoTestForceExit ({
   const found = findTestForceExit({ execArgv, env })
   if (!found) return null
 
-  if (env?.[FORCE_EXIT_ALLOW_ENV]) {
+  if (isAllowValue(env?.[FORCE_EXIT_ALLOW_ENV])) {
     warn(
       `WARNING: running with \`${found.arg}\` because ${FORCE_EXIT_ALLOW_ENV} is set.\n` +
       '  Test COUNTS from this run are not trustworthy — up to 20% of results are\n' +


### PR DESCRIPTION
## What

`--test-force-exit` makes the Node test runner **report fewer tests than it ran**, non-deterministically, while exiting 0 with `# fail 0`. Both `tests/_setup.mjs` files — and the two `node --test` packages that have no setup module — now refuse the flag outright.

## Measured (node v22.22.3)

`node --import ./tests/_setup.mjs --experimental-test-module-mocks --test tests/base-session.test.js`, a file with 192 tests:

```
WITH --test-force-exit:   192 / 165 / 173 / 162 / 154   (every run `# fail 0`, exit 0)
WITHOUT:                  192 / 192 / 192               (exit 0)
```

Three things the issue did not yet have:

1. **The tests are not skipped — their results are lost.** A root `beforeEach` appending one line per test to a side file recorded **all 192** on a run whose summary said 168.
2. **It is the process boundary.** With `--experimental-test-isolation=none` (or in-process, no `--test`) the flag reported 192 three times out of three. Under default isolation the child inherits the flag (`process.execArgv` in a child: `["--test-force-exit","--test-force-exit"]`), `process.exit()`s when its own root test settles, and whatever it had queued for the parent goes with it.
3. **RED stays red.** A deliberate failure planted mid-file and at the tail exited 1 on **14 of 14** runs, truncated or not — the child's non-zero exit reaches the parent regardless. So only GREEN was ever overstated. That matches the issue's claim and bounds the damage.

## Acceptance criteria

- [x] **Root-cause which handle keeps the runner alive such that the flag is needed at all** — none does, any more. #6027/#6042/#6100 fixed the leaks. Re-measured today: all eight files on the #6027 leak map exit on their own without the flag, and it saves no wall clock (byok-session 66.5s → 63.9s, byok-mcp-client 74.9s → 74.9s, tunnel/cloudflare 27.3s → 27.3s). The full suite completes without it — 14059 tests locally, 14049 in CI.
- [x] **Make truncation loud** — better than loud: refused. A run started with the flag dies at `--import` time, before a test executes, naming the code, the measurement and the escape hatch.
- [x] **Correct the stale docblock in `assert-test-count.mjs`** — it claimed the server test command passes the flag. It has not since #6042, and that sentence is what re-derived, for the next reader, that typing it locally was safe. Its floor also moves 9700 → 13500 (live: 14049 CI / 14059 local).
- [x] **Update `CLAUDE.md`'s guidance** — the testing-conventions section now gives the exact targeted-run command and says a file that hangs after its summary is a leak to tear down, not a flag to add. AGENTS.md regenerated.

## How it is guarded

`scripts/lib/no-test-force-exit.mjs` scans `execArgv` **and** `NODE_OPTIONS`, folding `_`→`-` (node accepts `--test_force_exit`) and stripping `=value` (`--test-force-exit=false` still truncates — 164/155/159 of 192). `CHROXY_ALLOW_TEST_FORCE_EXIT=1` waives it with a warning.

Installed everywhere `node --test` runs: `packages/server` and `packages/claude-hooks` call it from their setup module; `packages/protocol` and `packages/design-tokens` `--import` the side-effecting hook. dashboard/store-core (vitest) and app (jest) do not accept the flag.

Coverage is split deliberately: `scripts/__tests__/no-test-force-exit.test.mjs` (25 cases, wired into **Scripts Tests**) proves the module; a per-package call-site file proves each setup still calls it. Mutation-tested — 7 mutants, all killed red/legible in <1.3s, and deleting the server call site kills **only** the call-site file, which is why it exists.

Every spawn case carries a positive control. That was not decoration: the first cut's refusal cases were satisfied by a child that inherited `NODE_TEST_CONTEXT` and skipped running files entirely — exit 0, nothing reported. The control named it.

Catalogued as **entry 19** in `docs/false-safety-guards.md` — the instrument itself carrying the defect the document's own detection method (mutation testing) runs through.

Closes #7400