### PR TITLE
fix(app,dashboard): key the isPlanPending replay wipe to the replayed session

### DIFF
--- a/packages/app/src/__tests__/store/message-handler.test.ts
+++ b/packages/app/src/__tests__/store/message-handler.test.ts
@@ -537,6 +537,108 @@ describe('history_replay_start clears stale session_stopped marker (#4909)', () 
   });
 });
 
+// #7402 — the `isPlanPending` / `planAllowedPrompts` wipe on
+// `history_replay_start` must target the session the frame is REPLAYING, not
+// whichever session happens to be active. Same mis-keying #7340 fixed for
+// `activeAgents` in the block immediately above it, and #4909 fixed for
+// `stoppedAt`/`stoppedCode` in the block below.
+//
+// `subscribe_sessions` replays every newly-subscribed BACKGROUND session
+// (server `session-handlers.js`), and both clients fire it for all non-active
+// sessions on every `session_list` — i.e. on every reconnect. Keyed to
+// `activeSessionId`, that burst cancels a pending plan approval the user is
+// looking at, on the very reconnect that is supposed to restore it.
+describe('history_replay_start: isPlanPending wipe targeting (#7402)', () => {
+  afterEach(() => {
+    resetReplayFlags();
+  });
+
+  function seedTwoSessions() {
+    const store = createMockStore({
+      activeSessionId: 's1',
+      sessions: [
+        { sessionId: 's1', name: 'S1' } as any,
+        { sessionId: 's2', name: 'S2' } as any,
+      ],
+      sessionStates: {
+        s1: { ...createEmptySessionState(), isPlanPending: true, planAllowedPrompts: [{ tool: 'ExitPlanMode', prompt: 'go ahead' }] },
+        s2: createEmptySessionState(),
+      },
+    });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+    return store;
+  }
+
+  it("a background session's replay does not cancel the active session's pending plan", () => {
+    const store = seedTwoSessions();
+
+    _testMessageHandler.handle({ type: 'history_replay_start', sessionId: 's2' });
+
+    const state = store.getState();
+    expect(state.sessionStates.s1.isPlanPending).toBe(true);
+    expect(state.sessionStates.s1.planAllowedPrompts).toEqual([{ tool: 'ExitPlanMode', prompt: 'go ahead' }]);
+  });
+
+  it('still clears the active session when it is the one being replayed', () => {
+    const store = seedTwoSessions();
+
+    _testMessageHandler.handle({ type: 'history_replay_start', sessionId: 's1' });
+
+    const state = store.getState();
+    expect(state.sessionStates.s1.isPlanPending).toBe(false);
+    expect(state.sessionStates.s1.planAllowedPrompts).toEqual([]);
+  });
+
+  it("clears a background session's own pending plan when it is the replay target", () => {
+    const store = createMockStore({
+      activeSessionId: 's1',
+      sessions: [
+        { sessionId: 's1', name: 'S1' } as any,
+        { sessionId: 's2', name: 'S2' } as any,
+      ],
+      sessionStates: {
+        s1: createEmptySessionState(),
+        s2: { ...createEmptySessionState(), isPlanPending: true, planAllowedPrompts: [{ tool: 'ExitPlanMode', prompt: 'yes' }] },
+      },
+    });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    _testMessageHandler.handle({ type: 'history_replay_start', sessionId: 's2' });
+
+    const state = store.getState();
+    expect(state.sessionStates.s2.isPlanPending).toBe(false);
+    expect(state.sessionStates.s2.planAllowedPrompts).toEqual([]);
+  });
+
+  // Frames without an explicit sessionId fall back to activeSessionId via
+  // sharedHistoryReplayStart, so the single-session case is unchanged.
+  it('falls back to the active session when the frame omits sessionId', () => {
+    const store = seedTwoSessions();
+
+    _testMessageHandler.handle({ type: 'history_replay_start' });
+
+    const state = store.getState();
+    expect(state.sessionStates.s1.isPlanPending).toBe(false);
+    expect(state.sessionStates.s1.planAllowedPrompts).toEqual([]);
+  });
+
+  // The wipe now runs against the REPLAYED session, which — unlike the active
+  // one — can be a partially-built state whose transient slices are undefined.
+  it('does not throw when the replayed session state is partially built', () => {
+    const store = seedTwoSessions();
+    delete (store.getState().sessionStates.s2 as any).isPlanPending;
+    delete (store.getState().sessionStates.s2 as any).planAllowedPrompts;
+
+    expect(() =>
+      _testMessageHandler.handle({ type: 'history_replay_start', sessionId: 's2' }),
+    ).not.toThrow();
+
+    // ...and the active session's pending plan is still untouched.
+    expect(store.getState().sessionStates.s1.isPlanPending).toBe(true);
+  });
+});
 describe('session_timeout handler', () => {
   it('removes timed-out session from sessionStates and sessions list', () => {
     const store = createMockStore({

--- a/packages/app/src/__tests__/store/message-handler.test.ts
+++ b/packages/app/src/__tests__/store/message-handler.test.ts
@@ -628,6 +628,10 @@ describe('history_replay_start: isPlanPending wipe targeting (#7402)', () => {
   // one — can be a partially-built state whose transient slices are undefined.
   it('does not throw when the replayed session state is partially built', () => {
     const store = seedTwoSessions();
+    // `activeAgents` is the slice the `?? 0` guard in the merged updater
+    // actually defends — deleting only the plan slices leaves the test unable
+    // to fail for the reason it is named after (neither is read unguarded).
+    delete (store.getState().sessionStates.s2 as any).activeAgents;
     delete (store.getState().sessionStates.s2 as any).isPlanPending;
     delete (store.getState().sessionStates.s2 as any).planAllowedPrompts;
 

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -2477,18 +2477,24 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         // handed it the ACTIVE session, which is fully initialised. Targeting
         // the replayed session means it can now be handed a partially-built
         // state whose transient slices are still undefined.
-        updateSession(replayTargetId, (ss) =>
-          (ss.activeAgents?.length ?? 0) > 0 ? { activeAgents: [] } : {},
-        );
+        //
+        // #7402 — `isPlanPending`/`planAllowedPrompts` are wiped here, on the
+        // REPLAYED session, for exactly the reasons above. They used to be
+        // wiped via `updateActiveSession`, so the same background-replay burst
+        // cancelled a pending plan approval the user was looking at, on the
+        // very reconnect that was supposed to restore it. #7340 moved
+        // `activeAgents` and deliberately left this alone to keep its blast
+        // radius to the bug it was fixing; this is the follow-up.
+        updateSession(replayTargetId, (ss) => {
+          const patch: Partial<SessionState> = {};
+          if ((ss.activeAgents?.length ?? 0) > 0) patch.activeAgents = [];
+          if (ss.isPlanPending) {
+            patch.isPlanPending = false;
+            patch.planAllowedPrompts = [];
+          }
+          return patch;
+        });
       }
-      updateActiveSession((ss) => {
-        const patch: Partial<SessionState> = {};
-        if (ss.isPlanPending) {
-          patch.isPlanPending = false;
-          patch.planAllowedPrompts = [];
-        }
-        return Object.keys(patch).length > 0 ? patch : {};
-      });
       // #4909 — `session_stopped` is a transient event NOT recorded into
       // per-session history (#4868 wire path), so it isn't replayed on
       // reconnect. But the client-side `stoppedAt`/`stoppedCode` derived

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -2479,12 +2479,14 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         // state whose transient slices are still undefined.
         //
         // #7402 — `isPlanPending`/`planAllowedPrompts` are wiped here, on the
-        // REPLAYED session, for exactly the reasons above. They used to be
-        // wiped via `updateActiveSession`, so the same background-replay burst
-        // cancelled a pending plan approval the user was looking at, on the
-        // very reconnect that was supposed to restore it. #7340 moved
-        // `activeAgents` and deliberately left this alone to keep its blast
-        // radius to the bug it was fixing; this is the follow-up.
+        // REPLAYED session, for the same KEYING reason as `activeAgents` (not
+        // the guarding note above, which is about reading a partially-built
+        // state). They used to be wiped via `updateActiveSession`, so the same
+        // background-replay burst cancelled a pending plan approval the user
+        // was looking at, on the very reconnect that was supposed to restore
+        // it. #7340 moved `activeAgents` and deliberately left this alone to
+        // keep its blast radius to the bug it was fixing; this is the
+        // follow-up.
         updateSession(replayTargetId, (ss) => {
           const patch: Partial<SessionState> = {};
           if ((ss.activeAgents?.length ?? 0) > 0) patch.activeAgents = [];

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -3496,6 +3496,92 @@ describe('dashboard message-handler dispatch', () => {
     });
   });
 
+  // #7402 — the `isPlanPending` / `planAllowedPrompts` wipe on
+  // `history_replay_start` must target the session the frame is REPLAYING, not
+  // whichever session happens to be active. Same mis-keying #7340 fixed for
+  // `activeAgents` (the describe above) and #4909 fixed for
+  // `stoppedAt`/`stoppedCode`.
+  //
+  // `subscribe_sessions` replays every newly-subscribed BACKGROUND session, and
+  // both clients fire it for all non-active sessions on every `session_list` —
+  // i.e. on every reconnect. Keyed to `activeSessionId`, that burst cancels a
+  // pending plan approval the user is looking at, on the very reconnect that is
+  // supposed to restore it.
+  describe('history replay: isPlanPending wipe targeting (#7402)', () => {
+    function seedTwoSessions() {
+      const a = createEmptySessionState();
+      const b = createEmptySessionState();
+      (a as any).isPlanPending = true;
+      (a as any).planAllowedPrompts = [{ tool: 'ExitPlanMode', prompt: 'go ahead' }];
+      store = createMockStore(
+        baseState({
+          activeSessionId: 's1',
+          sessions: [{ sessionId: 's1', name: 'S1' } as any, { sessionId: 's2', name: 'S2' } as any],
+          sessionStates: { s1: a, s2: b },
+        }),
+      );
+      setStore(store);
+    }
+
+    it("a background session's replay does not cancel the active session's pending plan", () => {
+      seedTwoSessions();
+      handleMessage({ type: 'history_replay_start', sessionId: 's2' }, ctx() as any);
+      const st = (store.getState() as any).sessionStates;
+      expect(st.s1.isPlanPending).toBe(true);
+      expect(st.s1.planAllowedPrompts).toEqual([{ tool: 'ExitPlanMode', prompt: 'go ahead' }]);
+    });
+
+    it('still clears the active session when it is the one being replayed', () => {
+      seedTwoSessions();
+      handleMessage({ type: 'history_replay_start', sessionId: 's1' }, ctx() as any);
+      const st = (store.getState() as any).sessionStates;
+      expect(st.s1.isPlanPending).toBe(false);
+      expect(st.s1.planAllowedPrompts).toEqual([]);
+    });
+
+    it("clears a background session's own pending plan when it is the replay target", () => {
+      const a = createEmptySessionState();
+      const b = createEmptySessionState();
+      (b as any).isPlanPending = true;
+      (b as any).planAllowedPrompts = [{ tool: 'ExitPlanMode', prompt: 'yes' }];
+      store = createMockStore(
+        baseState({
+          activeSessionId: 's1',
+          sessions: [{ sessionId: 's1', name: 'S1' } as any, { sessionId: 's2', name: 'S2' } as any],
+          sessionStates: { s1: a, s2: b },
+        }),
+      );
+      setStore(store);
+      handleMessage({ type: 'history_replay_start', sessionId: 's2' }, ctx() as any);
+      const st = (store.getState() as any).sessionStates;
+      expect(st.s2.isPlanPending).toBe(false);
+      expect(st.s2.planAllowedPrompts).toEqual([]);
+    });
+
+    // Frames without an explicit sessionId fall back to activeSessionId, so
+    // the single-session case is unchanged.
+    it('falls back to the active session when the frame omits sessionId', () => {
+      seedTwoSessions();
+      handleMessage({ type: 'history_replay_start' }, ctx() as any);
+      const st = (store.getState() as any).sessionStates;
+      expect(st.s1.isPlanPending).toBe(false);
+      expect(st.s1.planAllowedPrompts).toEqual([]);
+    });
+
+    // The wipe now runs against the REPLAYED session, which — unlike the active
+    // one — can be a partially-built state whose transient slices are undefined.
+    it('does not throw when the replayed session state is partially built', () => {
+      seedTwoSessions();
+      delete ((store.getState() as any).sessionStates.s2 as any).isPlanPending;
+      delete ((store.getState() as any).sessionStates.s2 as any).planAllowedPrompts;
+      expect(() =>
+        handleMessage({ type: 'history_replay_start', sessionId: 's2' }, ctx() as any),
+      ).not.toThrow();
+      // ...and the active session's pending plan is still untouched.
+      expect((store.getState() as any).sessionStates.s1.isPlanPending).toBe(true);
+    });
+  });
+
   describe('history replay: user_input rehydration', () => {
     function seed() {
       store = createMockStore(

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -3572,6 +3572,10 @@ describe('dashboard message-handler dispatch', () => {
     // one — can be a partially-built state whose transient slices are undefined.
     it('does not throw when the replayed session state is partially built', () => {
       seedTwoSessions();
+      // `activeAgents` is the slice the `?? 0` guard in the merged updater
+      // actually defends — deleting only the plan slices leaves the test unable
+      // to fail for the reason it is named after (neither is read unguarded).
+      delete ((store.getState() as any).sessionStates.s2 as any).activeAgents;
       delete ((store.getState() as any).sessionStates.s2 as any).isPlanPending;
       delete ((store.getState() as any).sessionStates.s2 as any).planAllowedPrompts;
       expect(() =>

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -5141,28 +5141,35 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         // handed it the ACTIVE session, which is fully initialised. Targeting
         // the replayed session means it can now be handed a partially-built
         // state whose transient slices are still undefined.
-        updateSession(replayTargetId, (ss) =>
-          (ss.activeAgents?.length ?? 0) > 0 ? { activeAgents: [] } : {},
-        );
+        //
+        // #7402 — `isPlanPending`/`planAllowedPrompts` are wiped here, on the
+        // REPLAYED session, for exactly the reasons above. They used to be
+        // wiped via `updateActiveSession`, so the same background-replay burst
+        // cancelled a pending plan approval the user was looking at, on the
+        // very reconnect that was supposed to restore it. #7340 moved
+        // `activeAgents` and deliberately left this alone to keep its blast
+        // radius to the bug it was fixing; this is the follow-up.
+        //
+        // #4466: activeTools is deliberately NOT wiped here. The earlier #4308
+        // wipe rebuilt entries from replayed tool_start events with
+        // startedAt = Date.now(), so the "Running <tool> · Ns" pill restarted
+        // at 1s every time the user switched tabs. The in-flight set is
+        // authoritative (carried in-memory, not derivable from history), so
+        // keeping it intact preserves the elapsed-time clock. tool_result
+        // events that fire during replay still correctly drop resolved entries
+        // via sharedToolResult, and the dedup logic in sharedToolStart prevents
+        // replayed tool_start events from re-adding tools already in
+        // activeTools.
+        updateSession(replayTargetId, (ss) => {
+          const patch: Partial<SessionState> = {};
+          if ((ss.activeAgents?.length ?? 0) > 0) patch.activeAgents = [];
+          if (ss.isPlanPending) {
+            patch.isPlanPending = false;
+            patch.planAllowedPrompts = [];
+          }
+          return patch;
+        });
       }
-      updateActiveSession((ss) => {
-        const patch: Partial<SessionState> = {};
-        // #4466: preserve activeTools through the replay boundary. The
-        // earlier #4308 wipe rebuilt entries from replayed tool_start
-        // events with startedAt = Date.now(), so the "Running <tool> · Ns"
-        // pill restarted at 1s every time the user switched tabs. The
-        // in-flight set is authoritative (carried in-memory, not derivable
-        // from history), so keeping it intact preserves the elapsed-time
-        // clock. tool_result events that fire during replay still
-        // correctly drop resolved entries via sharedToolResult, and the
-        // dedup logic in sharedToolStart prevents replayed tool_start
-        // events from re-adding tools already in activeTools.
-        if (ss.isPlanPending) {
-          patch.isPlanPending = false;
-          patch.planAllowedPrompts = [];
-        }
-        return Object.keys(patch).length > 0 ? patch : {};
-      });
       break;
     }
 

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -883,12 +883,19 @@ export function resetReplayFlags(): void {
 // explicit reset). Closing the viewer, the watchdog firing, and Retry must
 // NOT disarm it mid-stream: frames arriving after a disarm are not inert.
 // A `message` frame would fall through the switch below to its flat
-// `get().addMessage(...)` fallback (transcript text rendered as live chat),
-// and a late `history_replay_start` would reach `updateActiveSession`, which
-// WIPES the live session's `activeAgents` and cancels `isPlanPending` /
-// `planAllowedPrompts` — i.e. opening and closing the read-only viewer could
-// silently drop a pending plan approval. So: closing the viewer stops
-// RENDERING, never INTERCEPTING.
+// `get().addMessage(...)` fallback, rendering transcript text as live chat.
+//
+// A late `history_replay_start` no longer wipes live transient state: #4909,
+// #7340 and #7402 between them moved every slice of that case body off
+// `activeSessionId` and onto the frame's own `replayTargetId`, which for a
+// transcript id has no `sessionStates` entry, so the wipe block is skipped
+// entirely. Do NOT read that as "late replay frames are now inert" — the two
+// unconditional statements above the wipe still run on the frame's raw id, so
+// a disarmed transcript stream would add a conversationId to
+// `_replayingSessions` (gating live-session replay logic on an id that is not
+// a session) and hand it to `reconcileReplayStart` as a rebuild baseline.
+//
+// So: closing the viewer stops RENDERING, never INTERCEPTING.
 //
 // Arming is REFCOUNTED per id because Retry re-requests the SAME
 // conversationId while stream 1 may still be on the wire — stream 1's
@@ -5132,9 +5139,10 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       // same id is what makes the pair a genuine snapshot replace.
       //
       // `replayTargetId` falls back to `activeSessionId` when the frame omits
-      // `sessionId`, so the single-session case is unchanged. This mirrors the
-      // #4909 block below, which made exactly this move for
-      // `stoppedAt`/`stoppedCode` and explained why.
+      // `sessionId`, so the single-session case is unchanged. This mirrors what
+      // #4909 did for `stoppedAt`/`stoppedCode` — in the APP's copy of this
+      // case, which is where that block lives; the dashboard has no equivalent
+      // block here because it clears `stoppedAt` in `connection.ts` instead.
       if (replayTargetId && get().sessionStates[replayTargetId]) {
         // `activeAgents?.length` — the old code read `ss.activeAgents.length`
         // unguarded and was safe only because `updateActiveSession` always
@@ -5143,12 +5151,14 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         // state whose transient slices are still undefined.
         //
         // #7402 — `isPlanPending`/`planAllowedPrompts` are wiped here, on the
-        // REPLAYED session, for exactly the reasons above. They used to be
-        // wiped via `updateActiveSession`, so the same background-replay burst
-        // cancelled a pending plan approval the user was looking at, on the
-        // very reconnect that was supposed to restore it. #7340 moved
-        // `activeAgents` and deliberately left this alone to keep its blast
-        // radius to the bug it was fixing; this is the follow-up.
+        // REPLAYED session, for the same KEYING reason as `activeAgents` (not
+        // the guarding note above, which is about reading a partially-built
+        // state). They used to be wiped via `updateActiveSession`, so the same
+        // background-replay burst cancelled a pending plan approval the user
+        // was looking at, on the very reconnect that was supposed to restore
+        // it. #7340 moved `activeAgents` and deliberately left this alone to
+        // keep its blast radius to the bug it was fixing; this is the
+        // follow-up.
         //
         // #4466: activeTools is deliberately NOT wiped here. The earlier #4308
         // wipe rebuilt entries from replayed tool_start events with


### PR DESCRIPTION
## Problem

On `history_replay_start`, both clients cleared `isPlanPending` / `planAllowedPrompts` via `updateActiveSession`, which resolves `state.activeSessionId` and **ignores the frame's `sessionId`** — even though `replayTargetId` is already computed two lines above.

`subscribe_sessions` replays every newly-subscribed **background** session (`handlers/session-handlers.js`), and both clients fire it for all non-active sessions on every `session_list` — i.e. on every reconnect. So a background session's replay cancelled the **active** session's pending plan approval, on the very reconnect that was supposed to restore it.

Same mis-keying #7340 fixed for `activeAgents` and #4909 fixed for `stoppedAt`/`stoppedCode`, in the same code block. #7340 deliberately left `isPlanPending` alone to keep its blast radius to the bug it was fixing; this is that follow-up.

## Fix

Fold the wipe into the existing `replayTargetId` block in both clients, so one `updateSession` call clears both transient slices for the session the frame is actually replaying. `replayTargetId` falls back to `activeSessionId` when the frame omits `sessionId`, so the single-session case is unchanged. The merged updater guards both slices (`ss.activeAgents?.length ?? 0`, `ss.isPlanPending`) because the replayed session — unlike the active one — can be a partially-built state.

The dashboard's #4466 note (why `activeTools` is deliberately *not* wiped) is preserved and moved with the block.

## Acceptance criteria

- [x] `isPlanPending` / `planAllowedPrompts` cleared for `replayTargetId`, not `activeSessionId`, on **both** clients
- [x] A test that a background session's replay does not cancel the active session's pending plan
- [x] A test that the single-session case (frame omits `sessionId`) is unchanged

## Verification

Five tests per client. Each was **proven red against the pre-fix source with the final fixtures** — sources reverted to `origin/main` with the new tests kept, giving **3 failed / 2 passed on both clients**; the 2 that pass are the "unchanged" controls (active-is-target, no-`sessionId` fallback), which is the split a correct fix should produce.

| Gate | Result |
|---|---|
| dashboard full suite | 301 files / **5252 passed** |
| app full suite | 181 suites / **2359 passed** |
| `tsc --noEmit` (dashboard) | clean |
| `tsc --noEmit` (app, as CI runs it) | clean |

`tsc` caught the first draft of the test fixtures using `string[]` for `planAllowedPrompts`; they now use the real `{ tool, prompt }` shape.

The app suite's "worker process has failed to exit gracefully" warning is **pre-existing** — reproduced on unmodified `origin/main` with these changes reverted.

Closes #7402