### PR TITLE
test(server): stop assert.match serialising whole files into failure output

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -331,6 +331,17 @@ The recurring causes:
   192 of one file's 192 tests across five runs, every run `# fail 0` and exit 0,
   while a side-channel proved all 192 had executed (`#7400`)
 
+**Collapse to a boolean before asserting against file text.** A failing
+`assert.match(subject, re)` carries the ENTIRE subject as the error's `actual`
+— 124 KB of TAP for a one-line assertion, and it has wedged the runner
+(`#7340`, catalogue entry 17). Write `assert.ok(re.test(src), 'message')`
+instead; `assert.deepEqual` against a large array wants the same treatment (map
+to the short field first). `#7401` swept the existing sites, and
+`scripts/lib/assert-match-payload-guard.mjs` — installed from
+`packages/server/tests/_setup.mjs` — bounds the payload for anything that
+lands later, without ever changing a verdict. Subjects a test wrote itself (a
+log, a generated script) are small and fine as-is.
+
 **Never pass `--test-force-exit`, and run what CI runs.** Every package that runs
 `node --test` refuses it now (`scripts/lib/no-test-force-exit.mjs`, installed via
 each `tests/_setup.mjs` or the `--import` hook) because it drops test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -312,6 +312,17 @@ The recurring causes:
   192 of one file's 192 tests across five runs, every run `# fail 0` and exit 0,
   while a side-channel proved all 192 had executed (`#7400`)
 
+**Collapse to a boolean before asserting against file text.** A failing
+`assert.match(subject, re)` carries the ENTIRE subject as the error's `actual`
+— 124 KB of TAP for a one-line assertion, and it has wedged the runner
+(`#7340`, catalogue entry 17). Write `assert.ok(re.test(src), 'message')`
+instead; `assert.deepEqual` against a large array wants the same treatment (map
+to the short field first). `#7401` swept the existing sites, and
+`scripts/lib/assert-match-payload-guard.mjs` — installed from
+`packages/server/tests/_setup.mjs` — bounds the payload for anything that
+lands later, without ever changing a verdict. Subjects a test wrote itself (a
+log, a generated script) are small and fine as-is.
+
 **Never pass `--test-force-exit`, and run what CI runs.** Every package that runs
 `node --test` refuses it now (`scripts/lib/no-test-force-exit.mjs`, installed via
 each `tests/_setup.mjs` or the `--import` hook) because it drops test

--- a/docs/false-safety-guards.md
+++ b/docs/false-safety-guards.md
@@ -909,6 +909,24 @@ assert.ok(/authoritative: true/.test(branch), msg)   // fail → red, in ~0.3s
 — and `assert.deepEqual(bigArrayOfPaths, [])` wants the same treatment: map to
 the short field you actually care about first.
 
+**The sweep landed in `#7401`, and it is now backed by a runtime cap.** Every
+assertion whose subject was a large checked-in file was converted; the ~10 that
+remain read a file the test itself just wrote and carry a note saying so. The
+conversion is a LIST, though, and a list beside a growing set is the first
+recurring cause on this page — so `scripts/lib/assert-match-payload-guard.mjs`
+(installed from `packages/server/tests/_setup.mjs`) bounds the failure payload
+for any site the list missed or that lands later. It never changes a verdict,
+only how much of the subject rides along.
+
+A static lint was written first and rejected on evidence: deciding "is this
+subject large file text?" from the syntax proved unsound in BOTH directions —
+tight enough to avoid false positives, it missed three real sites (a multi-line
+`await readFile()`, a subject derived through `.split().filter().join()`, and a
+call whose subject sat on the next line); loose enough to catch those, it went
+from 26 hits to 61, mostly small in-test strings. That is worth remembering
+before writing the next source-scanning guard: **a predicate that is not
+soundly decidable from the syntax should not be enforced from the syntax.**
+
 **Do not treat the wedge itself as an established mechanism.** Two reviewers
 tried independently to reproduce it and could not: one from a standalone script
 against a 101 KB subject (failed in ~1.2 s, emitting 124 KB of TAP), one by

--- a/packages/server/tests/_setup.mjs
+++ b/packages/server/tests/_setup.mjs
@@ -75,6 +75,7 @@ import { join, resolve } from 'node:path'
 
 import { installFsWriteSandbox } from '../../../scripts/lib/test-fs-sandbox.mjs'
 import { assertNoTestForceExit } from '../../../scripts/lib/no-test-force-exit.mjs'
+import { installAssertMatchPayloadGuard } from '../../../scripts/lib/assert-match-payload-guard.mjs'
 
 // --- Refuse `--test-force-exit` (#7400) --------------------------------------
 // First thing in the body, before any temp dir exists: the flag makes this
@@ -87,6 +88,23 @@ import { assertNoTestForceExit } from '../../../scripts/lib/no-test-force-exit.m
 // aggregates; the non-zero exit is the authoritative signal, not the message.)
 // See the module for the measurements and for why nothing needs the flag.
 assertNoTestForceExit()
+
+// --- Cap assert.match's failure payload (#7401) -------------------------------
+// A failing `assert.match(subject, re)` carries the ENTIRE subject as the
+// error's `actual` — 124 KB of TAP output for one assertion where the subject
+// is file text, and observed wedging the runner. #7401 converted every site
+// whose subject was a large checked-in source file, but that conversion is a
+// LIST, and a list beside a growing set is the first recurring cause in
+// docs/false-safety-guards.md. This caps the payload for any site the list
+// misses or that lands later. It never changes whether an assertion passes or
+// fails — only how much of the subject rides along on a failure. See the
+// module for why this is a runtime cap and not a lint (the static check has a
+// demonstrated false-negative class).
+//
+// Safe to run before the fs sandbox arms: the module reaches `node:assert`
+// through its own `createRequire` and never imports `node:fs`, so it cannot
+// disarm the guard installed below (#7262).
+installAssertMatchPayloadGuard()
 
 // CRITICAL: Patch `node:fs` via the CJS object obtained from `createRequire`,
 // NOT via an ESM default import. ESM `import fs from 'node:fs'` returns a

--- a/packages/server/tests/assert-match-payload-guard.test.js
+++ b/packages/server/tests/assert-match-payload-guard.test.js
@@ -19,6 +19,7 @@ import { join } from 'node:path'
 import {
   installAssertMatchPayloadGuard,
   DEFAULT_SUBJECT_LIMIT,
+  FULL_PAYLOAD_ENV,
 } from '../../../scripts/lib/assert-match-payload-guard.mjs'
 
 const TESTS_DIR = import.meta.dirname
