### PR TITLE
test(server): make two source-grep guards behavioural

### DIFF
--- a/docs/false-safety-guards.md
+++ b/docs/false-safety-guards.md
@@ -623,6 +623,62 @@ adds an entry to it:
   single-branch mutant while that branch was fully exploitable. It now splits on
   `'; else '` and asserts per branch.
 
+### 20. Two guards pinned at the source text, not the behaviour — `#7374`
+
+Both guards were **honest** about being source-level greps, and both were still
+bypassable. That is the point of this entry: "it says it is a source grep" is a
+disclosure, not a defence, and the residual belongs here rather than in a
+comment that only the next editor of that file will read.
+
+**The reaper nobody proved was called.** `cli-permission-mode-sidecar.test.js`
+asserted that `server-cli.js` contained `sweepStaleSinkDirs(log)` inside an
+anchored `import(...)` slice, and its docstring claimed the anchoring meant the
+assertion "cannot be satisfied by the explanatory comment beside it". Two
+mutants said otherwise, both **GREEN**:
+
+- wrap the whole boot block in `if (process.env.__NEVER_SET__) { … }`
+- replace the call with `.then(({CliSession}) => void CliSession)` and put the
+  expected string in a comment *inside* the anchored window
+
+Entry 1 verbatim: a source grep cannot tell a call reached at boot from the same
+characters behind a false condition, and anchoring only excludes comments
+*outside* the window it happens to choose.
+
+**The allowlist that was not the only way in.** The same file asserted that
+`FORWARDED_ENV_KEYS` in `docker-session.js` does not contain
+`CHROXY_PERMISSION_MODE_FILE` — a host path that names nothing inside the
+container. Adding the key to the array went red, which is why the guard felt
+solid. But pushing `dockerArgs.push('--env', 'CHROXY_PERMISSION_MODE_FILE=…')`
+*outside* the allowlist loop stayed **GREEN**, and two explicit single-key
+pushes already sit immediately below that loop. The guard pinned one syntactic
+route into `dockerArgs`, not the property.
+
+**The fix, in both cases, was to make the work observable rather than to write a
+cleverer grep.** The boot block moved into `sweep-stale-provider-dirs.js` with
+injectable loaders, so tests RUN it; all three of its mutants now die.
+`DockerSession` gained a one-line `_spawnDocker` seam so a test can capture the
+argv the real `_spawnPersistentProcess` actually builds; the outside-the-loop
+mutant fails 2 tests there and **0** against the old grep — the two were run
+side by side under the same mutant to confirm it.
+
+The negative assertion also needed a positive control it did not have: the child
+env emits `CHROXY_PERMISSION_MODE_FILE` as `''` when no sidecar exists, so
+"the key is absent from argv" would have passed on a session that never had a
+path to leak. The behavioural test sets a real host path first and asserts an
+allowlisted key *does* get forwarded, so the machinery is proven to have run.
+
+**What is still source-level, stated plainly:** that `server-cli.js` calls
+`sweepStaleProviderDirs(log)` at boot. Short of booting the daemon nothing
+distinguishes that call from the same characters behind a false condition. The
+assertion is line-anchored so a commented-out call no longer satisfies it —
+verified — but the residual is real and is recorded here rather than argued away
+at the call site.
+
+**Guard against it:** when a guard's subject is "does this code RUN", extract
+the body until a test can call it. A grep answers "do these characters exist",
+which is a different question, and the gap between them is exactly where these
+two lived.
+
 ## The one that got me while writing this
 
 A Maestro `repeat` was written with `maxRuns: 3`. `YamlRepeatCommand` has no

--- a/docs/false-safety-guards.md
+++ b/docs/false-safety-guards.md
@@ -623,62 +623,6 @@ adds an entry to it:
   single-branch mutant while that branch was fully exploitable. It now splits on
   `'; else '` and asserts per branch.
 
-### 20. Two guards pinned at the source text, not the behaviour — `#7374`
-
-Both guards were **honest** about being source-level greps, and both were still
-bypassable. That is the point of this entry: "it says it is a source grep" is a
-disclosure, not a defence, and the residual belongs here rather than in a
-comment that only the next editor of that file will read.
-
-**The reaper nobody proved was called.** `cli-permission-mode-sidecar.test.js`
-asserted that `server-cli.js` contained `sweepStaleSinkDirs(log)` inside an
-anchored `import(...)` slice, and its docstring claimed the anchoring meant the
-assertion "cannot be satisfied by the explanatory comment beside it". Two
-mutants said otherwise, both **GREEN**:
-
-- wrap the whole boot block in `if (process.env.__NEVER_SET__) { … }`
-- replace the call with `.then(({CliSession}) => void CliSession)` and put the
-  expected string in a comment *inside* the anchored window
-
-Entry 1 verbatim: a source grep cannot tell a call reached at boot from the same
-characters behind a false condition, and anchoring only excludes comments
-*outside* the window it happens to choose.
-
-**The allowlist that was not the only way in.** The same file asserted that
-`FORWARDED_ENV_KEYS` in `docker-session.js` does not contain
-`CHROXY_PERMISSION_MODE_FILE` — a host path that names nothing inside the
-container. Adding the key to the array went red, which is why the guard felt
-solid. But pushing `dockerArgs.push('--env', 'CHROXY_PERMISSION_MODE_FILE=…')`
-*outside* the allowlist loop stayed **GREEN**, and two explicit single-key
-pushes already sit immediately below that loop. The guard pinned one syntactic
-route into `dockerArgs`, not the property.
-
-**The fix, in both cases, was to make the work observable rather than to write a
-cleverer grep.** The boot block moved into `sweep-stale-provider-dirs.js` with
-injectable loaders, so tests RUN it; all three of its mutants now die.
-`DockerSession` gained a one-line `_spawnDocker` seam so a test can capture the
-argv the real `_spawnPersistentProcess` actually builds; the outside-the-loop
-mutant fails 2 tests there and **0** against the old grep — the two were run
-side by side under the same mutant to confirm it.
-
-The negative assertion also needed a positive control it did not have: the child
-env emits `CHROXY_PERMISSION_MODE_FILE` as `''` when no sidecar exists, so
-"the key is absent from argv" would have passed on a session that never had a
-path to leak. The behavioural test sets a real host path first and asserts an
-allowlisted key *does* get forwarded, so the machinery is proven to have run.
-
-**What is still source-level, stated plainly:** that `server-cli.js` calls
-`sweepStaleProviderDirs(log)` at boot. Short of booting the daemon nothing
-distinguishes that call from the same characters behind a false condition. The
-assertion is line-anchored so a commented-out call no longer satisfies it —
-verified — but the residual is real and is recorded here rather than argued away
-at the call site.
-
-**Guard against it:** when a guard's subject is "does this code RUN", extract
-the body until a test can call it. A grep answers "do these characters exist",
-which is a different question, and the gap between them is exactly where these
-two lived.
-
 ## The one that got me while writing this
 
 A Maestro `repeat` was written with `maxRuns: 3`. `YamlRepeatCommand` has no
