### PR TITLE
test(server): pin the WsHandler typedefs against CTX_NAMESPACES

### DIFF
--- a/packages/server/src/ws-handler-context.js
+++ b/packages/server/src/ws-handler-context.js
@@ -11,7 +11,12 @@
  *
  * This module is the SINGLE SOURCE OF TRUTH for the shape: the JSDoc typedef
  * below, the `CTX_NAMESPACES` list, and `assertCtxShape()` are all derived from
- * the same five buckets. ws-server.js builds the production ctx; tests build a
+ * the same five buckets. Only two of those were ever COUPLED, though —
+ * `nsCtx`'s `FIELD_TO_NS` and `assertCtxShape` both read `CTX_NAMESPACES`,
+ * while the typedef was decorative and drifted silently (seven fields missing,
+ * one present here but absent from the roster — #7403). They are now pinned
+ * against each other by `tests/ws-handler-context-typedef-parity.test.js`, so
+ * this paragraph is enforced rather than aspirational. ws-server.js builds the production ctx; tests build a
  * namespaced mock via `tests/test-helpers.js` and may run it through
  * `assertCtxShape()` so a partial mock fails loudly at construction instead of
  * at the first missing-field read deep inside a handler.
@@ -64,6 +69,13 @@
  * @property {object|null} skillsUsageRecorder - Per-skill usage aggregates (lives on SessionManager).
  * @property {(requestId: string, result: object) => void} resolvePairRequester - Resolve a pending pair request.
  * @property {(requestId: string, reason: string) => void} broadcastPairResolved - Fan-out a pair-resolved notice.
+ * @property {object|null} shellApprovalStore - #6277 host-local user-shell approval store; null in test ctx mocks.
+ * @property {object|null} repoEventStore - #5966 bounded RepoEventStore; null until the first GitHub-webhook delivery lazily creates it.
+ * @property {string|null} webhookPayloadUrl - #6540 GitHub payload URL derived from the live origin.
+ * @property {object|null} repoWebhookDeliveries - #6540 in-memory recent-delivery ring; null until the first delivery.
+ * @property {(value: string|null) => void} setWebhookSecretCache - #6540 refresh the in-process webhook-secret cache.
+ * @property {object|null} orchestrationManager - #6691 OrchestrationManager; null while the feature is off.
+ * @property {object|null} schedulerEngine - Scheduled-task engine; null when scheduling is off.
  *
  * @typedef {Object} WsHandlerRuntime
  * @property {boolean} draining - True while the server is draining for shutdown.
@@ -129,6 +141,12 @@ export const CTX_NAMESPACES = {
     'pushManager',
     'pairingManager',
     'checkpointManager',
+    // #6006: the token lifecycle manager, exposed so the primary-gated
+    // `revoke_token` handler can fire the operator panic button. Null under
+    // --no-auth. It was on the production ctx and in the typedef but NOT in
+    // this roster (#7403) — so `assertCtxShape({deep:true})` never required it
+    // and `nsCtx()` never routed it. The typedef was the correct side.
+    'tokenManager',
     'devPreview',
     'webTaskManager',
     'environmentManager',

--- a/packages/server/src/ws-handler-context.js
+++ b/packages/server/src/ws-handler-context.js
@@ -15,8 +15,14 @@
  * `nsCtx`'s `FIELD_TO_NS` and `assertCtxShape` both read `CTX_NAMESPACES`,
  * while the typedef was decorative and drifted silently (seven fields missing,
  * one present here but absent from the roster — #7403). They are now pinned
- * against each other by `tests/ws-handler-context-typedef-parity.test.js`, so
- * this paragraph is enforced rather than aspirational.
+ * against each other by `tests/ws-handler-context-typedef-parity.test.js`.
+ *
+ * That pins TWO of the three sides. `assertCtxShape({deep: true})`, which
+ * ws-server.js runs on its own `_handlerCtx` at construction, pins
+ * roster ⊆ production. What is still unpinned is production ⊆ roster — a
+ * getter added to ws-server.js's namespace literals but never added to
+ * CTX_NAMESPACES is invisible to every check here. That is exactly how
+ * `tokenManager` drifted for the whole life of #6006.
  *
  * ws-server.js builds the production ctx; tests build a
  * namespaced mock via `tests/test-helpers.js` and may run it through
@@ -71,13 +77,13 @@
  * @property {object|null} skillsUsageRecorder - Per-skill usage aggregates (lives on SessionManager).
  * @property {(requestId: string, result: object) => void} resolvePairRequester - Resolve a pending pair request.
  * @property {(requestId: string, reason: string) => void} broadcastPairResolved - Fan-out a pair-resolved notice.
- * @property {object|null} shellApprovalStore - #6277 host-local user-shell approval store; null in test ctx mocks.
+ * @property {object} shellApprovalStore - #6277 host-local user-shell approval store (always constructed on the production ctx; test mocks may pass null).
  * @property {object|null} repoEventStore - #5966 bounded RepoEventStore; null until the first GitHub-webhook delivery lazily creates it.
- * @property {string|null} webhookPayloadUrl - #6540 GitHub payload URL derived from the live origin.
+ * @property {{url: string|null, lanOnly: boolean, note: string|null}} webhookPayloadUrl - #6540 GitHub payload URL derived from the live origin (`deriveWebhookPayloadUrl`).
  * @property {object|null} repoWebhookDeliveries - #6540 in-memory recent-delivery ring; null until the first delivery.
  * @property {(value: string|null) => void} setWebhookSecretCache - #6540 refresh the in-process webhook-secret cache.
  * @property {object|null} orchestrationManager - #6691 OrchestrationManager; null while the feature is off.
- * @property {object|null} schedulerEngine - Scheduled-task engine; null when scheduling is off.
+ * @property {object|null} schedulerEngine - #6871 scheduled-task engine; null when scheduling is off.
  *
  * @typedef {Object} WsHandlerRuntime
  * @property {boolean} draining - True while the server is draining for shutdown.

--- a/packages/server/src/ws-handler-context.js
+++ b/packages/server/src/ws-handler-context.js
@@ -16,7 +16,9 @@
  * while the typedef was decorative and drifted silently (seven fields missing,
  * one present here but absent from the roster — #7403). They are now pinned
  * against each other by `tests/ws-handler-context-typedef-parity.test.js`, so
- * this paragraph is enforced rather than aspirational. ws-server.js builds the production ctx; tests build a
+ * this paragraph is enforced rather than aspirational.
+ *
+ * ws-server.js builds the production ctx; tests build a
  * namespaced mock via `tests/test-helpers.js` and may run it through
  * `assertCtxShape()` so a partial mock fails loudly at construction instead of
  * at the first missing-field read deep inside a handler.

--- a/packages/server/tests/ws-handler-context-typedef-parity.test.js
+++ b/packages/server/tests/ws-handler-context-typedef-parity.test.js
@@ -67,7 +67,15 @@ function typedefBlock(name) {
       'Both sides of this test derive from that convention.',
   )
   const rest = SRC.slice(start)
-  const next = rest.indexOf('@typedef', 1)
+  let next = rest.indexOf('@typedef', 1)
+  // Also stop at the end of the doc comment. The LAST typedef has no `@typedef`
+  // after it, so bounding only on that returned 5630 of the file's ~12.6k chars
+  // — the whole of CTX_NAMESPACES, assertCtxShape and every comment below.
+  // Green today only because no `@property` string happens to appear down
+  // there, which is the unanchored-slice hazard this repo has already been
+  // bitten by. Measured: 5630 chars → 350, same properties parsed.
+  const end = rest.indexOf('\n */')
+  if (end !== -1 && (next === -1 || end < next)) next = end
   return next === -1 ? rest : rest.slice(0, next)
 }
 
@@ -138,12 +146,44 @@ describe('WsHandler typedefs match CTX_NAMESPACES (#7403)', () => {
       )
     })
 
+    it(`${ns}: the parser reads EVERY @property line in the block`, () => {
+      // The parity assertion above compares parsed names. A line the regex
+      // cannot match is silently DROPPED, and in the documented-but-unrostered
+      // direction — the exact `tokenManager` bug this file exists to prevent —
+      // that reads as agreement. Three shapes were confirmed to pass 13/13
+      // while carrying an unrostered field: two levels of brace nesting, two
+      // spaces after `@property`, and a name wrapped onto the next line.
+      //
+      // Counting is the fix: parse-count must equal the number of `@property`
+      // occurrences, so an unreadable line fails HERE, naming the parser,
+      // rather than mutating a set comparison somewhere downstream.
+      const block = typedefBlock(typedefNameFor(ns))
+      const parsed = propertyNames(block)
+      const occurrences = (block.match(/@property/g) || []).length
+      assert.equal(
+        parsed.length,
+        occurrences,
+        `${typedefNameFor(ns)}: the @property parser read ${parsed.length} of ${occurrences} lines. ` +
+          'An unparseable @property is dropped silently and would make the parity check above ' +
+          'agree for the wrong reason. Parsed: ' + JSON.stringify(parsed),
+      )
+    })
+
     it(`${ns}: no field is documented twice`, () => {
       const documented = propertyNames(typedefBlock(typedefNameFor(ns)))
       const dupes = documented.filter((k, i) => documented.indexOf(k) !== i)
       assert.deepEqual(dupes, [], `duplicate @property entries in ${typedefNameFor(ns)}`)
     })
   }
+
+  it('the parser reads every @property line in WsHandlerContext too', () => {
+    const block = typedefBlock('WsHandlerContext')
+    assert.equal(
+      propertyNames(block).length,
+      (block.match(/@property/g) || []).length,
+      'an unparseable @property in WsHandlerContext would be dropped silently',
+    )
+  })
 
   it('the WsHandlerContext typedef documents exactly the five namespaces', () => {
     // The top-level typedef is the other half of the same roster, and it drifts

--- a/packages/server/tests/ws-handler-context-typedef-parity.test.js
+++ b/packages/server/tests/ws-handler-context-typedef-parity.test.js
@@ -40,10 +40,32 @@ function typedefNameFor(ns) {
   return `WsHandler${ns[0].toUpperCase()}${ns.slice(1)}`
 }
 
-/** The text of one `@typedef {Object} <name>` block, up to the next `@typedef`. */
+/**
+ * The text of one `@typedef {Object} <name>` block, up to the next `@typedef`.
+ *
+ * THROWS rather than returning null when the block is absent. The
+ * "every namespace resolves to a real typedef block" control below covers the
+ * same ground, but `node --test` can run an individual test in isolation
+ * (`--test-name-pattern`), so that control does not gate the parity tests. Left
+ * returning null, a renamed typedef would surface as
+ * `TypeError: Cannot read properties of null` from inside the regex helper —
+ * true, useless, and pointing at the wrong file.
+ */
 function typedefBlock(name) {
-  const start = SRC.indexOf(`@typedef {Object} ${name}`)
-  if (start === -1) return null
+  // Word-boundary matched, NOT `indexOf`. A plain substring search for
+  // `@typedef {Object} WsHandlerServices` also matches
+  // `@typedef {Object} WsHandlerServicesRenamed`, so renaming a typedef left
+  // this test green — measured, 13/13, with the block it was supposed to be
+  // pinning gone. Prefix-matching an identifier is the same class as a
+  // substring standing in for a token match (#7290/#7291).
+  const match = new RegExp(`@typedef \\{Object\\} ${name}\\b`).exec(SRC)
+  const start = match ? match.index : -1
+  assert.ok(
+    start !== -1,
+    `no '@typedef {Object} ${name}' block found in ws-handler-context.js — ` +
+      'the typedef was renamed or removed, or the WsHandler<Namespace> naming convention changed. ' +
+      'Both sides of this test derive from that convention.',
+  )
   const rest = SRC.slice(start)
   const next = rest.indexOf('@typedef', 1)
   return next === -1 ? rest : rest.slice(0, next)
@@ -85,8 +107,10 @@ describe('WsHandler typedefs match CTX_NAMESPACES (#7403)', () => {
     // empty, pass vacuously.
     for (const ns of CTX_NAMESPACE_NAMES) {
       const name = typedefNameFor(ns)
+      // typedefBlock() itself asserts the block exists, so this reads as
+      // "does not throw" — the explicit length check below is what makes it a
+      // control rather than a restatement.
       const block = typedefBlock(name)
-      assert.ok(block, `no '@typedef {Object} ${name}' block found for namespace '${ns}'`)
       assert.ok(
         propertyNames(block).length > 0,
         `'${name}' parsed to zero properties — the parser or the typedef is broken`,

--- a/packages/server/tests/ws-handler-context-typedef-parity.test.js
+++ b/packages/server/tests/ws-handler-context-typedef-parity.test.js
@@ -1,0 +1,137 @@
+/**
+ * The `WsHandler*` typedefs must match `CTX_NAMESPACES`, field for field (#7403).
+ *
+ * `ws-handler-context.js` declares itself the single source of truth for the
+ * handler-ctx shape: "the JSDoc typedef below, the `CTX_NAMESPACES` list, and
+ * `assertCtxShape()` are all derived from the same five buckets". Only two of
+ * those three were ever coupled — `nsCtx`'s `FIELD_TO_NS` and `assertCtxShape`
+ * both read `CTX_NAMESPACES`, while the typedef was decorative.
+ *
+ * It had drifted in both directions: `services` carried seven fields the
+ * typedef never mentioned (`shellApprovalStore`, `repoEventStore`,
+ * `webhookPayloadUrl`, `repoWebhookDeliveries`, `setWebhookSecretCache`,
+ * `orchestrationManager`, `schedulerEngine`), and `tokenManager` sat in the
+ * typedef and on the PRODUCTION ctx while being absent from the roster — so
+ * `assertCtxShape({deep: true})` never required it and `nsCtx()` never routed
+ * it.
+ *
+ * That direction matters: the typedef is what editors surface for `@type`
+ * hints in the handler modules, so drift makes the hints wrong in the direction
+ * of "this field does not exist" — the worst kind, because it reads as
+ * authoritative.
+ *
+ * BOTH SIDES ARE DERIVED. The typedef name comes from the namespace key, and
+ * the field lists come from the parsed source and the exported roster. There is
+ * no hardcoded list of fields anywhere in this file; adding a namespace or a
+ * field requires no edit here.
+ */
+
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+import { CTX_NAMESPACES, CTX_NAMESPACE_NAMES } from '../src/ws-handler-context.js'
+
+const SRC_PATH = new URL('../src/ws-handler-context.js', import.meta.url)
+const SRC = readFileSync(SRC_PATH, 'utf8')
+
+/** `services` → `WsHandlerServices`. Derived, so a new namespace needs no edit. */
+function typedefNameFor(ns) {
+  return `WsHandler${ns[0].toUpperCase()}${ns.slice(1)}`
+}
+
+/** The text of one `@typedef {Object} <name>` block, up to the next `@typedef`. */
+function typedefBlock(name) {
+  const start = SRC.indexOf(`@typedef {Object} ${name}`)
+  if (start === -1) return null
+  const rest = SRC.slice(start)
+  const next = rest.indexOf('@typedef', 1)
+  return next === -1 ? rest : rest.slice(0, next)
+}
+
+/**
+ * `@property` names in a block.
+ *
+ * The type brace-group is matched with one level of nesting allowed, because
+ * several properties carry inline object types — e.g.
+ * `@property {(a: string) => {changed: boolean}} claimPrimary`. A naive
+ * `\{[^}]*\}` stops at the inner `}` and captures a fragment of the type as the
+ * field name; the `propertyNames parser` test below is the control for that.
+ * A leading `[name]` (optional property) is unwrapped.
+ */
+function propertyNames(block) {
+  return [...block.matchAll(/@property \{[^{}]*(?:\{[^{}]*\}[^{}]*)*\} \[?([A-Za-z_$][\w$]*)\]?/g)].map(
+    (m) => m[1],
+  )
+}
+
+describe('WsHandler typedefs match CTX_NAMESPACES (#7403)', () => {
+  it('POSITIVE CONTROL: the property parser handles inline object types', () => {
+    // If this regex silently mis-parses, every set-equality below compares two
+    // wrong sets and can agree for the wrong reason. `claimPrimary`'s return
+    // type contains braces and is the real case that breaks a naive pattern.
+    const sample = [
+      ' * @property {(ws: any, msg: object) => void} send - one.',
+      ' * @property {(a: string, b: string, opts?: {force?: boolean}) => {changed: boolean, rejected?: boolean}} claimPrimary - nested.',
+      ' * @property {object|null} maybe - two.',
+      ' * @property {string} [optionalOne] - bracketed.',
+    ].join('\n')
+    assert.deepEqual(propertyNames(sample), ['send', 'claimPrimary', 'maybe', 'optionalOne'])
+  })
+
+  it('POSITIVE CONTROL: every namespace resolves to a real typedef block', () => {
+    // Without this, a renamed typedef would make `propertyNames` return [] and
+    // the parity test would fail confusingly — or, if the roster were also
+    // empty, pass vacuously.
+    for (const ns of CTX_NAMESPACE_NAMES) {
+      const name = typedefNameFor(ns)
+      const block = typedefBlock(name)
+      assert.ok(block, `no '@typedef {Object} ${name}' block found for namespace '${ns}'`)
+      assert.ok(
+        propertyNames(block).length > 0,
+        `'${name}' parsed to zero properties — the parser or the typedef is broken`,
+      )
+    }
+  })
+
+  for (const ns of CTX_NAMESPACE_NAMES) {
+    it(`${ns}: typedef and CTX_NAMESPACES carry exactly the same fields`, () => {
+      const name = typedefNameFor(ns)
+      const documented = propertyNames(typedefBlock(name))
+      const roster = CTX_NAMESPACES[ns]
+
+      const missing = roster.filter((k) => !documented.includes(k))
+      const stale = documented.filter((k) => !roster.includes(k))
+
+      assert.deepEqual(
+        { missing, stale },
+        { missing: [], stale: [] },
+        `${name} has drifted from CTX_NAMESPACES.${ns}.\n` +
+          (missing.length ? `  In the roster but NOT documented: ${missing.join(', ')}\n` : '') +
+          (stale.length ? `  Documented but NOT in the roster: ${stale.join(', ')}\n` : '') +
+          '  Both sides live in src/ws-handler-context.js. If a field is genuinely gone, ' +
+          'remove it from BOTH; if it is real, add it to both (and check ws-server.js provides it).',
+      )
+    })
+
+    it(`${ns}: no field is documented twice`, () => {
+      const documented = propertyNames(typedefBlock(typedefNameFor(ns)))
+      const dupes = documented.filter((k, i) => documented.indexOf(k) !== i)
+      assert.deepEqual(dupes, [], `duplicate @property entries in ${typedefNameFor(ns)}`)
+    })
+  }
+
+  it('the WsHandlerContext typedef documents exactly the five namespaces', () => {
+    // The top-level typedef is the other half of the same roster, and it drifts
+    // the same way. `correlationId` is spread on at dispatch time in
+    // ws-server.js rather than being a namespace, so it is excluded by name.
+    const documented = propertyNames(typedefBlock('WsHandlerContext')).filter(
+      (k) => k !== 'correlationId',
+    )
+    assert.deepEqual(
+      [...documented].sort(),
+      [...CTX_NAMESPACE_NAMES].sort(),
+      'WsHandlerContext must document exactly the namespaces in CTX_NAMESPACES',
+    )
+  })
+})


### PR DESCRIPTION
## Problem

`ws-handler-context.js` declares itself the single source of truth for the handler-ctx shape:

> This module is the SINGLE SOURCE OF TRUTH for the shape: the JSDoc typedef below, the `CTX_NAMESPACES` list, and `assertCtxShape()` are all derived from the same five buckets.

Only **two** of those three were coupled. `nsCtx`'s `FIELD_TO_NS` and `assertCtxShape` both read `CTX_NAMESPACES`; the typedef was decorative and drifted silently. It is what editors surface for `@type` hints in the handler modules, so drift makes the hints wrong in the direction of *"this field does not exist"* — the worst kind, because it reads as authoritative.

Measured drift before this PR:

| namespace | roster | typedef | |
|---|---:|---:|---|
| transport | 17 | 17 | in sync |
| sessions | 2 | 2 | in sync |
| permissions | 6 | 6 | in sync |
| **services** | **19** | **13** | 7 missing, 1 present-but-unrostered |
| runtime | 4 | 4 | in sync |

## The `tokenManager` call went the other way than the issue suggested

The issue listed `tokenManager` as *"stale"* in the typedef and offered "remove or restore". The evidence says **restore**: `ws-server.js:894` really does expose `get tokenManager()` on the services namespace, with a `#6006` comment explaining that the primary-gated `revoke_token` handler fires it, and `handlers/session-handlers.js:180` refers to `services.tokenManager` by name.

So the **roster** was the side that had drifted. Removing the field — the more obvious reading of "stale" — would have deleted a real one from the source of truth and left `assertCtxShape({deep: true})` permanently unable to require it.

Adding it back is safe and free: `FIELD_TO_NS` derives from `CTX_NAMESPACES`, so `nsCtx()` routes it automatically, and the deep assertions pass because production genuinely provides it — **174/174** across `test-helpers.test.js` and `ws-server.test.js`.

## The test derives both sides

No hardcoded field list anywhere: the typedef name comes from the namespace key (`services` → `WsHandlerServices`), the documented fields from the parsed source, the expected fields from the exported roster. Adding a namespace or a field requires **no edit to the test**.

It also carries a **positive control on its own parser**. Several properties have inline object types — `claimPrimary`'s `=> {changed: boolean, rejected?: boolean, …}` — and a naive `\{[^}]*\}` stops at the inner brace and captures a fragment of the *type* as the field name. That would make both sets wrong, and two wrong sets can agree. A second control asserts every namespace resolves to a real typedef block parsing to a non-empty field list, so a renamed typedef cannot make the comparison vacuous.

## Verification

Each mutant asserted to have landed before its result was trusted:

| Mutation | Result |
|---|---|
| Field added to the roster, left undocumented (*the 7-field drift*) | **1 fail** |
| Field documented but removed from the roster (*the `tokenManager` drift*) | **1 fail** |
| A namespace dropped from the top-level `WsHandlerContext` typedef | **1 fail** |

All five buckets now report in sync. 13 tests in the new file; **174/174** on the ctx-shape-dependent suites; all 9 custom server lints pass.

Full server suite: 2 files failed, both **load-induced flakes unrelated to this change**, each verified green in isolation — `BaseSession` on a *performance* assertion (`100-skill toggle took 252ms — expected <50ms`) under parallel load (192/192 alone), and `MCPClient` on spawn timing (33/33 alone).

The module's own source-of-truth paragraph is corrected to say what is now true: the coupling is enforced by a test rather than asserted in prose.

Closes #7403