@@ -63,6 +64,15 @@ describe('assert.match payload guard — verdicts are unchanged (#7401)', () => 
     const err = thrown(() => assert.doesNotMatch(`${BIG}NEEDLE`, /NEEDLE/))
     assert.ok(err, 'an over-limit matching subject must still throw for doesNotMatch')
     assert.equal(err.operator, 'doesNotMatch')
+    // Pin the PAYLOAD too, not just the verdict. Without this line, removing
+    // 'doesNotMatch' from the patch loop leaves the whole suite green: stock
+    // assert.doesNotMatch also throws with operator 'doesNotMatch', so every
+    // other assertion here is satisfied by the unguarded function. That mutant
+    // survived review, and this is what kills it.
+    assert.ok(
+      !String(err.actual).includes(BIG),
+      'doesNotMatch must withhold the subject too — not just match',
+    )
   })
 
   it('a large subject that does not match PASSES doesNotMatch', () => {
@@ -98,6 +108,29 @@ describe('assert.match payload guard — the payload is actually capped (#7401)'
   it('preserves a caller-supplied message verbatim', () => {
     const err = thrown(() => assert.match(BIG, /NEEDLE/, 'my specific complaint'))
     assert.equal(err.message, 'my specific complaint')
+  })
+
+  // Copilot suggested preserving a caller-supplied '' verbatim (i.e. `message
+  // !== undefined` rather than `message ||`). Measured against stock
+  // node:assert/strict on Node 22, that would DIVERGE: stock treats every
+  // falsy message as absent and generates one, with generatedMessage=true.
+  // The guard's contract is to be indistinguishable from stock except for
+  // payload size, so it matches stock and this pins that.
+  it('treats every falsy message as absent, exactly as stock assert does', () => {
+    for (const falsy of ['', 0, false, null, undefined]) {
+      const err = thrown(() => assert.match(BIG, /NEEDLE/, falsy))
+      assert.ok(err, `precondition: falsy message ${JSON.stringify(falsy)} still fails`)
+      assert.ok(
+        err.generatedMessage === true && err.message.includes('#7401'),
+        `falsy message ${JSON.stringify(falsy)} should fall back to the generated message`,
+      )
+    }
+  })
+
+  it('throws a caller-supplied Error verbatim, as stock does', () => {
+    const boom = new Error('boom')
+    const err = thrown(() => assert.match(BIG, /NEEDLE/, boom))
+    assert.equal(err, boom, "an Error message is stock's throw-it-verbatim path")
   })
 
   it('points the reader at the per-site fix when no message was supplied', () => {
@@ -136,6 +169,31 @@ describe('assert.match payload guard — mechanics (#7401)', () => {
     assert.ok(re.lastIndex > 0, 'exactly one .test() call should have advanced lastIndex')
   })
 
+  it('delegates AT the limit and truncates one char above it', () => {
+    // Pins DEFAULT_SUBJECT_LIMIT's boundary. Nothing else does, so `<=` could
+    // become `<` unnoticed. Verdicts are identical either side; what changes is
+    // whether the subject survives, so assert on that.
+    const atLimit = 'x'.repeat(DEFAULT_SUBJECT_LIMIT)
+    const overLimit = 'x'.repeat(DEFAULT_SUBJECT_LIMIT + 1)
+    assert.equal(thrown(() => assert.match(atLimit, /NEEDLE/)).actual, atLimit)
+    assert.ok(!String(thrown(() => assert.match(overLimit, /NEEDLE/)).actual).includes(overLimit))
+  })
+
+  it('honours the full-payload escape hatch, and only on an affirmative value', () => {
+    assert.equal(installAssertMatchPayloadGuard({ env: { [FULL_PAYLOAD_ENV]: '1' } }).skipped, true)
+    // `FOO=0` must NOT disarm it — the #7400 lesson.
+    assert.equal(installAssertMatchPayloadGuard({ env: { [FULL_PAYLOAD_ENV]: '0' } }).skipped, false)
+    assert.equal(installAssertMatchPayloadGuard({ env: {} }).skipped, false)
+  })
+
+  it('matches stock for a regex with an overridden exec', () => {
+    // `regexp.test()` reads `exec` off the object; `assert.match` uses the
+    // primordial one. A guard using `.test()` would report this failing
+    // assertion as a PASS.
+    const liar = Object.assign(new RegExp('NEEDLE'), { exec: () => ['x'] })
+    assert.ok(thrown(() => assert.match(BIG, liar)), 'must still fail despite a lying exec')
+  })
+
   it('is idempotent — installing twice does not double-wrap', () => {
     const again = installAssertMatchPayloadGuard()
     assert.deepEqual(again.patched, [], 'a second install on already-patched objects is a no-op')
@@ -153,17 +211,52 @@ describe('assert.match payload guard — mechanics (#7401)', () => {
 // it. There are none today. This fails the moment one lands, rather than the
 // guard quietly covering less than it claims — the same "category enforced,
 // not asserted" shape as tests/setup-sandbox-coverage.test.js.
+function walkTestFiles(dir, out = []) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name)
+    if (entry.isDirectory()) walkTestFiles(full, out)
+    else if (/\.(m?js)$/.test(entry.name)) out.push(full)
+  }
+  return out
+}
+
+/**
+ * A named or namespace import of `node:assert`, tolerant of the statement
+ * being split across lines (`[^'"]*` crosses newlines).
+ *
+ * Anchored to the start of a line with the `m` flag, which is what keeps it
+ * off PROSE: this file and the guard module both mention
+ * `import { match } from 'node:assert'` inside comments, and those lines begin
+ * with `//` or ` *`. An unanchored search matches them and the test fails
+ * against itself — which is exactly how the first version of this regex
+ * behaved.
+ */
+const NON_DEFAULT_ASSERT_IMPORT =
+  /^[ \t]*import\s+[^'"]*?(?:\{|\*)[^'"]*?from\s*['"]node:assert(?:\/strict)?['"]/gm
+
 describe('assert.match payload guard — coverage is enforced (#7401)', () => {
+  it('scans every server test file, subdirectories included', () => {
+    // Positive control for the scan itself. The first version of this test
+    // used a flat `readdirSync(TESTS_DIR)` and silently skipped the 50 test
+    // files under tests/security, tests/handlers, tests/cli and friends — a
+    // guard covering 91% of what it claimed to cover, which is the defect
+    // class this whole PR is about. Pin the traversal, not just its verdict.
+    const files = walkTestFiles(TESTS_DIR)
+    const nested = files.filter((f) => f.slice(TESTS_DIR.length + 1).includes('/'))
+    assert.ok(
+      nested.length > 0,
+      'the walk must descend into subdirectories; found none, so the scan below proves nothing',
+    )
+    assert.ok(files.length > 500, `expected the full server test corpus, got ${files.length} files`)
+  })
+
   it('no server test imports assert by a binding form the guard cannot patch', () => {
     const offenders = []
-    for (const entry of readdirSync(TESTS_DIR)) {
-      if (!entry.endsWith('.test.js')) continue
-      const src = readFileSync(join(TESTS_DIR, entry), 'utf8')
-      for (const line of src.split('\n')) {
-        // `import { x } from 'node:assert'` or `import * as x from 'node:assert'`
-        if (/^\s*import\s+(?:\{|\*)\s.*from\s+['"]node:assert(?:\/strict)?['"]/.test(line)) {
-          offenders.push(`${entry}: ${line.trim()}`)
-        }
+    for (const file of walkTestFiles(TESTS_DIR)) {
+      const src = readFileSync(file, 'utf8')
+      NON_DEFAULT_ASSERT_IMPORT.lastIndex = 0
+      for (const m of src.matchAll(NON_DEFAULT_ASSERT_IMPORT)) {
+        offenders.push(`${file.slice(TESTS_DIR.length + 1)}: ${m[0].replace(/\s+/g, ' ').trim()}`)
       }
     }
     assert.ok(
@@ -172,5 +265,36 @@ describe('assert.match payload guard — coverage is enforced (#7401)', () => {
         'switch them to `import assert from \'node:assert/strict\'` or widen the guard:\n' +
         offenders.join('\n'),
     )
+  })
+
+  it('the offender regex actually detects both bypassing forms, incl. multi-line', () => {
+    // Positive control for the DETECTOR. Without this, the test above passes
+    // just as well with a regex that matches nothing at all.
+    const bypasses = [
+      "import { match } from 'node:assert'",
+      "import * as assert from 'node:assert'",
+      "import assert, { match } from 'node:assert/strict'",
+      'import {\n  match,\n  doesNotMatch,\n} from \'node:assert\'',
+    ]
+    for (const sample of bypasses) {
+      NON_DEFAULT_ASSERT_IMPORT.lastIndex = 0
+      assert.ok(
+        NON_DEFAULT_ASSERT_IMPORT.test(sample),
+        `should have flagged a bypassing import: ${JSON.stringify(sample)}`,
+      )
+    }
+    // ...and must NOT flag the default form, or every file becomes an offender.
+    for (const ok of ["import assert from 'node:assert/strict'", "import assert from 'node:assert'"]) {
+      NON_DEFAULT_ASSERT_IMPORT.lastIndex = 0
+      assert.ok(!NON_DEFAULT_ASSERT_IMPORT.test(ok), `should not have flagged: ${ok}`)
+    }
+    // ...nor a mention inside a comment, which is why it is line-anchored.
+    for (const prose of [
+      "// A NAMED import (`import { match } from 'node:assert'`) would bypass it.",
+      " * `import * as assert from 'node:assert'` binds differently.",
+    ]) {
+      NON_DEFAULT_ASSERT_IMPORT.lastIndex = 0
+      assert.ok(!NON_DEFAULT_ASSERT_IMPORT.test(prose), `should not have flagged prose: ${prose}`)
+    }
   })
 })

--- a/packages/server/tests/assert-match-payload-guard.test.js
+++ b/packages/server/tests/assert-match-payload-guard.test.js
@@ -1,0 +1,176 @@
+/**
+ * Proof for the `assert.match` payload guard (#7401).
+ *
+ * The guard's whole value is that it shrinks a FAILURE payload without ever
+ * changing a pass/fail verdict. Both halves are load-bearing and both are
+ * pinned here — a guard that turned a failing assertion into a silent pass
+ * would be a far worse bug than the 124 KB TAP block it was written to stop.
+ *
+ * The guard is installed process-wide by `_setup.mjs`, so the `assert` this
+ * file imports is already patched; the tests exercise it through the same
+ * default-import surface every other server test uses.
+ */
+
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import {
+  installAssertMatchPayloadGuard,
+  DEFAULT_SUBJECT_LIMIT,
+} from '../../../scripts/lib/assert-match-payload-guard.mjs'
+
+const TESTS_DIR = import.meta.dirname
+const BIG = 'x'.repeat(DEFAULT_SUBJECT_LIMIT * 3)
+const SMALL = 'x'.repeat(32)
+
+/** Run `fn`, returning the thrown error or null. */
+function thrown(fn) {
+  try {
+    fn()
+    return null
+  } catch (err) {
+    return err
+  }
+}
+
+describe('assert.match payload guard — verdicts are unchanged (#7401)', () => {
+  it('is actually installed on the assert this test imported', () => {
+    // Positive control. Without this, every "does not throw" case below would
+    // pass just as well with the guard absent, and the file would be testing
+    // stock assert rather than the guard.
+    assert.ok(
+      assert.match.name === 'chroxyGuardedAssert',
+      'the process-wide guard from _setup.mjs must be patched onto node:assert/strict',
+    )
+  })
+
+  it('a large subject that MATCHES still passes', () => {
+    assert.doesNotThrow(() => assert.match(`${BIG}NEEDLE`, /NEEDLE/))
+  })
+
+  // THE critical case. If the guard ever swallows this, it has converted a
+  // real failure into a green test — the exact class docs/false-safety-guards.md
+  // catalogues, introduced by the fix for one of its entries.
+  it('a large subject that does NOT match still FAILS', () => {
+    const err = thrown(() => assert.match(BIG, /NEEDLE/))
+    assert.ok(err, 'an over-limit non-matching subject must still throw')
+    assert.equal(err.operator, 'match')
+  })
+
+  it('a large subject that matches still FAILS doesNotMatch', () => {
+    const err = thrown(() => assert.doesNotMatch(`${BIG}NEEDLE`, /NEEDLE/))
+    assert.ok(err, 'an over-limit matching subject must still throw for doesNotMatch')
+    assert.equal(err.operator, 'doesNotMatch')
+  })
+
+  it('a large subject that does not match PASSES doesNotMatch', () => {
+    assert.doesNotThrow(() => assert.doesNotMatch(BIG, /NEEDLE/))
+  })
+})
+
+describe('assert.match payload guard — the payload is actually capped (#7401)', () => {
+  it('withholds the subject from a failing over-limit assertion', () => {
+    const err = thrown(() => assert.match(BIG, /NEEDLE/))
+    assert.ok(err, 'precondition: the assertion failed')
+    // The harm being prevented is the SERIALISED size — that is what lands in
+    // the TAP YAML block, so measure that rather than the message alone.
+    const serialised = JSON.stringify({
+      message: err.message,
+      actual: err.actual,
+      expected: String(err.expected),
+    })
+    assert.ok(
+      serialised.length < 2000,
+      `failure payload must stay bounded; got ${serialised.length} chars for a ${BIG.length}-char subject`,
+    )
+    assert.ok(
+      !err.actual.includes(BIG),
+      'the full subject must not ride along on the error',
+    )
+    assert.ok(
+      String(err.actual).includes(`${BIG.length} chars total`),
+      'the preview should still say how big the withheld subject was',
+    )
+  })
+
+  it('preserves a caller-supplied message verbatim', () => {
+    const err = thrown(() => assert.match(BIG, /NEEDLE/, 'my specific complaint'))
+    assert.equal(err.message, 'my specific complaint')
+  })
+
+  it('points the reader at the per-site fix when no message was supplied', () => {
+    const err = thrown(() => assert.match(BIG, /NEEDLE/))
+    assert.ok(
+      err.message.includes('assert.ok(') && err.message.includes('#7401'),
+      'the default message should name the boolean-collapse fix',
+    )
+  })
+})
+
+describe('assert.match payload guard — small subjects are untouched (#7401)', () => {
+  it('leaves a small failing subject fully intact in `actual`', () => {
+    const err = thrown(() => assert.match(SMALL, /NEEDLE/))
+    assert.ok(err, 'precondition: the assertion failed')
+    assert.equal(err.actual, SMALL, 'under the limit, stock assert behaviour is preserved')
+  })
+
+  it('delegates non-string subjects and non-regexp patterns unchanged', () => {
+    // The guard must not intercept argument-validation errors and reshape
+    // them. These two codes are stock `node:assert/strict` behaviour, verified
+    // against an unpatched assert — and note they DIFFER from each other, so a
+    // guard that normalised both into one error would fail here.
+    assert.throws(() => assert.match(123, /x/), { code: 'ERR_ASSERTION' })
+    assert.throws(() => assert.match('abc', 'not-a-regexp'), { code: 'ERR_INVALID_ARG_TYPE' })
+  })
+})
+
+describe('assert.match payload guard — mechanics (#7401)', () => {
+  it('evaluates the regex exactly once, so a /g lastIndex advances as it would unguarded', () => {
+    // A /g regex is stateful. Stock assert.match calls .test() once; if the
+    // guard called it twice the second call would resume from lastIndex and
+    // could report the opposite verdict.
+    const re = /NEEDLE/g
+    assert.match(`${BIG}NEEDLE`, re)
+    assert.ok(re.lastIndex > 0, 'exactly one .test() call should have advanced lastIndex')
+  })
+
+  it('is idempotent — installing twice does not double-wrap', () => {
+    const again = installAssertMatchPayloadGuard()
+    assert.deepEqual(again.patched, [], 'a second install on already-patched objects is a no-op')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// The guard's one coverage hole, enforced rather than asserted.
+// ---------------------------------------------------------------------------
+//
+// The guard patches the `node:assert` / `node:assert/strict` CJS objects. A
+// DEFAULT import resolves to that live object, so every current server test is
+// covered. A NAMED or NAMESPACE import (`import { match } from 'node:assert'`,
+// `import * as assert from 'node:assert'`) binds differently and would bypass
+// it. There are none today. This fails the moment one lands, rather than the
+// guard quietly covering less than it claims — the same "category enforced,
+// not asserted" shape as tests/setup-sandbox-coverage.test.js.
+describe('assert.match payload guard — coverage is enforced (#7401)', () => {
+  it('no server test imports assert by a binding form the guard cannot patch', () => {
+    const offenders = []
+    for (const entry of readdirSync(TESTS_DIR)) {
+      if (!entry.endsWith('.test.js')) continue
+      const src = readFileSync(join(TESTS_DIR, entry), 'utf8')
+      for (const line of src.split('\n')) {
+        // `import { x } from 'node:assert'` or `import * as x from 'node:assert'`
+        if (/^\s*import\s+(?:\{|\*)\s.*from\s+['"]node:assert(?:\/strict)?['"]/.test(line)) {
+          offenders.push(`${entry}: ${line.trim()}`)
+        }
+      }
+    }
+    assert.ok(
+      offenders.length === 0,
+      'these use a non-default assert import, which the payload guard cannot patch — ' +
+        'switch them to `import assert from \'node:assert/strict\'` or widen the guard:\n' +
+        offenders.join('\n'),
+    )
+  })
+})

--- a/packages/server/tests/assert-match-payload-guard.test.js
+++ b/packages/server/tests/assert-match-payload-guard.test.js
@@ -14,7 +14,7 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 import { readdirSync, readFileSync } from 'node:fs'
-import { join } from 'node:path'
+import { dirname, join, relative, sep } from 'node:path'
 
 import {
   installAssertMatchPayloadGuard,
@@ -242,7 +242,13 @@ describe('assert.match payload guard — coverage is enforced (#7401)', () => {
     // guard covering 91% of what it claimed to cover, which is the defect
     // class this whole PR is about. Pin the traversal, not just its verdict.
     const files = walkTestFiles(TESTS_DIR)
-    const nested = files.filter((f) => f.slice(TESTS_DIR.length + 1).includes('/'))
+    // `dirname(f) !== TESTS_DIR`, NOT a '/' search on the relative path: on
+    // Windows `join` emits backslashes, so `includes('/')` finds nothing and
+    // this control fails for a reason that has nothing to do with the walk.
+    // It did exactly that on the Windows CI job — the control working as
+    // intended (it refused to certify a scan it could not verify) via an
+    // implementation that was POSIX-only.
+    const nested = files.filter((f) => dirname(f) !== TESTS_DIR)
     assert.ok(
       nested.length > 0,
       'the walk must descend into subdirectories; found none, so the scan below proves nothing',
@@ -256,7 +262,8 @@ describe('assert.match payload guard — coverage is enforced (#7401)', () => {
       const src = readFileSync(file, 'utf8')
       NON_DEFAULT_ASSERT_IMPORT.lastIndex = 0
       for (const m of src.matchAll(NON_DEFAULT_ASSERT_IMPORT)) {
-        offenders.push(`${file.slice(TESTS_DIR.length + 1)}: ${m[0].replace(/\s+/g, ' ').trim()}`)
+        const rel = relative(TESTS_DIR, file).split(sep).join('/')
+        offenders.push(`${rel}: ${m[0].replace(/\s+/g, ' ').trim()}`)
       }
     }
     assert.ok(

--- a/packages/server/tests/bump-version-trap-cleanup.test.js
+++ b/packages/server/tests/bump-version-trap-cleanup.test.js
@@ -11,9 +11,11 @@ const SCRIPT = resolve(ROOT, 'scripts/bump-version.sh')
 describe('bump-version.sh trap-cleans orphan .tmp files (#3886)', () => {
   it('script source defines a TMP_FILES tracker and EXIT trap', () => {
     const src = readFileSync(SCRIPT, 'utf-8')
-    assert.match(src, /TMP_FILES=\(\)/, 'script should declare TMP_FILES array')
-    assert.match(src, /track_tmp\s*\(\)/, 'script should define track_tmp()')
-    assert.match(src, /trap\s+cleanup_tmp_files\s+EXIT/, 'script should register EXIT trap')
+    // #7401 — boolean collapse: bump-version.sh is ~26 KB, not the "few KB" it
+    // looks like; a failing assert.match would serialise all of it as `actual`.
+    assert.ok(/TMP_FILES=\(\)/.test(src), 'script should declare TMP_FILES array')
+    assert.ok(/track_tmp\s*\(\)/.test(src), 'script should define track_tmp()')
+    assert.ok(/trap\s+cleanup_tmp_files\s+EXIT/.test(src), 'script should register EXIT trap')
   })
 
   it('script registers Cargo.lock .tmp before its awk write', () => {
@@ -26,7 +28,7 @@ describe('bump-version.sh trap-cleans orphan .tmp files (#3886)', () => {
     // when iOS moved to CNG (#5642) — the native version now comes from
     // app.json at prebuild — so this guards the remaining awk-into-place site.
     const pattern = /track_tmp "\$CARGO_LOCK\.tmp"[\s\S]{0,400}awk[\s\S]{0,400}> "\$CARGO_LOCK\.tmp"/
-    assert.match(src, pattern, 'Cargo.lock awk block should call track_tmp before writing the .tmp')
+    assert.ok(pattern.test(src), 'Cargo.lock awk block should call track_tmp before writing the .tmp')
   })
 
   it('forced awk failure under the same trap pattern leaves no orphan .tmp', () => {

--- a/packages/server/tests/byok-mcp-trust-spawn-config.test.js
+++ b/packages/server/tests/byok-mcp-trust-spawn-config.test.js
@@ -194,6 +194,8 @@ describe('#7001 the remote trust key covers the endpoint and its headers', () =>
     const disk = readFileSync(storePath, 'utf8')
     assert.ok(!disk.includes('pw') && !disk.includes('tok=secret') && !disk.includes('Bearer'),
       'no credential material may reach the trust store')
+    // #7401 — left as assert.match deliberately: the subject is a file this test just wrote (a small trust-store JSON), so the whole
+    // subject in a failure is useful rather than a 100 KB TAP block.
     assert.match(disk, /"url": "https:\/\/mcp\.example\.com\/api"/, 'the sanitized url stays readable on disk')
   })
 

--- a/packages/server/tests/event-ingest.test.js
+++ b/packages/server/tests/event-ingest.test.js
@@ -571,6 +571,7 @@ describe('loadOrCreateIngestSecret', () => {
   it('creates the secret 0600 with base64url content and is stable across loads', () => {
     const secretPath = join(dir, 'sub', 'ingest-secret')
     const secret = loadOrCreateIngestSecret(secretPath)
+    // #7401 — left as assert.match deliberately: the subject is a file this test just wrote (a single ~43-char secret line).
     assert.match(secret, /^[A-Za-z0-9_-]{40,}$/, 'base64url, 32 bytes')
     const mode = statSync(secretPath).mode & 0o777
     assert.equal(mode, 0o600, 'secret file is 0600')

--- a/packages/server/tests/logger.test.js
+++ b/packages/server/tests/logger.test.js
@@ -76,6 +76,7 @@ describe('initFileLogging', () => {
 
     const content = readFileSync(join(logDir, 'chroxy.log'), 'utf8')
     // Format: 2026-02-22T12:34:56.789Z [WARN] [widget] something bad
+    // #7401 — left as assert.match deliberately: the subject is a file this test just wrote (a log file of a few lines).
     assert.match(content, /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z/)
     assert.ok(content.includes('[WARN]'), 'should contain level')
     assert.ok(content.includes('[widget]'), 'should contain component')

--- a/packages/server/tests/orchestration-transition-guards.test.js
+++ b/packages/server/tests/orchestration-transition-guards.test.js
@@ -458,6 +458,8 @@ test('#6732 the manager has exactly one guarded run-status and one guarded subta
   assert.equal(updateLines.length, 1, `every subtask-status write must go through _setSubtaskStatus; found ${updateLines.length} raw _ledger.updateSubtask( call sites:\n${updateLines.join('\n')}`)
 
   // and those single sites must be the asserting helpers
-  assert.match(src, /_setRunStatus\s*\([^)]*\)\s*\{[\s\S]{0,600}?assertRunTransition\(/, '_setRunStatus must call assertRunTransition')
-  assert.match(src, /_setSubtaskStatus\s*\([^)]*\)\s*\{[\s\S]{0,600}?assertNodeTransition\(/, '_setSubtaskStatus must call assertNodeTransition')
+  // #7401 — boolean collapse: `src` is orchestration-manager.js (~66 KB) and a
+  // failing assert.match would serialise all of it as the error's `actual`.
+  assert.ok(/_setRunStatus\s*\([^)]*\)\s*\{[\s\S]{0,600}?assertRunTransition\(/.test(src), '_setRunStatus must call assertRunTransition')
+  assert.ok(/_setSubtaskStatus\s*\([^)]*\)\s*\{[\s\S]{0,600}?assertNodeTransition\(/.test(src), '_setSubtaskStatus must call assertNodeTransition')
 })

--- a/packages/server/tests/permission-hook-floor.test.js
+++ b/packages/server/tests/permission-hook-floor.test.js
@@ -1094,7 +1094,10 @@ describe('anti-drift: the floor has exactly ONE implementation (#7004)', () => {
         `permission-hook.sh must not reimplement the floor (found ${literal} in executable code)`,
       )
     }
-    assert.match(hookCode, /permission-floor/, 'it asks the daemon instead')
+    // #7401 — boolean collapse: `hookCode` is permission-hook.sh with comment
+    // lines stripped, ~8 KB. Missed by the first sweep because it is a DERIVED
+    // binding (.split().filter().join()), never bound from a read directly.
+    assert.ok(/permission-floor/.test(hookCode), 'it asks the daemon instead')
   })
 
   it('the hook pre-filter covers EVERY field the floor scans (drift → this fails)', () => {

--- a/packages/server/tests/permission-hook-floor.test.js
+++ b/packages/server/tests/permission-hook-floor.test.js
@@ -1061,18 +1061,27 @@ describe('anti-drift: the floor has exactly ONE implementation (#7004)', () => {
   const hookCode = hookSrc.split('\n').filter((l) => !/^\s*#/.test(l)).join('\n')
 
   it('both call sites go through the SAME isFlooredTarget from permission-floor.js', () => {
-    assert.match(managerSrc, /from '\.\/permission-floor\.js'/, 'permission-manager imports the shared floor')
-    assert.match(managerSrc, /isFlooredTarget\(toolName, input, this\._cwd\)/, 'in-process path calls it')
-    assert.match(wsPermSrc, /import \{ isFlooredTarget \} from '\.\/permission-floor\.js'/, 'hook path imports it')
-    assert.match(wsPermSrc, /isFlooredTarget\(tool, input, cwd\)/, 'hook path calls it')
+    // #7401 — boolean collapse: these subjects are permission-manager.js (~61 KB)
+    // and ws-permissions.js (~52 KB). A failing assert.match carries the entire
+    // subject as the error's `actual`, which is what wedged the runner in #7340.
+    assert.ok(/from '\.\/permission-floor\.js'/.test(managerSrc), 'permission-manager imports the shared floor')
+    assert.ok(/isFlooredTarget\(toolName, input, this\._cwd\)/.test(managerSrc), 'in-process path calls it')
+    assert.ok(/import \{ isFlooredTarget \} from '\.\/permission-floor\.js'/.test(wsPermSrc), 'hook path imports it')
+    assert.ok(/isFlooredTarget\(tool, input, cwd\)/.test(wsPermSrc), 'hook path calls it')
   })
 
   it('the tool-aware read-vs-write choice exists in exactly one file', () => {
     // If a second site re-derives "which floor applies to which tool", the two
     // pipelines can drift again — that IS #7004.
-    assert.match(floorSrc, /SECRET_READ_FLOOR_TOOLS\.has\(toolName\)/)
-    assert.doesNotMatch(managerSrc, /SECRET_READ_FLOOR_TOOLS\.has/)
-    assert.doesNotMatch(wsPermSrc, /SECRET_READ_FLOOR_TOOLS\.has/)
+    // #7401 — boolean collapse, and the two negatives gain a message: a failing
+    // `assert.doesNotMatch(managerSrc, re)` with no message is the worst case of
+    // all — ~61 KB of `actual` and nothing telling you what broke.
+    assert.ok(/SECRET_READ_FLOOR_TOOLS\.has\(toolName\)/.test(floorSrc),
+      'permission-floor.js owns the tool-aware read-vs-write choice')
+    assert.ok(!/SECRET_READ_FLOOR_TOOLS\.has/.test(managerSrc),
+      'permission-manager must NOT re-derive which floor applies to which tool (#7004)')
+    assert.ok(!/SECRET_READ_FLOOR_TOOLS\.has/.test(wsPermSrc),
+      'ws-permissions must NOT re-derive which floor applies to which tool (#7004)')
     // And the predicate set is still the documented one.
     assert.deepEqual([...SECRET_READ_FLOOR_TOOLS].sort(), ['Glob', 'Grep', 'Read'])
   })

--- a/packages/server/tests/scheduled-task-health-parity.test.js
+++ b/packages/server/tests/scheduled-task-health-parity.test.js
@@ -267,9 +267,12 @@ describe('scheduled-task health — CLI source parity (#6868 / PR #7013)', () =>
         src.includes('deriveScheduledTaskHealthTag'),
         'the CLI has no local healthTag() — it must then import deriveScheduledTaskHealthTag from @chroxy/protocol, or it has no health mapping at all',
       )
-      assert.match(
-        src,
-        /from\s+'@chroxy\/protocol'/,
+      // #7401 — boolean collapse: `src` is schedule-cmd.js (~32 KB), the
+      // largest subject in this sweep outside the provider modules. Missed by
+      // the first sweep because the CALL spans lines, so the subject is not on
+      // the same line as `assert.match(`.
+      assert.ok(
+        /from\s+'@chroxy\/protocol'/.test(src),
         'the CLI must take its health mapping from the shared @chroxy/protocol module',
       )
       return

--- a/packages/server/tests/sdk-session-intentional-stop.test.js
+++ b/packages/server/tests/sdk-session-intentional-stop.test.js
@@ -224,7 +224,11 @@ describe('SdkSession _callQuery finally — source contains safety-net clear for
     // Pin both: (a) the comment header so future edits understand the
     // intent, and (b) the actual clear line. Without the clear, the race
     // where `result` lands before interrupt() throws would leak the flag.
-    assert.match(src, /#4881: safety-net clear of _intentionalStop/,
+    // #7401 — `assert.ok(re.test(src), msg)`, not `assert.match(src, re)`:
+    // `src` is sdk-session.js (~100 KB), and a failing assert.match carries the
+    // ENTIRE subject as the error's `actual`. The boolean collapse keeps the
+    // failure payload to `false` plus this message.
+    assert.ok(/#4881: safety-net clear of _intentionalStop/.test(src),
       'finally must carry the documented race-safety comment')
     // Locate the comment then assert the clear is within 10 lines after.
     // #5375 hoisted the flag to BaseSession, so the safety-net clear is now

--- a/packages/server/tests/service.test.js
+++ b/packages/server/tests/service.test.js
@@ -165,8 +165,9 @@ describe('service', () => {
       it('shell-quotes the path in the POSIX wrapper', () => {
         const wrapper = generateServiceWrapper({ ...cfg, configDirEnv: "/tmp/it's here" })
         // #7401 — left as assert.match deliberately: `wrapper` is a generated
-    // service wrapper script of a few dozen lines, not a checked-in source file.
-    assert.match(wrapper, /export CHROXY_CONFIG_DIR='\/tmp\/it'/, 'must reuse the wrapper quoting helper')
+        // service wrapper script of a few dozen lines, not a checked-in source
+        // file.
+        assert.match(wrapper, /export CHROXY_CONFIG_DIR='\/tmp\/it'/, 'must reuse the wrapper quoting helper')
       })
     })
 
@@ -368,7 +369,8 @@ describe('service', () => {
       // wrapper written to disk
       assert.ok(existsSync(wrapperPath))
       const wrapper = readFileSync(wrapperPath, 'utf-8')
-      // #7401 — see the note above: a generated wrapper script, not file text.
+      // #7401 — left as assert.match deliberately: a generated service wrapper
+      // script this test just wrote, a few dozen lines.
       assert.match(wrapper, /cd \/d "C:\\work"/)
       assert.match(wrapper, /"C:\\Program Files\\nodejs\\node\.exe" "C:\\chroxy\\cli\.js" start/)
       assert.match(wrapper, /chroxy-stdout\.log/)

--- a/packages/server/tests/service.test.js
+++ b/packages/server/tests/service.test.js
@@ -164,7 +164,9 @@ describe('service', () => {
 
       it('shell-quotes the path in the POSIX wrapper', () => {
         const wrapper = generateServiceWrapper({ ...cfg, configDirEnv: "/tmp/it's here" })
-        assert.match(wrapper, /export CHROXY_CONFIG_DIR='\/tmp\/it'/, 'must reuse the wrapper quoting helper')
+        // #7401 — left as assert.match deliberately: `wrapper` is a generated
+    // service wrapper script of a few dozen lines, not a checked-in source file.
+    assert.match(wrapper, /export CHROXY_CONFIG_DIR='\/tmp\/it'/, 'must reuse the wrapper quoting helper')
       })
     })
 
@@ -366,6 +368,7 @@ describe('service', () => {
       // wrapper written to disk
       assert.ok(existsSync(wrapperPath))
       const wrapper = readFileSync(wrapperPath, 'utf-8')
+      // #7401 — see the note above: a generated wrapper script, not file text.
       assert.match(wrapper, /cd \/d "C:\\work"/)
       assert.match(wrapper, /"C:\\Program Files\\nodejs\\node\.exe" "C:\\chroxy\\cli\.js" start/)
       assert.match(wrapper, /chroxy-stdout\.log/)

--- a/packages/server/tests/shell-audit.test.js
+++ b/packages/server/tests/shell-audit.test.js
@@ -77,6 +77,7 @@ describe('shell-audit — always-on under quiet LOG_LEVEL (#6001)', () => {
     closeFileLogging()
 
     const content = readFileSync(join(logDir, 'chroxy.log'), 'utf8')
+    // #7401 — left as assert.match deliberately: the subject is a file this test just wrote (an audit log of a few lines).
     assert.match(content, /event=user_shell_create/)
     assert.match(content, /sessionId="sess-9"/)
     assert.match(content, /\[AUDIT\]/)

--- a/packages/server/tests/ws-file-ops-cache.test.js
+++ b/packages/server/tests/ws-file-ops-cache.test.js
@@ -104,7 +104,9 @@ describe('#1931 — CWD real path cache TTL', () => {
     assert.ok(source.includes('_cwdRealCache'), 'should have CWD real path cache')
     assert.ok(source.includes('CWD_CACHE_TTL'), 'should have TTL constant')
     assert.ok(source.includes('60_000'), 'TTL should be 60 seconds')
-    assert.match(source, /\bts\b/, 'should store a timestamp field for cache entries')
-    assert.match(source, /Date\.now\(\)\s*-\s*\w+\.ts/, 'should compare current time against cached timestamp')
+    // #7401 — boolean collapse: `source` is index.js + common.js concatenated
+    // (~14 KB); a failing assert.match would carry the whole thing as `actual`.
+    assert.ok(/\bts\b/.test(source), 'should store a timestamp field for cache entries')
+    assert.ok(/Date\.now\(\)\s*-\s*\w+\.ts/.test(source), 'should compare current time against cached timestamp')
   })
 })

--- a/scripts/lib/assert-match-payload-guard.mjs
+++ b/scripts/lib/assert-match-payload-guard.mjs
@@ -1,0 +1,132 @@
+/**
+ * Cap the FAILURE PAYLOAD of `assert.match` / `assert.doesNotMatch` (#7401).
+ *
+ * A failing `assert.match(subject, re)` carries the ENTIRE subject as the
+ * error's `actual`. Where the subject is file text that means serialising the
+ * whole file into the TAP YAML block for a one-line assertion — measured at
+ * 124 KB of TAP output for a single assertion, and in-tree it was observed
+ * wedging `node --test` outright (catalogue entry 18, and the hang mode of
+ * entry 17).
+ *
+ * The per-call-site fix is to collapse to a boolean before asserting:
+ *
+ *     assert.match(src, /pattern/)              // fail → the whole file as `actual`
+ *     assert.ok(/pattern/.test(src), message)   // fail → `false`, plus a real message
+ *
+ * #7401 converted every site whose subject was a large checked-in source file.
+ * This module exists because that conversion is a LIST, and a list beside a
+ * growing set is the first recurring cause in `docs/false-safety-guards.md`
+ * (#7192, #7197, #7267, #7270). The list will regrow.
+ *
+ * WHY A RUNTIME CAP RATHER THAN A LINT. The obvious guard is a static check
+ * for `assert.match(<ident>` where `<ident>` is bound from a file read. That
+ * check has a demonstrated false-negative class: while sweeping for #7401 a
+ * regex over `readFileSync` missed `ws-file-ops-cache.test.js` outright,
+ * because the binding was a multi-line `await readFile(...)` from
+ * `fs/promises` — a site the issue itself named. A guard that silently misses
+ * the cases it was written for is the exact defect class this repo catalogues,
+ * so the check moved to where the value actually is: runtime, where the
+ * subject's real size is known and no binding style can hide it.
+ *
+ * WHAT THIS DOES NOT DO. It never changes whether an assertion passes or
+ * fails — only how much of the subject rides along on a failure. The regex is
+ * evaluated exactly once, the same way `assert.match` evaluates it, so a
+ * stateful `/g` regex behaves identically to the unguarded call.
+ *
+ * COVERAGE AND ITS ONE HOLE. Every server test imports assert as a DEFAULT
+ * import (`import assert from 'node:assert/strict'`, 567 sites; plain
+ * `node:assert`, 5). A default import resolves to the live CJS
+ * `module.exports` object, so patching that object's properties is seen by
+ * every one of them regardless of link order — unlike the `node:fs` case in
+ * `_setup.mjs`, this does not depend on a lazy-snapshot race. A NAMED or
+ * NAMESPACE import (`import { match } from 'node:assert'`) WOULD bypass it.
+ * There are currently none, and that is enforced rather than asserted:
+ * `tests/assert-match-payload-guard.test.js` fails if one appears.
+ */
+
+import { createRequire } from 'node:module'
+
+/**
+ * Subjects at or below this many characters are passed through untouched — a
+ * few KB of `actual` is genuinely useful in a failure and costs nothing. The
+ * smallest subject #7401 converted was ~14 KB; the largest small subject left
+ * alone (a test-written log or wrapper script) is a few hundred bytes, so the
+ * boundary is not close to either class.
+ */
+export const DEFAULT_SUBJECT_LIMIT = 4096
+
+/** How much of an over-limit subject to show in the failure message. */
+const PREVIEW_CHARS = 200
+
+function preview(subject) {
+  const head = subject.slice(0, PREVIEW_CHARS).replace(/\n/g, '\\n')
+  return `${head}… [${subject.length} chars total, truncated by the #7401 payload guard]`
+}
+
+/**
+ * Patch `match` / `doesNotMatch` on one assert-like object. Idempotent: a
+ * second install on the same object is a no-op, so importing this from more
+ * than one setup file cannot double-wrap.
+ */
+function patchOne(target, limit, AssertionError) {
+  if (!target || target.__chroxyMatchPayloadGuard) return false
+  for (const name of ['match', 'doesNotMatch']) {
+    const original = target[name]
+    if (typeof original !== 'function') continue
+    const wantMatch = name === 'match'
+    target[name] = function chroxyGuardedAssert(subject, regexp, message) {
+      // Delegate anything we are not certain about, so every argument-
+      // validation error assert raises today is raised identically.
+      if (typeof subject !== 'string' || !(regexp instanceof RegExp) || subject.length <= limit) {
+        return original.call(this, subject, regexp, message)
+      }
+      // Evaluate ONCE, exactly as assert.match does, so a /g regex's lastIndex
+      // advances the same way it would have unguarded.
+      const matched = regexp.test(subject)
+      if (matched === wantMatch) return
+      throw new AssertionError({
+        message:
+          message ||
+          `The ${wantMatch ? 'input did not match' : 'input was expected not to match'} the regular expression ${regexp}. ` +
+            `Subject withheld: ${subject.length} chars. ` +
+            `Use assert.ok(${wantMatch ? '' : '!'}${regexp}.test(subject), 'message') at this call site (#7401).`,
+        actual: preview(subject),
+        expected: regexp,
+        operator: name,
+        stackStartFn: chroxyGuardedAssert,
+      })
+    }
+  }
+  Object.defineProperty(target, '__chroxyMatchPayloadGuard', {
+    value: true,
+    enumerable: false,
+    configurable: true,
+  })
+  return true
+}
+
+/**
+ * Install the guard on both `node:assert` and `node:assert/strict`.
+ *
+ * Reached through `createRequire` rather than an ESM import for the same
+ * reason `_setup.mjs` does it for `node:fs`: we need the live CJS
+ * `module.exports` object that default importers resolve to, not a module
+ * namespace object whose properties cannot be reassigned.
+ *
+ * @returns {{ patched: string[], limit: number }}
+ */
+export function installAssertMatchPayloadGuard({ limit = DEFAULT_SUBJECT_LIMIT } = {}) {
+  const require = createRequire(import.meta.url)
+  const assert = require('node:assert')
+  const strict = require('node:assert/strict')
+  const { AssertionError } = assert
+
+  const patched = []
+  if (patchOne(assert, limit, AssertionError)) patched.push('node:assert')
+  // `assert.strict` and `node:assert/strict` are the same object in Node, but
+  // patch by both handles so this stays correct if that ever stops holding.
+  if (patchOne(strict, limit, AssertionError)) patched.push('node:assert/strict')
+  if (patchOne(assert.strict, limit, AssertionError)) patched.push('node:assert.strict')
+
+  return { patched, limit }
+}

--- a/scripts/lib/assert-match-payload-guard.mjs
+++ b/scripts/lib/assert-match-payload-guard.mjs
@@ -5,8 +5,8 @@
  * error's `actual`. Where the subject is file text that means serialising the
  * whole file into the TAP YAML block for a one-line assertion — measured at
  * 124 KB of TAP output for a single assertion, and in-tree it was observed
- * wedging `node --test` outright (catalogue entry 18, and the hang mode of
- * entry 17).
+ * wedging `node --test` outright (`docs/false-safety-guards.md` entry 17,
+ * which carries both that measurement and the hang).
  *
  * The per-call-site fix is to collapse to a boolean before asserting:
  *
@@ -18,45 +18,105 @@
  * growing set is the first recurring cause in `docs/false-safety-guards.md`
  * (#7192, #7197, #7267, #7270). The list will regrow.
  *
- * WHY A RUNTIME CAP RATHER THAN A LINT. The obvious guard is a static check
- * for `assert.match(<ident>` where `<ident>` is bound from a file read. That
- * check has a demonstrated false-negative class: while sweeping for #7401 a
- * regex over `readFileSync` missed `ws-file-ops-cache.test.js` outright,
- * because the binding was a multi-line `await readFile(...)` from
- * `fs/promises` — a site the issue itself named. A guard that silently misses
- * the cases it was written for is the exact defect class this repo catalogues,
- * so the check moved to where the value actually is: runtime, where the
- * subject's real size is known and no binding style can hide it.
+ * WHY A RUNTIME CAP RATHER THAN A LINT. Statically deciding "is this subject
+ * large file text?" means inferring where an identifier was bound, and that
+ * inference proved unreliable in BOTH directions while sweeping for #7401:
+ *
+ *   - Too tight and it misses real sites. A regex over `readFileSync` missed
+ *     `ws-file-ops-cache.test.js` (a multi-line `await readFile()` from
+ *     `fs/promises`), `permission-hook-floor.test.js` (subject derived via
+ *     `.split().filter().join()`, never bound from a read directly), and
+ *     `scheduled-task-health-parity.test.js` (the CALL spans lines, so the
+ *     subject is not on the same line as `assert.match(`).
+ *   - Too loose and it drowns in false positives. Widening the same sweep to
+ *     follow derived bindings took it from 26 hits to 61, most of them small
+ *     in-test strings.
+ *
+ * At runtime the subject's real size is simply known, and no binding style can
+ * hide it. The argument is not that static analysis is bad — it is that this
+ * particular predicate is not soundly decidable from the syntax.
+ *
+ * A purely SYNTACTIC lint ("always pass a message", or "ban these two methods
+ * in tests/") has no such false negatives and would be a fine complement. It
+ * is deliberately not what this does: it would churn the ~10 legitimate
+ * small-subject sites and still not bound the payload of anything that slipped
+ * through.
  *
  * WHAT THIS DOES NOT DO. It never changes whether an assertion passes or
- * fails — only how much of the subject rides along on a failure. The regex is
- * evaluated exactly once, the same way `assert.match` evaluates it, so a
- * stateful `/g` regex behaves identically to the unguarded call.
+ * fails, and it does not reshape any error assert would otherwise raise — only
+ * how much of the subject rides along on a failure. The regex is evaluated
+ * exactly once, through the same primordial `RegExp.prototype.exec` that
+ * `assert.match` uses, so `/g` and `/y` lastIndex behaviour, and any
+ * overridden `exec`/`test` on the regex object, behave identically to the
+ * unguarded call.
  *
- * COVERAGE AND ITS ONE HOLE. Every server test imports assert as a DEFAULT
- * import (`import assert from 'node:assert/strict'`, 567 sites; plain
- * `node:assert`, 5). A default import resolves to the live CJS
- * `module.exports` object, so patching that object's properties is seen by
- * every one of them regardless of link order — unlike the `node:fs` case in
- * `_setup.mjs`, this does not depend on a lazy-snapshot race. A NAMED or
- * NAMESPACE import (`import { match } from 'node:assert'`) WOULD bypass it.
- * There are currently none, and that is enforced rather than asserted:
- * `tests/assert-match-payload-guard.test.js` fails if one appears.
+ * WHERE THIS IS INSTALLED, AND ITS LIMITS. Four packages run `node --test`
+ * (`server`, `claude-hooks`, `protocol`, `design-tokens`). This installs from
+ * `packages/server/tests/_setup.mjs` ONLY — server is where every large-subject
+ * assertion lives; the other three were swept and have none. Extending it is a
+ * `--import` flag away (see `no-test-force-exit-hook.mjs` for the
+ * side-effecting-entry-point pattern the two `_setup`-less packages use), and
+ * is tracked rather than done here. As with every guard installed this way, a
+ * run that skips `--import` altogether — a bare `node --test tests/foo.test.js`
+ * — is out of reach; such a run also has no fs write sandbox, which is the
+ * larger reason not to do it.
+ *
+ * COVERAGE, AND THE BINDING-FORM RULE IT INHERITS. Patching the CJS
+ * `module.exports` object covers DEFAULT importers (`import assert from
+ * 'node:assert/strict'`) unconditionally, because a default import resolves to
+ * that live object.
+ *
+ * NAMED and NAMESPACE importers are covered too, but for the more fragile
+ * reason `_setup.mjs` documents at length for `node:fs`: Node builds the
+ * synthetic ESM module for `node:assert` LAZILY, snapshotting its named exports
+ * off `module.exports` the first time some ESM module imports it. As long as
+ * that first link happens AFTER this install runs, the snapshot is taken from
+ * the already-patched object. Measured on Node 22: with the install ordered
+ * first, a named importer sees a 258-char `actual`; put a bare
+ * `import _ from 'node:assert/strict'` ahead of it and the same importer sees
+ * the full 5000.
+ *
+ * So this module inherits the #7262 obligation, transposed: NOTHING EVALUATED
+ * BEFORE `_setup.mjs`'s BODY MAY ESM-IMPORT `node:assert`. This file reaches it
+ * through `createRequire` for exactly that reason, and imports nothing else.
+ *
+ * That fragility is why the ban on non-default assert imports is kept as a
+ * belt-and-braces posture rather than relied on either way:
+ * `tests/assert-match-payload-guard.test.js` fails if a named or namespace
+ * import lands, so the guard never quietly depends on link order alone.
  */
 
 import { createRequire } from 'node:module'
 
 /**
- * Subjects at or below this many characters are passed through untouched — a
- * few KB of `actual` is genuinely useful in a failure and costs nothing. The
- * smallest subject #7401 converted was ~14 KB; the largest small subject left
- * alone (a test-written log or wrapper script) is a few hundred bytes, so the
- * boundary is not close to either class.
+ * Subjects at or below this many characters pass through untouched — a few KB
+ * of `actual` is genuinely useful in a failure and costs nothing.
+ *
+ * The number sits in a real gap in the observed population: the smallest
+ * subject #7401 converted is ~14 KB (`ws-file-ops` index+common), and every
+ * subject deliberately left as `assert.match` is a file the test itself just
+ * wrote — a log, a 43-char secret, a ~1 KB generated wrapper script. Nothing
+ * in the suite sits near 4096 in either direction.
  */
 export const DEFAULT_SUBJECT_LIMIT = 4096
 
+/** Set to an affirmative value to restore full subjects in failure output. */
+export const FULL_PAYLOAD_ENV = 'CHROXY_ASSERT_MATCH_FULL_PAYLOAD'
+
+/** Marks an already-patched assert object. */
+export const PAYLOAD_GUARD_MARKER = Symbol.for('chroxy.assertMatchPayloadGuard')
+
 /** How much of an over-limit subject to show in the failure message. */
 const PREVIEW_CHARS = 200
+
+/**
+ * Affirmative-value check, matching `no-test-force-exit.mjs`. `FOO=0` under
+ * plain truthiness would disarm the guard while reading, to whoever exported
+ * it, as "guard on" (#7400).
+ */
+function envEnabled(value) {
+  return ['1', 'true', 'yes', 'on'].includes(String(value ?? '').trim().toLowerCase())
+}
 
 function preview(subject) {
   const head = subject.slice(0, PREVIEW_CHARS).replace(/\n/g, '\\n')
@@ -69,22 +129,45 @@ function preview(subject) {
  * than one setup file cannot double-wrap.
  */
 function patchOne(target, limit, AssertionError) {
-  if (!target || target.__chroxyMatchPayloadGuard) return false
+  if (!target || target[PAYLOAD_GUARD_MARKER]) return false
   for (const name of ['match', 'doesNotMatch']) {
     const original = target[name]
     if (typeof original !== 'function') continue
     const wantMatch = name === 'match'
     target[name] = function chroxyGuardedAssert(subject, regexp, message) {
       // Delegate anything we are not certain about, so every argument-
-      // validation error assert raises today is raised identically.
-      if (typeof subject !== 'string' || !(regexp instanceof RegExp) || subject.length <= limit) {
+      // validation error assert raises today is raised identically. An Error
+      // passed as `message` is stock's "throw the caller's error verbatim"
+      // path and must not be reshaped into an AssertionError either.
+      if (
+        typeof subject !== 'string' ||
+        !(regexp instanceof RegExp) ||
+        subject.length <= limit ||
+        message instanceof Error
+      ) {
         return original.call(this, subject, regexp, message)
       }
-      // Evaluate ONCE, exactly as assert.match does, so a /g regex's lastIndex
-      // advances the same way it would have unguarded.
-      const matched = regexp.test(subject)
+      // Evaluate ONCE, through the PRIMORDIAL exec — the same one
+      // `assert.match` uses. `regexp.test(...)` would instead go through the
+      // generic RegExpExec path, which reads `exec` off the object, so a regex
+      // with an overridden `exec`/`test` could be judged differently here than
+      // by stock assert — including a real failure reported as a pass.
+      let matched
+      try {
+        matched = RegExp.prototype.exec.call(regexp, subject) !== null
+      } catch {
+        // A RegExp.prototype-derived object with no internal slot lands here;
+        // stock raises its own ERR_INVALID_ARG_TYPE for it, so hand it back.
+        return original.call(this, subject, regexp, message)
+      }
       if (matched === wantMatch) return
-      throw new AssertionError({
+      // `message ||`, matching Node's own `assert.match`, which treats EVERY
+      // falsy message as absent and generates one (measured: '', 0, false and
+      // null all produce the generated text with generatedMessage=true). A
+      // `!== undefined` check reads more principled but diverges from stock for
+      // exactly those callers.
+      const generatedMessage = !message
+      const err = new AssertionError({
         message:
           message ||
           `The ${wantMatch ? 'input did not match' : 'input was expected not to match'} the regular expression ${regexp}. ` +
@@ -95,9 +178,14 @@ function patchOne(target, limit, AssertionError) {
         operator: name,
         stackStartFn: chroxyGuardedAssert,
       })
+      // AssertionError computes `generatedMessage` from whether a message was
+      // passed to IT — and we always pass one. Restore what stock would have
+      // reported, so a consumer reading this field cannot tell the guard apart.
+      err.generatedMessage = generatedMessage
+      throw err
     }
   }
-  Object.defineProperty(target, '__chroxyMatchPayloadGuard', {
+  Object.defineProperty(target, PAYLOAD_GUARD_MARKER, {
     value: true,
     enumerable: false,
     configurable: true,
@@ -108,14 +196,19 @@ function patchOne(target, limit, AssertionError) {
 /**
  * Install the guard on both `node:assert` and `node:assert/strict`.
  *
- * Reached through `createRequire` rather than an ESM import for the same
- * reason `_setup.mjs` does it for `node:fs`: we need the live CJS
- * `module.exports` object that default importers resolve to, not a module
- * namespace object whose properties cannot be reassigned.
+ * Reached through `createRequire` rather than an ESM import for two reasons:
+ * we need the live CJS `module.exports` object that default importers resolve
+ * to, and an ESM `import` here would itself trigger the lazy synthetic-module
+ * link described above, before the patch is applied.
  *
- * @returns {{ patched: string[], limit: number }}
+ * @returns {{ patched: string[], limit: number, skipped: boolean }}
  */
-export function installAssertMatchPayloadGuard({ limit = DEFAULT_SUBJECT_LIMIT } = {}) {
+export function installAssertMatchPayloadGuard({
+  limit = DEFAULT_SUBJECT_LIMIT,
+  env = process.env,
+} = {}) {
+  if (envEnabled(env[FULL_PAYLOAD_ENV])) return { patched: [], limit, skipped: true }
+
   const require = createRequire(import.meta.url)
   const assert = require('node:assert')
   const strict = require('node:assert/strict')
@@ -128,5 +221,5 @@ export function installAssertMatchPayloadGuard({ limit = DEFAULT_SUBJECT_LIMIT }
   if (patchOne(strict, limit, AssertionError)) patched.push('node:assert/strict')
   if (patchOne(assert.strict, limit, AssertionError)) patched.push('node:assert.strict')
 
-  return { patched, limit }
+  return { patched, limit, skipped: false }
 }


### PR DESCRIPTION
## Problem

A failing `assert.match(subject, re)` carries the **entire subject** as the error's `actual`. Where the subject is file text, that means serialising the whole file into the TAP YAML block for a one-line assertion — measured at 124 KB for a single assertion, and in-tree it was observed wedging the runner outright.

```js
assert.match(src, /pattern/)              // fail → the whole file as `actual`
assert.ok(/pattern/.test(src), message)   // fail → `false`, plus a real message
```

## Part 1 — the sites

The issue listed 4 sites and said the list was not exhaustive. A mechanical sweep found **26**, which is rather the point: the list was already stale when it was written.

Converted every assertion whose subject is a large **checked-in** file:

| Subject | Size | Sites |
|---|---:|---|
| `sdk-session.js` | ~100 KB | `sdk-session-intentional-stop` |
| `orchestration-manager.js` | ~66 KB | `orchestration-transition-guards` ×2 |
| `permission-manager.js` | ~61 KB | `permission-hook-floor` ×3 |
| `ws-permissions.js` | ~52 KB | `permission-hook-floor` ×3 |
| `bump-version.sh` | ~26 KB | `bump-version-trap-cleanup` ×4 |
| `permission-floor.js` | ~25 KB | `permission-hook-floor` ×1 |
| `ws-file-ops` index+common | ~14 KB | `ws-file-ops-cache` ×2 |

Two notes on judgement:

- The issue described `bump-version.sh` as "a few-KB shell script" and suggested leaving it. It is **26 KB** — converted.
- The two `assert.doesNotMatch` calls in `permission-hook-floor` had **no message at all**: the worst case of the lot, ~61 KB of `actual` and nothing telling you what broke. They gained one.

The remaining **10 sites read files the test itself just wrote** (a log, a 43-char secret, a generated wrapper script). Those keep `assert.match` and each carries a note saying why the subject is small enough not to matter — the "explicitly left with a note" half of AC1.

## Part 2 — stopping it regrowing (AC2)

That conversion is a **list**, and a list beside a growing set is the first recurring cause in `docs/false-safety-guards.md` (#7192, #7197, #7267, #7270).

The obvious guard is a static lint for `assert.match(<ident>` where the identifier is bound from a file read. **I wrote that lint first, and it has a demonstrated false-negative class:** a regex over `readFileSync` missed `ws-file-ops-cache.test.js` — a site *the issue itself names* — because the binding was a multi-line `await readFile()` from `fs/promises`. A guard that silently misses the cases it was written for is precisely the defect class this repo catalogues, so the check moved to **runtime**, where the subject's real size is known and no binding style can hide it.

`scripts/lib/assert-match-payload-guard.mjs`, installed from `packages/server/tests/_setup.mjs`:

- Caps the failure payload for any site the list misses or that lands later.
- **Never changes whether an assertion passes or fails** — only how much of the subject rides along on a failure.
- Evaluates the regex **exactly once**, as `assert.match` does, so a stateful `/g` regex behaves identically.
- Delegates non-string subjects and non-regexp patterns untouched, preserving both distinct stock argument-validation errors.

**Coverage, enforced rather than asserted.** Every server test imports assert as a *default* import (567 `node:assert/strict`, 5 `node:assert`), which resolves to the live CJS object — so patching it covers all of them without depending on the lazy-link race that `_setup.mjs` documents for `node:fs`. A named or namespace import *would* bypass it. There are none, and the coverage test fails the moment one lands, in the same shape as `setup-sandbox-coverage.test.js`.

## Verification

Every guarantee is mutation-proven, each mutant asserted to have **landed** before trusting its result:

| Mutation | Result |
|---|---|
| Guard swallows an over-limit failure (the catastrophic bug) | **5 tests fail** |
| Truncation removed (`PREVIEW_CHARS` → 100000) | **1 test fails** |
| A named `assert` import added to a test file | **coverage test fails** |

One mutation initially reported a clean 13/13 because my `sed` escaping was wrong and it **never applied** — caught by asserting the mutant landed. Worth noting since that failure mode reads exactly like "the guard is fine".

Full server suite, Node 22, compared against unmodified `origin/main`:

| | `origin/main` | this branch |
|---|---|---|
| tests run | 14065 | **14078** (+13, exactly the new guard tests) |
| failing | 19 across 11 files | 19 across 11 files — **identical list** |

Those 19 are pre-existing and local to this macOS box (symlink privileges, curl passthrough, provider detection); I verified the lists are byte-identical rather than assuming. All 9 custom server lints pass.

Closes #7401