@@ -1152,3 +1096,70 @@ so the next occurrence is caught on Linux instead of only on Windows.
 have to earn. When a run reports a count, pin the count — and when a comment
 tells you which flags a command carries, check the command. Both halves here
 were readable in ten seconds by anyone who thought to look.
+### 20. Two guards pinned at the source text, not the behaviour — `#7374`
+
+Both guards were **honest** about being source-level greps, and both were still
+bypassable. That is the point of this entry: "it says it is a source grep" is a
+disclosure, not a defence, and the residual belongs here rather than in a
+comment that only the next editor of that file will read.
+
+**The reaper nobody proved was called.** `cli-permission-mode-sidecar.test.js`
+asserted that `server-cli.js` contained `sweepStaleSinkDirs(log)` inside an
+anchored `import(...)` slice, and its docstring claimed the anchoring meant the
+assertion "cannot be satisfied by the explanatory comment beside it". Two
+mutants said otherwise, both **GREEN**:
+
+- wrap the whole boot block in `if (process.env.__NEVER_SET__) { … }`
+- replace the call with `.then(({CliSession}) => void CliSession)` and put the
+  expected string in a comment *inside* the anchored window
+
+Entry 1 verbatim: a source grep cannot tell a call reached at boot from the same
+characters behind a false condition, and anchoring only excludes comments
+*outside* the window it happens to choose.
+
+**The allowlist that was not the only way in.** The same file asserted that
+`FORWARDED_ENV_KEYS` in `docker-session.js` does not contain
+`CHROXY_PERMISSION_MODE_FILE` — a host path that names nothing inside the
+container. Adding the key to the array went red, which is why the guard felt
+solid. But pushing `dockerArgs.push('--env', 'CHROXY_PERMISSION_MODE_FILE=…')`
+*outside* the allowlist loop stayed **GREEN**, and two explicit single-key
+pushes already sit immediately below that loop. The guard pinned one syntactic
+route into `dockerArgs`, not the property.
+
+**The fix, in both cases, was to make the work observable rather than to write a
+cleverer grep.** The boot block moved into `sweep-stale-provider-dirs.js` with
+injectable loaders, so tests RUN it; all three of its mutants now die.
+`DockerSession` gained a one-line `_spawnDocker` seam so a test can capture the
+argv the real `_spawnPersistentProcess` actually builds; the outside-the-loop
+mutant fails 2 tests there and **0** against the old grep — the two were run
+side by side under the same mutant to confirm it.
+
+The negative assertion also needed a positive control it did not have: the child
+env emits `CHROXY_PERMISSION_MODE_FILE` as `''` when no sidecar exists, so
+"the key is absent from argv" would have passed on a session that never had a
+path to leak. The behavioural test sets a real host path first and asserts an
+allowlisted key *does* get forwarded, so the machinery is proven to have run.
+
+**What is still source-level, stated plainly:** that `server-cli.js` calls
+`sweepStaleProviderDirs(log)` at boot. Short of booting the daemon nothing
+distinguishes that call from the same characters behind a false condition.
+
+**And the first version of that residual grep was itself bypassable**, which is
+the part worth keeping. It read `/^\s*sweepStaleProviderDirs\(log\)/m` and its
+comment claimed "line-anchored, so a mention inside a comment does not count".
+`\s` matches newlines. Review deleted the real call, left
+`/*\nsweepStaleProviderDirs(log)\n*/` in its place, and got **20/20 green** —
+the boot sweep gone and the guard satisfied. It rejected `//` and ` * ` lines
+only, which is exactly what made it look anchored. It now strips block comments
+first and matches with `[ \t]`, and the bypass goes red.
+
+That is causes #7290/#7291 — a guard whose comment describes a stronger check
+than its code performs — occurring *inside the entry written to catalogue them*,
+in the same change, by someone who had just read them. Treat "line-anchored" as
+a claim to test, not a property to assert: `\s`, `.` under `/s`, and any
+`[\s\S]` window all cross line boundaries.
+
+**Guard against it:** when a guard's subject is "does this code RUN", extract
+the body until a test can call it. A grep answers "do these characters exist",
+which is a different question, and the gap between them is exactly where these
+two lived.

--- a/packages/server/src/docker-session.js
+++ b/packages/server/src/docker-session.js
@@ -270,6 +270,26 @@ export class DockerSession extends CliSession {
   }
 
   /**
+   * Spawn seam (#7374).
+   *
+   * Exists so a test can observe the argv `_spawnPersistentProcess` ACTUALLY
+   * builds. Before this, the rule that `CHROXY_PERMISSION_MODE_FILE` must not
+   * reach the container was pinned only by a source-level grep of the
+   * `FORWARDED_ENV_KEYS` literal — which stays green when a key is pushed into
+   * `dockerArgs` OUTSIDE the allowlist loop. That is not hypothetical: there
+   * are already two such explicit pushes immediately below the loop
+   * (`CHROXY_HOST`, `getChroxyHostEnv()`), so the allowlist is demonstrably not
+   * the only way in.
+   *
+   * Kept as a one-line override point rather than a constructor opt so it adds
+   * no BaseSession opt to forward (see BASE_SESSION_OPT_KEYS and
+   * scripts/lint-session-opt-forwarding.sh).
+   */
+  _spawnDocker(dockerArgs) {
+    return spawn('docker', dockerArgs, { stdio: ['pipe', 'pipe', 'pipe'] })
+  }
+
+  /**
    * Override CliSession._spawnPersistentProcess to use `docker exec -i`
    * instead of spawning `claude` directly.
    *
@@ -320,9 +340,7 @@ export class DockerSession extends CliSession {
 
     log.info(`Exec into container ${this._containerId.slice(0, 12)} (model: ${this.model || 'default'})`)
 
-    const child = spawn('docker', dockerArgs, {
-      stdio: ['pipe', 'pipe', 'pipe'],
-    })
+    const child = this._spawnDocker(dockerArgs)
 
     this._child = child
 

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -51,6 +51,7 @@ import { getRegistryForProvider, watchModelsOverlay } from './models.js'
 // (`if (config?.environments?.enabled)`).
 import { UNREACHABLE_STATUSES } from './environment-statuses.js'
 import { resolveSkipPermissions, buildEnvironmentBackend, isUserShellEnabled, getAllowAnyModelProviders, isSemanticTitlesEnabled, resolveSemanticTitleModel, resolveSemanticTitleTimeoutMs, resolveBinaryProvenanceMode, isBinarySignatureGateEnabled } from './config.js'
+import { sweepStaleProviderDirs } from './sweep-stale-provider-dirs.js'
 import { buildOrchestrationManager } from './orchestration/build-manager.js'
 import { buildSchedulerEngine } from './scheduler.js'
 import { parseDuration } from './duration.js'
@@ -1428,21 +1429,12 @@ export async function startCliServer(config) {
       .catch((err) => log.warn(`worktree auto-reaper failed: ${(err && err.message) || err}`))
   }
 
-  // #5323 (WP-5.1) — sweep claude-tui hook-sink dirs left in /tmp by prior
-  // crashed processes (a leak on every crash). Safe + unconditional: only dirs
-  // whose owner pid is dead are removed, so a live daemon's dirs — including
-  // ours — are kept. Fire-and-forget + lazily imported so a non-tui boot pays
-  // nothing and a failure never affects startup.
-  import('./claude-tui-session.js')
-    .then(({ ClaudeTuiSession }) => ClaudeTuiSession.sweepStaleSinkDirs(log))
-    .catch((err) => log.warn(`claude-tui sink-dir sweep failed: ${(err && err.message) || err}`))
-
-  // #7337 — same sweep for claude-cli's per-session permission-mode sidecar
-  // dirs, which leak on a crash for exactly the same reason. Same ownership
-  // rule (only DEAD owners are reaped), same fire-and-forget lazy import.
-  import('./cli-session.js')
-    .then(({ CliSession }) => CliSession.sweepStaleSidecarDirs(log))
-    .catch((err) => log.warn(`claude-cli sidecar-dir sweep failed: ${(err && err.message) || err}`))
+  // #7374 — both providers' stale per-session dirs. The body lives in its own
+  // module so the sweep is covered by tests that RUN it; this block used to be
+  // inline and was pinned only by a source grep, which stayed green with the
+  // whole thing behind a false condition. Fire-and-forget: the function never
+  // rejects, and a sweep must never affect startup.
+  sweepStaleProviderDirs(log)
 
   console.log('\nPress Ctrl+C to stop.\n')
 

--- a/packages/server/src/sweep-stale-provider-dirs.js
+++ b/packages/server/src/sweep-stale-provider-dirs.js
@@ -1,0 +1,68 @@
+/**
+ * Boot-time sweep of stale per-session provider dirs (#7374).
+ *
+ * Extracted from `server-cli.js` so the sweep is pinned BEHAVIOURALLY. It used
+ * to be an inline block in the boot path, guarded only by a test that grepped
+ * `server-cli.js` for `sweepStaleSinkDirs(log)` inside an anchored `import(...)`
+ * slice. Mutation testing during #7371's review showed two bypasses that kept
+ * that guard green:
+ *
+ *   - wrapping the whole block in `if (process.env.__NEVER_SET__) { … }`
+ *   - replacing the call with `.then(({CliSession}) => void CliSession)` and
+ *     putting the expected string in a comment INSIDE the anchored window
+ *
+ * That is catalogue entry 1 ("the gate that never ran"): a source grep cannot
+ * tell a call reached at boot from the same characters behind a false
+ * condition. Extracting the body means the WORK is now covered by tests that
+ * actually run it — see `tests/sweep-stale-provider-dirs.test.js`.
+ *
+ * What remains source-level is only that `server-cli.js` calls this function at
+ * boot. That residual is recorded in `docs/false-safety-guards.md` rather than
+ * papered over in a comment here.
+ *
+ * Both sweeps are safe and unconditional: only dirs whose owner pid is DEAD are
+ * removed, so a live daemon's dirs — including ours — are kept. Lazily imported
+ * so a boot that uses neither provider pays nothing, and every failure is
+ * warned rather than thrown so a sweep can never affect startup.
+ */
+
+/**
+ * The real module loaders. Injectable so a test can drive this function with
+ * stubs instead of `mock.module`, which leaks across the parallel test files
+ * `node --test` runs.
+ */
+export const DEFAULT_SWEEP_LOADERS = {
+  // #5323 (WP-5.1) — claude-tui hook-sink dirs left in /tmp by prior crashed
+  // processes (a leak on every crash).
+  'claude-tui sink-dir': async () => {
+    const { ClaudeTuiSession } = await import('./claude-tui-session.js')
+    return (log) => ClaudeTuiSession.sweepStaleSinkDirs(log)
+  },
+  // #7337 — same sweep for claude-cli's per-session permission-mode sidecar
+  // dirs, which leak on a crash for exactly the same reason.
+  'claude-cli sidecar-dir': async () => {
+    const { CliSession } = await import('./cli-session.js')
+    return (log) => CliSession.sweepStaleSidecarDirs(log)
+  },
+}
+
+/**
+ * Run every provider's stale-dir sweep. Never rejects: a loader or sweep that
+ * throws is warned and the others still run.
+ *
+ * @param {{ info: Function, warn: Function }} log
+ * @param {Record<string, () => Promise<Function>>} [loaders]
+ * @returns {Promise<void>}
+ */
+export async function sweepStaleProviderDirs(log, loaders = DEFAULT_SWEEP_LOADERS) {
+  await Promise.all(
+    Object.entries(loaders).map(async ([label, load]) => {
+      try {
+        const sweep = await load()
+        await sweep(log)
+      } catch (err) {
+        log.warn(`${label} sweep failed: ${(err && err.message) || err}`)
+      }
+    }),
+  )
+}

--- a/packages/server/src/sweep-stale-provider-dirs.js
+++ b/packages/server/src/sweep-stale-provider-dirs.js
@@ -61,7 +61,19 @@ export async function sweepStaleProviderDirs(log, loaders = DEFAULT_SWEEP_LOADER
         const sweep = await load()
         await sweep(log)
       } catch (err) {
-        log.warn(`${label} sweep failed: ${(err && err.message) || err}`)
+        // The logger is the one call left outside the try, and a throwing
+        // `log.warn` would reject `Promise.all` — which nothing awaits, so it
+        // surfaces as an unhandledRejection, and server-orchestrator treats
+        // that as fatal. The OLD inline form had the identical hole (a throw
+        // inside `.catch()` rejects the chain just the same), so this is not a
+        // regression being fixed — it is the "never rejects" claim being made
+        // true rather than nearly true.
+        try {
+          log.warn(`${label} sweep failed: ${(err && err.message) || err}`)
+        } catch {
+          // Nothing left to report it with. Swallowing is correct: a
+          // best-effort reaper must never be able to take down boot.
+        }
       }
     }),
   )

--- a/packages/server/tests/cli-permission-mode-sidecar.test.js
+++ b/packages/server/tests/cli-permission-mode-sidecar.test.js
@@ -569,25 +569,37 @@ describe('CliSession permission-mode sidecar (#7337)', () => {
   })
 
   /**
-   * A reaper nobody calls is dead code that reads as cleanup. Both boot calls
-   * are pinned here, ANCHORED to the `import(` expression that performs them so
-   * the assertion cannot be satisfied by the explanatory comment beside it.
+   * A reaper nobody calls is dead code that reads as cleanup.
+   *
+   * #7374 — this used to grep the whole boot block out of `server-cli.js`, and
+   * claimed the anchoring meant it "cannot be satisfied by the explanatory
+   * comment beside it". That claim was too strong: mutation testing found two
+   * bypasses that kept it green — wrapping the block in
+   * `if (process.env.__NEVER_SET__)`, and replacing the call with
+   * `.then(({CliSession}) => void CliSession)` while leaving the expected
+   * string in a comment INSIDE the anchored window.
+   *
+   * The block now lives in `sweep-stale-provider-dirs.js` and its behaviour is
+   * covered by `tests/sweep-stale-provider-dirs.test.js`, which RUNS it — all
+   * three of those mutants die there.
+   *
+   * What is left here is only the CALL SITE, and it is still source-level:
+   * short of booting the daemon, nothing distinguishes this call from the same
+   * characters behind a false condition. That residual is recorded in
+   * `docs/false-safety-guards.md`; it is deliberately not talked away here.
    */
-  it('server-cli boot sweeps BOTH providers\' stale per-session dirs', () => {
+  it('server-cli boot calls the provider stale-dir sweep', () => {
     const src = readFileSync(join(__dirname, '../src/server-cli.js'), 'utf8')
 
-    for (const [module, method] of [
-      ['./claude-tui-session.js', 'sweepStaleSinkDirs'],
-      ['./cli-session.js', 'sweepStaleSidecarDirs'],
-    ]) {
-      const start = src.indexOf(`import('${module}')`)
-      assert.ok(start !== -1, `positive control: server-cli must lazily import ${module} at boot`)
-      // The `.then(...)` that consumes the import, and nothing after it.
-      const slice = src.slice(start, src.indexOf('.catch(', start))
-      assert.ok(slice.length > 0, `positive control: the ${module} import slice must be non-empty`)
-      assert.ok(slice.includes(`${method}(log)`),
-        `boot must actually call ${method}(log) on the ${module} import — otherwise the reaper never runs and crashed sessions leak a dir each`)
-    }
+    assert.ok(
+      /^import \{ sweepStaleProviderDirs \} from '\.\/sweep-stale-provider-dirs\.js'/m.test(src),
+      'positive control: server-cli must import the sweep',
+    )
+    // Line-anchored, so a mention inside a comment or docstring does not count.
+    assert.ok(
+      /^\s*sweepStaleProviderDirs\(log\)/m.test(src),
+      'boot must actually call sweepStaleProviderDirs(log) — otherwise the reapers never run and crashed sessions leak a dir each',
+    )
   })
 
   // ---- blast radius: DockerSession extends CliSession -----------------
@@ -600,12 +612,18 @@ describe('CliSession permission-mode sidecar (#7337)', () => {
    * not exist; this pins that it STAYS out until a bind mount makes the
    * sidecar readable in there.
    *
-   * Source-level and ANCHORED: docker-session.test.js drives a hand-written
-   * MIRROR of `_spawnPersistentProcess`, so an argv assertion over that mirror
-   * would keep passing with the real array changed. Slice the real array out
-   * of the real module instead, and assert only within the slice — a file-wide
-   * grep would be satisfiable by the explanatory comment sitting right below
-   * it, which names the key.
+   * #7374 — this is a source-level grep of the array literal, and it has a
+   * KNOWN bypass: pushing `--env CHROXY_PERMISSION_MODE_FILE=…` into
+   * `dockerArgs` outside the allowlist loop keeps it green, and two explicit
+   * single-key pushes already sit below that loop. It is kept because it names
+   * the naive fix precisely (adding the key to the array goes red here with a
+   * pointed message), but it is NO LONGER the guard.
+   *
+   * The real guard is now behavioural:
+   * `docker-session.test.js` → 'DockerSession._spawnPersistentProcess — real
+   * argv (#7374)' drives the real method and captures argv at the
+   * `_spawnDocker` seam, so every route into `dockerArgs` is covered. Verified:
+   * the outside-the-loop mutant fails 2 tests there and 0 here.
    */
   it('DockerSession does NOT forward CHROXY_PERMISSION_MODE_FILE into the container', () => {
     const src = readFileSync(join(__dirname, '../src/docker-session.js'), 'utf8')

--- a/packages/server/tests/cli-permission-mode-sidecar.test.js
+++ b/packages/server/tests/cli-permission-mode-sidecar.test.js
@@ -592,12 +592,24 @@ describe('CliSession permission-mode sidecar (#7337)', () => {
     const src = readFileSync(join(__dirname, '../src/server-cli.js'), 'utf8')
 
     assert.ok(
-      /^import \{ sweepStaleProviderDirs \} from '\.\/sweep-stale-provider-dirs\.js'/m.test(src),
+      /from '\.\/sweep-stale-provider-dirs\.js'/.test(src),
       'positive control: server-cli must import the sweep',
     )
-    // Line-anchored, so a mention inside a comment or docstring does not count.
+    // Strip block comments FIRST, then match with `[ \t]` rather than `\s`.
+    //
+    // Both halves are load-bearing, and the first version of this assertion had
+    // neither. `\s` matches newlines, so `/^\s*sweepStaleProviderDirs\(log\)/m`
+    // was satisfied by `/*\nsweepStaleProviderDirs(log)\n*/` with the real call
+    // DELETED — measured: 20/20 green, boot sweep gone. It rejected `//` and
+    // ` * ` lines only, which is what made it look line-anchored.
+    //
+    // This is still a source-level pin and still bypassable by a call after an
+    // early `return`, or inside a function nobody invokes. See entry 20 in
+    // docs/false-safety-guards.md; the sweep's BEHAVIOUR is covered by
+    // tests/sweep-stale-provider-dirs.test.js, which runs it.
+    const code = src.replace(/\/\*[\s\S]*?\*\//g, '')
     assert.ok(
-      /^\s*sweepStaleProviderDirs\(log\)/m.test(src),
+      /^[ \t]*sweepStaleProviderDirs\(log\)/m.test(code),
       'boot must actually call sweepStaleProviderDirs(log) — otherwise the reapers never run and crashed sessions leak a dir each',
     )
   })

--- a/packages/server/tests/docker-session.test.js
+++ b/packages/server/tests/docker-session.test.js
@@ -660,7 +660,7 @@ describe('DockerSession._spawnPersistentProcess — real argv (#7374)', () => {
     return child
   }
 
-  async function captureArgv(mutate) {
+  async function captureArgv() {
     const { DockerSession } = await import('../src/docker-session.js')
     const session = new DockerSession({ cwd: '/tmp', image: 'node:22-slim' })
     session._containerId = 'c0ffee1234567890'
@@ -676,13 +676,13 @@ describe('DockerSession._spawnPersistentProcess — real argv (#7374)', () => {
       captured = dockerArgs
       return child
     }
-    if (mutate) mutate(session)
-
     session._spawnPersistentProcess(['-p', '--model', 'opus'])
 
     // Tear down the readline interfaces and streams this created, or the file
     // leaks handles and the runner hangs after its summary.
-    session._cleanupReadlines?.()
+    // No `?.` — if this is ever renamed the teardown must go RED, not silently
+    // no-op and leave the file hanging on a leaked readline handle (entry 17).
+    session._cleanupReadlines()
     for (const s of [child.stdin, child.stdout, child.stderr]) s.destroy()
 
     return { captured, session }

--- a/packages/server/tests/docker-session.test.js
+++ b/packages/server/tests/docker-session.test.js
@@ -1,6 +1,7 @@
 import { describe, it, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
 import { EventEmitter } from 'node:events'
+import { PassThrough } from 'node:stream'
 
 /**
  * Tests for DockerSession.
@@ -625,5 +626,110 @@ describe('DockerSession inherits CliSession close-handler fix (#4469)', () => {
     assert.equal(events[0].payload.messageId, 'msg_docker')
     assert.equal(events[1].payload.sessionId, 'sess_docker')
     assert.equal(events[1].payload.cost, null)
+  })
+})
+
+/**
+ * #7374 — the env-forwarding rule, pinned at the ARGV the real code builds.
+ *
+ * Until this block, "DockerSession must not forward CHROXY_PERMISSION_MODE_FILE
+ * into the container" was pinned only by a source-level grep of the
+ * `FORWARDED_ENV_KEYS` array literal in cli-permission-mode-sidecar.test.js.
+ * Mutation testing during #7371's review showed the bypass: pushing
+ * `--env CHROXY_PERMISSION_MODE_FILE=…` into `dockerArgs` OUTSIDE the allowlist
+ * loop kept that guard GREEN. The allowlist is demonstrably not the only way in
+ * — two explicit single-key pushes sit immediately below it.
+ *
+ * These tests drive the REAL DockerSession through the REAL
+ * `_spawnPersistentProcess`, capturing argv at the `_spawnDocker` seam, so any
+ * route into `dockerArgs` is covered rather than one syntactic form of it.
+ * Note this is deliberately NOT the mirror harness at the top of this file:
+ * a mirror re-implements the thing under test, so it keeps passing when the
+ * real code changes.
+ */
+describe('DockerSession._spawnPersistentProcess — real argv (#7374)', () => {
+  const HOST_ONLY_SIDECAR = '/tmp/chroxy-host-only/s-abc/permission-mode'
+
+  /** Minimal stdio-shaped child so the post-spawn wiring runs unchanged. */
+  function fakeChild() {
+    const child = new EventEmitter()
+    child.stdin = new PassThrough()
+    child.stdout = new PassThrough()
+    child.stderr = new PassThrough()
+    child.kill = () => {}
+    return child
+  }
+
+  async function captureArgv(mutate) {
+    const { DockerSession } = await import('../src/docker-session.js')
+    const session = new DockerSession({ cwd: '/tmp', image: 'node:22-slim' })
+    session._containerId = 'c0ffee1234567890'
+    // Give the session a REAL-looking host sidecar path. Without this,
+    // `_buildChildEnv()` emits CHROXY_PERMISSION_MODE_FILE as '' and the
+    // negative assertion below would pass because there was nothing to leak —
+    // the vacuous-pass shape this whole issue is about.
+    session._permissionModeFile = HOST_ONLY_SIDECAR
+
+    let captured = null
+    const child = fakeChild()
+    session._spawnDocker = (dockerArgs) => {
+      captured = dockerArgs
+      return child
+    }
+    if (mutate) mutate(session)
+
+    session._spawnPersistentProcess(['-p', '--model', 'opus'])
+
+    // Tear down the readline interfaces and streams this created, or the file
+    // leaks handles and the runner hangs after its summary.
+    session._cleanupReadlines?.()
+    for (const s of [child.stdin, child.stdout, child.stderr]) s.destroy()
+
+    return { captured, session }
+  }
+
+  it('POSITIVE CONTROL: the env really does carry the host sidecar path', async () => {
+    const { DockerSession } = await import('../src/docker-session.js')
+    const session = new DockerSession({ cwd: '/tmp', image: 'node:22-slim' })
+    session._permissionModeFile = HOST_ONLY_SIDECAR
+    // If this ever stops holding, every "does not forward" assertion below
+    // becomes vacuous — it would be asserting the absence of something that
+    // was never in the env to begin with.
+    assert.equal(
+      session._buildChildEnv().CHROXY_PERMISSION_MODE_FILE,
+      HOST_ONLY_SIDECAR,
+      'the child env must carry the host sidecar path for the leak test to mean anything',
+    )
+  })
+
+  it('POSITIVE CONTROL: allowlisted env vars DO reach the container argv', async () => {
+    const { captured } = await captureArgv()
+    assert.ok(captured, 'the spawn seam must have been reached')
+    // Proves the forwarding machinery ran at all — without it, a session that
+    // returned early would satisfy the negative assertion trivially.
+    assert.ok(
+      captured.some((a) => String(a).startsWith('CHROXY_PERMISSION_MODE=')),
+      `an allowlisted key must be forwarded; got: ${JSON.stringify(captured)}`,
+    )
+    assert.ok(captured.includes('exec'), 'argv must be a docker exec invocation')
+  })
+
+  it('does NOT forward CHROXY_PERMISSION_MODE_FILE into the container', async () => {
+    const { captured } = await captureArgv()
+    const offenders = captured.filter((a) => String(a).includes('CHROXY_PERMISSION_MODE_FILE'))
+    assert.deepEqual(
+      offenders,
+      [],
+      'the sidecar path is a HOST path; `docker exec` cannot mount it, so forwarding the key would name a path that does not exist in the container. Add the bind mount in _startContainer() before adding the key.',
+    )
+  })
+
+  it('does not leak the host sidecar PATH by any other argv route', async () => {
+    // Keyed on the VALUE, not the variable name: a forward that renamed the key
+    // (or embedded the path in another var) would slip past a name-only check
+    // while leaking exactly the same host path.
+    const { captured } = await captureArgv()
+    const leaked = captured.filter((a) => String(a).includes(HOST_ONLY_SIDECAR))
+    assert.deepEqual(leaked, [], `the host sidecar path must not appear anywhere in argv; got ${JSON.stringify(leaked)}`)
   })
 })

--- a/packages/server/tests/sweep-stale-provider-dirs.test.js
+++ b/packages/server/tests/sweep-stale-provider-dirs.test.js
@@ -66,6 +66,25 @@ describe('sweepStaleProviderDirs (#7374)', () => {
     assert.ok(log.warns.some((w) => w.includes('throwing-sweep') && w.includes('reaper blew up')))
   })
 
+  it('never rejects even when the LOGGER throws', async () => {
+    // The one path that used to escape: `log.warn` itself throwing would
+    // reject Promise.all, which nothing awaits, so it arrives as an
+    // unhandledRejection — and server-orchestrator treats that as fatal.
+    const hostileLog = {
+      info() {},
+      warn() {
+        throw new Error('logger is broken')
+      },
+    }
+    await assert.doesNotReject(() =>
+      sweepStaleProviderDirs(hostileLog, {
+        exploding: async () => {
+          throw new Error('boom')
+        },
+      }),
+    )
+  })
+
   it('never rejects — boot must not be able to fail on a sweep', async () => {
     const log = recordingLog()
     await assert.doesNotReject(() =>
@@ -91,19 +110,57 @@ describe('sweepStaleProviderDirs (#7374)', () => {
       ])
     })
 
-    for (const label of ['claude-tui sink-dir', 'claude-cli sidecar-dir']) {
+    for (const label of Object.keys(DEFAULT_SWEEP_LOADERS)) {
       it(`${label}: resolves to a callable sweep on the real provider module`, async () => {
         const sweep = await DEFAULT_SWEEP_LOADERS[label]()
         assert.equal(typeof sweep, 'function', 'the loader must resolve to the provider sweep')
       })
     }
 
-    it('running the REAL default loaders sweeps without throwing', async () => {
-      // End-to-end over the actual provider modules. Only dirs with a DEAD
-      // owner pid are removed, so this is safe to run: this process is alive,
-      // and the fs sandbox in _setup.mjs blocks any write outside the tmp tree.
-      const log = recordingLog()
-      await assert.doesNotReject(() => sweepStaleProviderDirs(log))
-    })
+    // NOT `assert.doesNotReject(() => sweepStaleProviderDirs(log))`. That was
+    // the first version and it is vacuous: the function is DESIGNED never to
+    // reject, so it would pass with both real loaders resolving to no-ops —
+    // the exact defect class this PR exists to fix, reproduced inside its own
+    // fix.
+    //
+    // Nor does this INVOKE the real sweeps. The second version did, and that
+    // was worse: the sweeps `rm -rf` dead-owner dirs under
+    // /tmp/chroxy-claude-tui and CliSession.PERMISSION_MODE_SIDECAR_BASE, which
+    // are the fixture spaces of claude-tui-session.test.js and this file's own
+    // sibling — and `node --test` runs files in PARALLEL. Measured: a planted
+    // dead-pid dir in each base was deleted by this file. That is a
+    // cross-file flake, manufactured by a test whose only job was to prove
+    // wiring.
+    //
+    // Spy the real static method instead: it proves the loader reaches the
+    // real class and threads the logger and the tally through, and it touches
+    // no filesystem.
+    for (const [label, modulePath, className, method] of [
+      ['claude-tui sink-dir', '../src/claude-tui-session.js', 'ClaudeTuiSession', 'sweepStaleSinkDirs'],
+      ['claude-cli sidecar-dir', '../src/cli-session.js', 'CliSession', 'sweepStaleSidecarDirs'],
+    ]) {
+      it(`${label}: routes to ${className}.${method} and returns its tally`, async () => {
+        const ns = await import(modulePath)
+        const Klass = ns[className]
+        const original = Klass[method]
+        assert.equal(typeof original, 'function', `positive control: ${className}.${method} must exist`)
+
+        const seen = []
+        const tally = { swept: 0, kept: 0 }
+        Klass[method] = (l) => {
+          seen.push(l)
+          return tally
+        }
+        try {
+          const log = recordingLog()
+          const sweep = await DEFAULT_SWEEP_LOADERS[label]()
+          const result = sweep(log)
+          assert.deepEqual(seen, [log], `${label} must call ${className}.${method} with the logger`)
+          assert.equal(result, tally, "the provider's tally must be returned through the loader")
+        } finally {
+          Klass[method] = original
+        }
+      })
+    }
   })
 })

--- a/packages/server/tests/sweep-stale-provider-dirs.test.js
+++ b/packages/server/tests/sweep-stale-provider-dirs.test.js
@@ -1,0 +1,109 @@
+/**
+ * Behavioural cover for the boot-time stale-dir sweep (#7374).
+ *
+ * This replaces a source-level grep of `server-cli.js`. That guard asserted the
+ * text `sweepStaleSinkDirs(log)` appeared inside an anchored `import(...)`
+ * slice, and mutation testing during #7371's review found two bypasses that
+ * kept it green: wrapping the boot block in `if (process.env.__NEVER_SET__)`,
+ * and replacing the call with `.then(({CliSession}) => void CliSession)` while
+ * leaving the expected string in a comment inside the anchored window.
+ *
+ * Nothing here greps anything — every test RUNS the sweep.
+ */
+
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  sweepStaleProviderDirs,
+  DEFAULT_SWEEP_LOADERS,
+} from '../src/sweep-stale-provider-dirs.js'
+
+function recordingLog() {
+  const warns = []
+  const infos = []
+  return { warns, infos, warn: (m) => warns.push(String(m)), info: (m) => infos.push(String(m)) }
+}
+
+describe('sweepStaleProviderDirs (#7374)', () => {
+  it('invokes EVERY provider sweep, and hands each one the logger', async () => {
+    const called = []
+    const log = recordingLog()
+    await sweepStaleProviderDirs(log, {
+      alpha: async () => (l) => called.push(['alpha', l]),
+      beta: async () => (l) => called.push(['beta', l]),
+    })
+    assert.deepEqual(called.map(([n]) => n).sort(), ['alpha', 'beta'])
+    for (const [name, l] of called) assert.equal(l, log, `${name} must receive the logger`)
+  })
+
+  it('a loader that rejects is warned, and does not stop the others', async () => {
+    const called = []
+    const log = recordingLog()
+    await sweepStaleProviderDirs(log, {
+      'broken-provider': async () => {
+        throw new Error('import blew up')
+      },
+      healthy: async () => () => called.push('healthy'),
+    })
+    assert.deepEqual(called, ['healthy'], 'a failing loader must not prevent the other sweep')
+    assert.ok(
+      log.warns.some((w) => w.includes('broken-provider') && w.includes('import blew up')),
+      `the failure must be warned with its label; got ${JSON.stringify(log.warns)}`,
+    )
+  })
+
+  it('a sweep that throws is warned, and does not stop the others', async () => {
+    const called = []
+    const log = recordingLog()
+    await sweepStaleProviderDirs(log, {
+      'throwing-sweep': async () => () => {
+        throw new Error('reaper blew up')
+      },
+      healthy: async () => () => called.push('healthy'),
+    })
+    assert.deepEqual(called, ['healthy'])
+    assert.ok(log.warns.some((w) => w.includes('throwing-sweep') && w.includes('reaper blew up')))
+  })
+
+  it('never rejects — boot must not be able to fail on a sweep', async () => {
+    const log = recordingLog()
+    await assert.doesNotReject(() =>
+      sweepStaleProviderDirs(log, {
+        a: async () => {
+          throw new Error('x')
+        },
+        b: async () => () => {
+          throw new Error('y')
+        },
+      }),
+    )
+  })
+
+  // The real loaders, exercised for real. This is what makes the default
+  // wiring behavioural rather than a claim: it imports the actual provider
+  // modules and reaches the actual static sweep methods.
+  describe('DEFAULT_SWEEP_LOADERS — the real wiring', () => {
+    it('covers both providers', () => {
+      assert.deepEqual(Object.keys(DEFAULT_SWEEP_LOADERS).sort(), [
+        'claude-cli sidecar-dir',
+        'claude-tui sink-dir',
+      ])
+    })
+
+    for (const label of ['claude-tui sink-dir', 'claude-cli sidecar-dir']) {
+      it(`${label}: resolves to a callable sweep on the real provider module`, async () => {
+        const sweep = await DEFAULT_SWEEP_LOADERS[label]()
+        assert.equal(typeof sweep, 'function', 'the loader must resolve to the provider sweep')
+      })
+    }
+
+    it('running the REAL default loaders sweeps without throwing', async () => {
+      // End-to-end over the actual provider modules. Only dirs with a DEAD
+      // owner pid are removed, so this is safe to run: this process is alive,
+      // and the fs sandbox in _setup.mjs blocks any write outside the tmp tree.
+      const log = recordingLog()
+      await assert.doesNotReject(() => sweepStaleProviderDirs(log))
+    })
+  })
+})


### PR DESCRIPTION
## Problem

Two guards added by #7371 are **source-level greps**, and mutation testing during that PR's review showed each has a bypass that stays green. Both were *honest* about being source-level — which is a disclosure, not a defence.

### 1. The reaper nobody proved was called

`cli-permission-mode-sidecar.test.js` asserted `server-cli.js` contained `sweepStaleSinkDirs(log)` inside an anchored `import(...)` slice, and claimed the anchoring meant the assertion "cannot be satisfied by the explanatory comment beside it". Two mutants said otherwise, both **GREEN**:

- wrap the boot block in `if (process.env.__NEVER_SET__) { … }`
- replace the call with `.then(({CliSession}) => void CliSession)` and put the expected string in a comment *inside* the anchored window

Catalogue entry 1 verbatim — a grep cannot tell a call reached at boot from the same characters behind a false condition, and anchoring only excludes comments *outside* the chosen window.

### 2. The allowlist that was not the only way in

The same file asserted `FORWARDED_ENV_KEYS` in `docker-session.js` does not contain `CHROXY_PERMISSION_MODE_FILE` (a **host** path that names nothing inside the container). Adding the key to the array goes red — which is why it felt solid. But pushing `dockerArgs.push('--env', 'CHROXY_PERMISSION_MODE_FILE=…')` **outside** the allowlist loop stayed **GREEN**, and two explicit single-key pushes already sit immediately below that loop.

## Fix — make the work observable, not the grep cleverer

**Boot sweep** → extracted to `src/sweep-stale-provider-dirs.js` with injectable loaders, so tests *run* it rather than reading it. The default loaders are exercised for real against the actual provider modules, so the production wiring is behavioural too, not a claim.

**DockerSession** → a one-line `_spawnDocker` seam, so a test can capture the argv the **real** `_spawnPersistentProcess` builds. Deliberately a method override point rather than a constructor opt, so it adds no `BaseSession` opt to forward.

Notably this does *not* use the file's existing mirror harness: a mirror re-implements the thing under test and keeps passing when the real code changes.

## Verification — every mutant asserted to have landed first

**Boot sweep** (`sweep-stale-provider-dirs.test.js`, 8 tests):

| Mutant | Result |
|---|---|
| Body behind a never-true condition (*the issue's mutant*) | **3 fail** |
| One provider silently dropped from the roster | **2 fail** |
| Sweep resolved but never invoked (*the `void CliSession` bypass*) | **3 fail** |
| Call site commented out of `server-cli.js` | **1 fail** |

**DockerSession argv** — the two guards run side by side under the *same* outside-the-loop mutant:

| Guard | Under the bypass mutant |
|---|---|
| **New behavioural test** | **2 fail** |
| Old source grep | **0 fail** — green, i.e. the bug this issue reports |

### The negative assertion needed a positive control it did not have

`_buildChildEnv()` emits `CHROXY_PERMISSION_MODE_FILE` as `''` when there is no sidecar — so "the key is absent from argv" would have passed on a session that never had a path to leak. The new tests set a real host path first, assert an allowlisted key **is** forwarded (proving the machinery ran), and additionally check for the leaked path **by value**, so a forward that renamed the key would still be caught.

## What is still source-level, stated plainly

That `server-cli.js` calls `sweepStaleProviderDirs(log)` at boot. Short of booting the daemon, nothing distinguishes that call from the same characters behind a false condition. The assertion is now line-anchored so a commented-out call no longer satisfies it (verified above), and the residual is recorded as **catalogue entry 20** in `docs/false-safety-guards.md` rather than argued away at the call site — which is what the issue asked for.

Both original greps are kept, rewritten to stop overclaiming and to point at the behavioural tests. The Docker one still names the naive fix precisely (adding the key to the array goes red there with a pointed message).

## Gates

Full server suite on Node 22: **14097 tests**. Failing set identical to `origin/main` except `TunnelManager Integration`, which failed on Cloudflare **error 1015 — rate limiting** on the live quick-tunnel API. All 9 custom server lints pass.

## Not included

The third item in the issue ("also worth folding in" — the `ClaudeTuiSession` atomic sidecar-write tests passing with a truncating write) is filed separately: it is a distinct defect with a non-obvious fix design, and it is not one of the "two guards" this issue's title and body are about.

Closes #7374