### PR TITLE
fix(app,dashboard): key the history_replay_end '(resolved)' sweep to the replayed session

### DIFF
--- a/packages/app/src/__tests__/store/message-handler.test.ts
+++ b/packages/app/src/__tests__/store/message-handler.test.ts
@@ -662,8 +662,6 @@ describe("history_replay_end: '(resolved)' sweep targeting (#7410)", () => {
     resetReplayFlags();
   });
 
-  const FUTURE = Date.now() + 600_000;
-
   /**
    * An AskUserQuestion-shaped prompt: `type: 'prompt'` with no `requestId` and
    * no `expiresAt`. `user_question` IS in the server's history ring buffer, so
@@ -687,7 +685,27 @@ describe("history_replay_end: '(resolved)' sweep targeting (#7410)", () => {
       type: 'prompt',
       content: 'Allow Write to src/index.ts?',
       requestId,
-      expiresAt: FUTURE,
+      // Computed per call, not once at describe-collection time: a slow suite
+      // would otherwise leave the fixture expired and silently non-live.
+      expiresAt: Date.now() + 600_000,
+      timestamp: 1,
+    } as any;
+  }
+
+  /**
+   * A permission prompt whose frame carried no `remainingMs`. `remainingMs` is
+   * `.optional()` in `ServerPermissionRequestSchema` and the shared parser maps
+   * an omitted value to `null`, so the client leaves `expiresAt` undefined —
+   * giving a genuinely LIVE, answerable prompt for which
+   * `isLivePermissionPrompt` is FALSE. This is the shape that made an earlier
+   * `!isLivePermissionPrompt(...)` predicate stamp a live approval.
+   */
+  function livePromptNoTtl(id: string, requestId: string) {
+    return {
+      id,
+      type: 'prompt',
+      content: 'Allow Bash: rm -rf /tmp/x?',
+      requestId,
       timestamp: 1,
     } as any;
   }
@@ -782,6 +800,38 @@ describe("history_replay_end: '(resolved)' sweep targeting (#7410)", () => {
     const s1Prompt = store.getState().sessionStates.s1.messages[0] as any;
     expect(s1Prompt.answered).toBeUndefined();
     expect(isLivePermissionPrompt(s1Prompt, Date.now())).toBe(true);
+  });
+
+  // The sweep keys off `requestId`, not liveness, and this is why. A permission
+  // frame may omit `remainingMs` (`.optional()` in the schema), which leaves
+  // `expiresAt` undefined and makes `isLivePermissionPrompt` false for a prompt
+  // the user can still answer. A liveness-based predicate stamps it; a
+  // `requestId`-based one cannot.
+  it('does not stamp a live permission prompt that has no expiresAt', () => {
+    const store = seed(historicalPrompt('p1'), livePromptNoTtl('p2', 'req-2'));
+    const before = store.getState().sessionStates.s2.messages[0] as any;
+    // Positive controls: it IS a permission prompt (has a requestId) and it is
+    // NOT recognised as live — i.e. exactly the gap being closed.
+    expect(before.requestId).toBe('req-2');
+    expect(before.expiresAt).toBeUndefined();
+    expect(isLivePermissionPrompt(before, Date.now())).toBe(false);
+
+    _testMessageHandler.handle({ type: 'history_replay_end', sessionId: 's2' });
+
+    expect((store.getState().sessionStates.s2.messages[0] as any).answered).toBeUndefined();
+  });
+
+  // `updateSession` no-ops on an id with no state. Stamping the active session
+  // instead — what the pre-fix code did — was never right for a frame naming a
+  // session this client does not track.
+  it('stamps nothing when the replayed session has no state', () => {
+    const store = seed(historicalPrompt('p1'), historicalPrompt('p2'));
+
+    _testMessageHandler.handle({ type: 'history_replay_end', sessionId: 's-gone' });
+
+    const st = store.getState().sessionStates;
+    expect((st.s1.messages[0] as any).answered).toBeUndefined();
+    expect((st.s2.messages[0] as any).answered).toBeUndefined();
   });
 });
 

--- a/packages/app/src/__tests__/store/message-handler.test.ts
+++ b/packages/app/src/__tests__/store/message-handler.test.ts
@@ -643,6 +643,99 @@ describe('history_replay_start: isPlanPending wipe targeting (#7402)', () => {
     expect(store.getState().sessionStates.s1.isPlanPending).toBe(true);
   });
 });
+
+// #7410 — the `answered: '(resolved)'` sweep on `history_replay_end` must
+// target the session the frame is ENDING, not whichever session happens to be
+// active. Fourth instance of this mis-keying in this file after #4909
+// (`stoppedAt`), #7340 (`activeAgents`) and #7402 (`isPlanPending`), and the
+// worst of the four: the predicate is `type === 'prompt' && !answered`, which
+// matches LIVE prompts as well as replayed ones. `isLivePermissionPrompt`
+// (store-core) is `type === 'prompt' && requestId && expiresAt > now &&
+// !answered`, so a stamp of '(resolved)' takes a live prompt out of the
+// pending-permission surface — and AskUserQuestion emits `type: 'prompt'` too.
+//
+// `subscribe_sessions` replays every background session on every reconnect, so
+// keyed to `activeSessionId` this silently dismissed a permission approval the
+// user was looking at, every time a second session reconnected.
+describe("history_replay_end: '(resolved)' sweep targeting (#7410)", () => {
+  afterEach(() => {
+    resetReplayFlags();
+  });
+
+  const FUTURE = Date.now() + 600_000;
+
+  /** A live, unanswered permission prompt — `isLivePermissionPrompt` is true. */
+  function livePrompt(id: string, requestId: string) {
+    return {
+      id,
+      type: 'prompt',
+      content: 'Allow Write to src/index.ts?',
+      requestId,
+      expiresAt: FUTURE,
+      timestamp: 1,
+    } as any;
+  }
+
+  function seedTwoSessions() {
+    const store = createMockStore({
+      activeSessionId: 's1',
+      sessions: [
+        { sessionId: 's1', name: 'S1' } as any,
+        { sessionId: 's2', name: 'S2' } as any,
+      ],
+      sessionStates: {
+        s1: { ...createEmptySessionState(), messages: [livePrompt('p1', 'req-1')] },
+        s2: { ...createEmptySessionState(), messages: [livePrompt('p2', 'req-2')] },
+      },
+    });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+    return store;
+  }
+
+  it("a background session's replay-end does not resolve the active session's LIVE prompt", () => {
+    const store = seedTwoSessions();
+    // Positive control (#7409's lesson): prove the fixture really is a live
+    // prompt BEFORE asserting it survives, so a malformed fixture fails the
+    // test instead of satisfying it vacuously.
+    expect(
+      isLivePermissionPrompt(store.getState().sessionStates.s1.messages[0] as any, Date.now()),
+    ).toBe(true);
+
+    _testMessageHandler.handle({ type: 'history_replay_end', sessionId: 's2' });
+
+    const s1Prompt = store.getState().sessionStates.s1.messages[0] as any;
+    expect(s1Prompt.answered).toBeUndefined();
+    expect(isLivePermissionPrompt(s1Prompt, Date.now())).toBe(true);
+  });
+
+  it("stamps the REPLAYED session's own unanswered prompts", () => {
+    const store = seedTwoSessions();
+
+    _testMessageHandler.handle({ type: 'history_replay_end', sessionId: 's2' });
+
+    expect((store.getState().sessionStates.s2.messages[0] as any).answered).toBe('(resolved)');
+  });
+
+  it('still stamps the active session when it is the one being replayed', () => {
+    const store = seedTwoSessions();
+
+    _testMessageHandler.handle({ type: 'history_replay_end', sessionId: 's1' });
+
+    expect((store.getState().sessionStates.s1.messages[0] as any).answered).toBe('(resolved)');
+    // ...and the background session is left alone, the mirror of the first case.
+    expect((store.getState().sessionStates.s2.messages[0] as any).answered).toBeUndefined();
+  });
+
+  it('falls back to the active session when the frame omits sessionId', () => {
+    const store = seedTwoSessions();
+
+    _testMessageHandler.handle({ type: 'history_replay_end' } as any);
+
+    expect((store.getState().sessionStates.s1.messages[0] as any).answered).toBe('(resolved)');
+  });
+});
+
 describe('session_timeout handler', () => {
   it('removes timed-out session from sessionStates and sessions list', () => {
     const store = createMockStore({

--- a/packages/app/src/__tests__/store/message-handler.test.ts
+++ b/packages/app/src/__tests__/store/message-handler.test.ts
@@ -664,6 +664,22 @@ describe("history_replay_end: '(resolved)' sweep targeting (#7410)", () => {
 
   const FUTURE = Date.now() + 600_000;
 
+  /**
+   * An AskUserQuestion-shaped prompt: `type: 'prompt'` with no `requestId` and
+   * no `expiresAt`. `user_question` IS in the server's history ring buffer, so
+   * this is what a genuinely REPLAYED prompt looks like — and it is what the
+   * sweep exists to stamp. `isLivePermissionPrompt` is false for it.
+   */
+  function historicalPrompt(id: string) {
+    return {
+      id,
+      type: 'prompt',
+      content: 'Which approach?',
+      options: ['a', 'b'],
+      timestamp: 1,
+    } as any;
+  }
+
   /** A live, unanswered permission prompt — `isLivePermissionPrompt` is true. */
   function livePrompt(id: string, requestId: string) {
     return {
@@ -676,7 +692,7 @@ describe("history_replay_end: '(resolved)' sweep targeting (#7410)", () => {
     } as any;
   }
 
-  function seedTwoSessions() {
+  function seed(s1First: any, s2First: any) {
     const store = createMockStore({
       activeSessionId: 's1',
       sessions: [
@@ -684,8 +700,8 @@ describe("history_replay_end: '(resolved)' sweep targeting (#7410)", () => {
         { sessionId: 's2', name: 'S2' } as any,
       ],
       sessionStates: {
-        s1: { ...createEmptySessionState(), messages: [livePrompt('p1', 'req-1')] },
-        s2: { ...createEmptySessionState(), messages: [livePrompt('p2', 'req-2')] },
+        s1: { ...createEmptySessionState(), messages: [s1First] },
+        s2: { ...createEmptySessionState(), messages: [s2First] },
       },
     });
     setStore(store as any);
@@ -693,11 +709,70 @@ describe("history_replay_end: '(resolved)' sweep targeting (#7410)", () => {
     return store;
   }
 
+  // --- the keying guard -----------------------------------------------------
+  //
+  // HISTORICAL prompts on both sides on purpose. If s1 held a LIVE prompt here
+  // the live-prompt exclusion would protect it too, and the test would still
+  // pass with the keying reverted to `updateActiveSession` — pinning nothing.
+  // Keyed correctly is the ONLY reason s1's prompt survives this case.
+  it("a background session's replay-end stamps that session, not the active one", () => {
+    const store = seed(historicalPrompt('p1'), historicalPrompt('p2'));
+
+    _testMessageHandler.handle({ type: 'history_replay_end', sessionId: 's2' });
+
+    const st = store.getState().sessionStates;
+    expect((st.s1.messages[0] as any).answered).toBeUndefined();
+    expect((st.s2.messages[0] as any).answered).toBe('(resolved)');
+  });
+
+  it('still stamps the active session when it is the one being replayed', () => {
+    const store = seed(historicalPrompt('p1'), historicalPrompt('p2'));
+
+    _testMessageHandler.handle({ type: 'history_replay_end', sessionId: 's1' });
+
+    const st = store.getState().sessionStates;
+    expect((st.s1.messages[0] as any).answered).toBe('(resolved)');
+    expect((st.s2.messages[0] as any).answered).toBeUndefined();
+  });
+
+  it('falls back to the active session when the frame omits sessionId', () => {
+    const store = seed(historicalPrompt('p1'), historicalPrompt('p2'));
+
+    _testMessageHandler.handle({ type: 'history_replay_end' } as any);
+
+    expect((store.getState().sessionStates.s1.messages[0] as any).answered).toBe('(resolved)');
+  });
+
+  // --- the live-prompt exclusion --------------------------------------------
+  //
+  // `permission_request` is in the server's `builtinTransient` list, so it is
+  // never in the history ring buffer: a live permission prompt present at
+  // replay-end always raced the (chunked, back-pressure-paused) replay rather
+  // than being replayed. Stamping it destroys the approval the user
+  // reconnected to answer.
+  it("does not stamp a LIVE permission prompt belonging to the REPLAYED session", () => {
+    const store = seed(historicalPrompt('p1'), livePrompt('p2', 'req-2'));
+    // Positive control: prove the fixture is live BEFORE asserting it survives,
+    // so a malformed fixture fails rather than satisfying the assertion for
+    // free (#7409's lesson).
+    expect(
+      isLivePermissionPrompt(store.getState().sessionStates.s2.messages[0] as any, Date.now()),
+    ).toBe(true);
+
+    _testMessageHandler.handle({ type: 'history_replay_end', sessionId: 's2' });
+
+    const s2Prompt = store.getState().sessionStates.s2.messages[0] as any;
+    expect(s2Prompt.answered).toBeUndefined();
+    expect(isLivePermissionPrompt(s2Prompt, Date.now())).toBe(true);
+  });
+
+  // --- the end-to-end scenario from #7410 -----------------------------------
+  //
+  // Protected twice over now (wrong session AND live), which is the point: this
+  // pins the user-visible regression, while the two guards above pin each
+  // mechanism independently.
   it("a background session's replay-end does not resolve the active session's LIVE prompt", () => {
-    const store = seedTwoSessions();
-    // Positive control (#7409's lesson): prove the fixture really is a live
-    // prompt BEFORE asserting it survives, so a malformed fixture fails the
-    // test instead of satisfying it vacuously.
+    const store = seed(livePrompt('p1', 'req-1'), historicalPrompt('p2'));
     expect(
       isLivePermissionPrompt(store.getState().sessionStates.s1.messages[0] as any, Date.now()),
     ).toBe(true);
@@ -707,32 +782,6 @@ describe("history_replay_end: '(resolved)' sweep targeting (#7410)", () => {
     const s1Prompt = store.getState().sessionStates.s1.messages[0] as any;
     expect(s1Prompt.answered).toBeUndefined();
     expect(isLivePermissionPrompt(s1Prompt, Date.now())).toBe(true);
-  });
-
-  it("stamps the REPLAYED session's own unanswered prompts", () => {
-    const store = seedTwoSessions();
-
-    _testMessageHandler.handle({ type: 'history_replay_end', sessionId: 's2' });
-
-    expect((store.getState().sessionStates.s2.messages[0] as any).answered).toBe('(resolved)');
-  });
-
-  it('still stamps the active session when it is the one being replayed', () => {
-    const store = seedTwoSessions();
-
-    _testMessageHandler.handle({ type: 'history_replay_end', sessionId: 's1' });
-
-    expect((store.getState().sessionStates.s1.messages[0] as any).answered).toBe('(resolved)');
-    // ...and the background session is left alone, the mirror of the first case.
-    expect((store.getState().sessionStates.s2.messages[0] as any).answered).toBeUndefined();
-  });
-
-  it('falls back to the active session when the frame omits sessionId', () => {
-    const store = seedTwoSessions();
-
-    _testMessageHandler.handle({ type: 'history_replay_end' } as any);
-
-    expect((store.getState().sessionStates.s1.messages[0] as any).answered).toBe('(resolved)');
   });
 });
 

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -148,6 +148,10 @@ import {
   // (byte-identical wording with the dashboard).
   handleAppendMemoryResult as sharedAppendMemoryResult,
   formatMemoryAppendNotice,
+  // #7410 — the `history_replay_end` '(resolved)' sweep must not stamp a LIVE
+  // permission prompt. Imported rather than re-expressed inline so there is
+  // exactly one definition of "live permission prompt" in the codebase.
+  isLivePermissionPrompt,
 } from '@chroxy/store-core';
 import type {
   DeltaFlusher,
@@ -2564,17 +2568,37 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         // omits `sessionId`, so the single-session case is unchanged; and
         // `updateSession` no-ops on an id with no state, which is the right
         // outcome for the "session vanished mid-replay" branch above.
+        //
+        // LIVE permission prompts are excluded, and that follows from the wire
+        // contract rather than from taste: `permission_request` is in the
+        // server's `builtinTransient` list (`session-manager.js`), so it is
+        // NEVER written to the history ring buffer and can never arrive as a
+        // replayed entry. A live permission prompt sitting in `messages` at
+        // replay-end is therefore always a LIVE one that raced the replay —
+        // replay is chunked in 20-entry `setImmediate` batches with
+        // back-pressure pauses (`ws-history.js`), so that race is wide, and
+        // `reconcileReplayEnd`'s baseline slice deliberately keeps such
+        // entries. Stamping it destroys the pending approval the user
+        // reconnected to answer, which is the opposite of this sweep's premise
+        // ("anything in history is already resolved").
+        //
+        // `user_question` prompts, by contrast, ARE in the ring buffer and are
+        // re-sent on every replay, so they stay stampable — and they carry no
+        // `requestId`/`expiresAt`, so `isLivePermissionPrompt` leaves them
+        // alone by construction. (A live AskUserQuestion that races a replay is
+        // indistinguishable from a replayed one on the wire; see #7420.)
         if (endTargetId) {
+          // One `now` for the whole sweep so the `some` predicate and the `map`
+          // predicate cannot disagree across a millisecond boundary.
+          const sweepNow = Date.now();
+          const isStampable = (m: ChatMessage): boolean =>
+            m.type === 'prompt' && !m.answered && !isLivePermissionPrompt(m, sweepNow);
           updateSession(endTargetId, (ss) => {
-            const hasUnansweredPrompts = ss.messages.some(
-              (m) => m.type === 'prompt' && !m.answered
-            );
+            const hasUnansweredPrompts = ss.messages.some(isStampable);
             if (!hasUnansweredPrompts) return {};
             return {
               messages: ss.messages.map((m) =>
-                m.type === 'prompt' && !m.answered
-                  ? { ...m, answered: '(resolved)' }
-                  : m
+                isStampable(m) ? { ...m, answered: '(resolved)' } : m
               ),
             };
           });

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -148,10 +148,6 @@ import {
   // (byte-identical wording with the dashboard).
   handleAppendMemoryResult as sharedAppendMemoryResult,
   formatMemoryAppendNotice,
-  // #7410 — the `history_replay_end` '(resolved)' sweep must not stamp a LIVE
-  // permission prompt. Imported rather than re-expressed inline so there is
-  // exactly one definition of "live permission prompt" in the codebase.
-  isLivePermissionPrompt,
 } from '@chroxy/store-core';
 import type {
   DeltaFlusher,
@@ -2569,30 +2565,45 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         // `updateSession` no-ops on an id with no state, which is the right
         // outcome for the "session vanished mid-replay" branch above.
         //
-        // LIVE permission prompts are excluded, and that follows from the wire
-        // contract rather than from taste: `permission_request` is in the
-        // server's `builtinTransient` list (`session-manager.js`), so it is
-        // NEVER written to the history ring buffer and can never arrive as a
-        // replayed entry. A live permission prompt sitting in `messages` at
-        // replay-end is therefore always a LIVE one that raced the replay —
-        // replay is chunked in 20-entry `setImmediate` batches with
-        // back-pressure pauses (`ws-history.js`), so that race is wide, and
-        // `reconcileReplayEnd`'s baseline slice deliberately keeps such
-        // entries. Stamping it destroys the pending approval the user
-        // reconnected to answer, which is the opposite of this sweep's premise
-        // ("anything in history is already resolved").
+        // Permission prompts are excluded by `requestId`, and that follows from
+        // the wire contract rather than from taste. Exactly two things produce
+        // a `type: 'prompt'` ChatMessage, and history splits them cleanly:
         //
-        // `user_question` prompts, by contrast, ARE in the ring buffer and are
-        // re-sent on every replay, so they stay stampable — and they carry no
-        // `requestId`/`expiresAt`, so `isLivePermissionPrompt` leaves them
-        // alone by construction. (A live AskUserQuestion that races a replay is
-        // indistinguishable from a replayed one on the wire; see #7420.)
+        //   - `permission_request` is in the server's `builtinTransient` list
+        //     (`session-manager.js`), so it is NEVER written to the history
+        //     ring buffer and can never arrive as a replayed entry. It is the
+        //     only producer that sets `requestId`.
+        //   - `user_question` IS in the ring buffer and is re-sent on every
+        //     replay (`store-core/handlers/user-question.ts`), and it sets no
+        //     `requestId`.
+        //
+        // So `!m.requestId` is precisely "could this have come from history?",
+        // which is the only question this sweep is entitled to ask. A prompt
+        // with a `requestId` present at replay-end always raced the replay
+        // instead of being replayed — and that is routine, not exotic:
+        // `replayHistory` sends its first 20-entry chunk synchronously and
+        // defers the rest, while `resendPendingPermissions` runs later in the
+        // same post-auth block (`ws-history.js`), so on any session with more
+        // than one chunk of history the re-sent permission lands BEFORE
+        // `history_replay_end`. `reconcileReplayEnd`'s baseline slice keeps it
+        // deliberately. Stamping it destroys the pending approval the user
+        // reconnected to answer — the opposite of this sweep's premise that
+        // anything in history is already resolved.
+        //
+        // NOT `isLivePermissionPrompt`: that also requires `expiresAt > now`,
+        // and `expiresAt` is only set when the frame carried `remainingMs`,
+        // which is `.optional()` in `ServerPermissionRequestSchema`. An emitter
+        // that omits it yields a live prompt with `requestId` and no
+        // `expiresAt` — not "live" by that predicate, and stamped. It would
+        // also stamp a `permission_expired` prompt, whose `answered` is left
+        // empty on purpose (it is a DECISION token and no decision was made).
+        // `requestId` has neither hole.
+        //
+        // Still open: a LIVE AskUserQuestion racing a replay is byte-identical
+        // to a replayed one, so nothing here can separate them — see #7420.
         if (endTargetId) {
-          // One `now` for the whole sweep so the `some` predicate and the `map`
-          // predicate cannot disagree across a millisecond boundary.
-          const sweepNow = Date.now();
           const isStampable = (m: ChatMessage): boolean =>
-            m.type === 'prompt' && !m.answered && !isLivePermissionPrompt(m, sweepNow);
+            m.type === 'prompt' && !m.answered && !m.requestId;
           updateSession(endTargetId, (ss) => {
             const hasUnansweredPrompts = ss.messages.some(isStampable);
             if (!hasUnansweredPrompts) return {};

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -2546,23 +2546,41 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         } else {
           reconcileReplayEnd(endTargetId, [], endLatestSeq);
         }
+        // Mark all replayed prompts as answered — any prompt in history
+        // has already been resolved by the server.
+        //
+        // #7410 — keyed to `endTargetId`, NOT `activeSessionId`. The predicate
+        // matches LIVE prompts as well as historical ones:
+        // `isLivePermissionPrompt` is `type === 'prompt' && requestId &&
+        // expiresAt > now && !answered`, and AskUserQuestion emits
+        // `type: 'prompt'` too. Keyed to the active session, a BACKGROUND
+        // session's replay-end stamped '(resolved)' on a permission approval
+        // the user was looking at — silently dismissing it — and
+        // `subscribe_sessions` replays every background session, so that
+        // happened on every multi-session reconnect. Fourth instance of this
+        // mis-keying in this pair of files after #4909, #7340 and #7402.
+        //
+        // `endTargetId` already falls back to `activeSessionId` when the frame
+        // omits `sessionId`, so the single-session case is unchanged; and
+        // `updateSession` no-ops on an id with no state, which is the right
+        // outcome for the "session vanished mid-replay" branch above.
+        if (endTargetId) {
+          updateSession(endTargetId, (ss) => {
+            const hasUnansweredPrompts = ss.messages.some(
+              (m) => m.type === 'prompt' && !m.answered
+            );
+            if (!hasUnansweredPrompts) return {};
+            return {
+              messages: ss.messages.map((m) =>
+                m.type === 'prompt' && !m.answered
+                  ? { ...m, answered: '(resolved)' }
+                  : m
+              ),
+            };
+          });
+        }
       }
       _ctx.isSessionSwitchReplay = false;
-      // Mark all replayed prompts as answered — any prompt in history
-      // has already been resolved by the server.
-      updateActiveSession((ss) => {
-        const hasUnansweredPrompts = ss.messages.some(
-          (m) => m.type === 'prompt' && !m.answered
-        );
-        if (!hasUnansweredPrompts) return {};
-        return {
-          messages: ss.messages.map((m) =>
-            m.type === 'prompt' && !m.answered
-              ? { ...m, answered: '(resolved)' }
-              : m
-          ),
-        };
-      });
       break;
 
     // --- User input echoed from other clients ---

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -57,6 +57,7 @@ import {
   MCP_SERVER_OP_PENDING_CAP,
 } from './message-handler'
 import { createEmptySessionState } from './utils'
+import { isLivePermissionPrompt } from '@chroxy/store-core'
 import type { ConnectionState } from './types'
 
 function createMockStore(initial: Partial<ConnectionState>) {
@@ -3583,6 +3584,92 @@ describe('dashboard message-handler dispatch', () => {
       ).not.toThrow();
       // ...and the active session's pending plan is still untouched.
       expect((store.getState() as any).sessionStates.s1.isPlanPending).toBe(true);
+    });
+  });
+
+  // #7410 — the `answered: '(resolved)'` sweep on `history_replay_end` must
+  // target the session the frame is ENDING, not whichever session happens to be
+  // active. Fourth instance of this mis-keying in this pair of files after
+  // #4909 (`stoppedAt`), #7340 (`activeAgents`) and #7402 (`isPlanPending`,
+  // the describe above), and the worst of the four: the predicate is
+  // `type === 'prompt' && !answered`, which matches LIVE prompts as well as
+  // replayed ones. `isLivePermissionPrompt` (store-core) is
+  // `type === 'prompt' && requestId && expiresAt > now && !answered`, so a
+  // stamp of '(resolved)' takes a live prompt out of the pending-permission
+  // surface — and AskUserQuestion emits `type: 'prompt'` too.
+  //
+  // `subscribe_sessions` replays every background session on every reconnect,
+  // so keyed to `activeSessionId` this silently dismissed a permission approval
+  // the user was looking at, every time a second session reconnected.
+  describe("history_replay_end: '(resolved)' sweep targeting (#7410)", () => {
+    const FUTURE = Date.now() + 600_000;
+
+    /** A live, unanswered permission prompt — `isLivePermissionPrompt` is true. */
+    function livePrompt(id: string, requestId: string) {
+      return {
+        id,
+        type: 'prompt',
+        content: 'Allow Write to src/index.ts?',
+        requestId,
+        expiresAt: FUTURE,
+        timestamp: 1,
+      } as any;
+    }
+
+    function seedTwoSessions() {
+      store = createMockStore(
+        baseState({
+          activeSessionId: 's1',
+          sessions: [{ sessionId: 's1', name: 'S1' } as any, { sessionId: 's2', name: 'S2' } as any],
+          sessionStates: {
+            s1: { ...createEmptySessionState(), messages: [livePrompt('p1', 'req-1')] },
+            s2: { ...createEmptySessionState(), messages: [livePrompt('p2', 'req-2')] },
+          },
+        }),
+      );
+      setStore(store);
+    }
+
+    it("a background session's replay-end does not resolve the active session's LIVE prompt", () => {
+      seedTwoSessions();
+      // Positive control (#7409's lesson): prove the fixture really is a live
+      // prompt BEFORE asserting it survives, so a malformed fixture fails the
+      // test instead of satisfying it vacuously.
+      expect(
+        isLivePermissionPrompt((store.getState() as any).sessionStates.s1.messages[0], Date.now()),
+      ).toBe(true);
+
+      handleMessage({ type: 'history_replay_end', sessionId: 's2' }, ctx() as any);
+
+      const s1Prompt = (store.getState() as any).sessionStates.s1.messages[0];
+      expect(s1Prompt.answered).toBeUndefined();
+      expect(isLivePermissionPrompt(s1Prompt, Date.now())).toBe(true);
+    });
+
+    it("stamps the REPLAYED session's own unanswered prompts", () => {
+      seedTwoSessions();
+
+      handleMessage({ type: 'history_replay_end', sessionId: 's2' }, ctx() as any);
+
+      expect((store.getState() as any).sessionStates.s2.messages[0].answered).toBe('(resolved)');
+    });
+
+    it('still stamps the active session when it is the one being replayed', () => {
+      seedTwoSessions();
+
+      handleMessage({ type: 'history_replay_end', sessionId: 's1' }, ctx() as any);
+
+      expect((store.getState() as any).sessionStates.s1.messages[0].answered).toBe('(resolved)');
+      // ...and the background session is left alone, the mirror of the first case.
+      expect((store.getState() as any).sessionStates.s2.messages[0].answered).toBeUndefined();
+    });
+
+    it('falls back to the active session when the frame omits sessionId', () => {
+      seedTwoSessions();
+
+      handleMessage({ type: 'history_replay_end' } as any, ctx() as any);
+
+      expect((store.getState() as any).sessionStates.s1.messages[0].answered).toBe('(resolved)');
     });
   });
 

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -3604,6 +3604,22 @@ describe('dashboard message-handler dispatch', () => {
   describe("history_replay_end: '(resolved)' sweep targeting (#7410)", () => {
     const FUTURE = Date.now() + 600_000;
 
+    /**
+     * An AskUserQuestion-shaped prompt: `type: 'prompt'` with no `requestId`
+     * and no `expiresAt`. `user_question` IS in the server's history ring
+     * buffer, so this is what a genuinely REPLAYED prompt looks like — and it
+     * is what the sweep exists to stamp. `isLivePermissionPrompt` is false.
+     */
+    function historicalPrompt(id: string) {
+      return {
+        id,
+        type: 'prompt',
+        content: 'Which approach?',
+        options: ['a', 'b'],
+        timestamp: 1,
+      } as any;
+    }
+
     /** A live, unanswered permission prompt — `isLivePermissionPrompt` is true. */
     function livePrompt(id: string, requestId: string) {
       return {
@@ -3616,25 +3632,84 @@ describe('dashboard message-handler dispatch', () => {
       } as any;
     }
 
-    function seedTwoSessions() {
+    function seed(s1First: any, s2First: any) {
       store = createMockStore(
         baseState({
           activeSessionId: 's1',
           sessions: [{ sessionId: 's1', name: 'S1' } as any, { sessionId: 's2', name: 'S2' } as any],
           sessionStates: {
-            s1: { ...createEmptySessionState(), messages: [livePrompt('p1', 'req-1')] },
-            s2: { ...createEmptySessionState(), messages: [livePrompt('p2', 'req-2')] },
+            s1: { ...createEmptySessionState(), messages: [s1First] },
+            s2: { ...createEmptySessionState(), messages: [s2First] },
           },
         }),
       );
       setStore(store);
     }
 
+    // --- the keying guard ---------------------------------------------------
+    //
+    // HISTORICAL prompts on both sides on purpose. If s1 held a LIVE prompt
+    // here the live-prompt exclusion would protect it too, and the test would
+    // still pass with the keying reverted to `updateActiveSession` — pinning
+    // nothing. Correct keying is the ONLY reason s1's prompt survives.
+    it("a background session's replay-end stamps that session, not the active one", () => {
+      seed(historicalPrompt('p1'), historicalPrompt('p2'));
+
+      handleMessage({ type: 'history_replay_end', sessionId: 's2' }, ctx() as any);
+
+      const st = (store.getState() as any).sessionStates;
+      expect(st.s1.messages[0].answered).toBeUndefined();
+      expect(st.s2.messages[0].answered).toBe('(resolved)');
+    });
+
+    it('still stamps the active session when it is the one being replayed', () => {
+      seed(historicalPrompt('p1'), historicalPrompt('p2'));
+
+      handleMessage({ type: 'history_replay_end', sessionId: 's1' }, ctx() as any);
+
+      const st = (store.getState() as any).sessionStates;
+      expect(st.s1.messages[0].answered).toBe('(resolved)');
+      expect(st.s2.messages[0].answered).toBeUndefined();
+    });
+
+    it('falls back to the active session when the frame omits sessionId', () => {
+      seed(historicalPrompt('p1'), historicalPrompt('p2'));
+
+      handleMessage({ type: 'history_replay_end' } as any, ctx() as any);
+
+      expect((store.getState() as any).sessionStates.s1.messages[0].answered).toBe('(resolved)');
+    });
+
+    // --- the live-prompt exclusion ------------------------------------------
+    //
+    // `permission_request` is in the server's `builtinTransient` list, so it is
+    // never in the history ring buffer: a live permission prompt present at
+    // replay-end always raced the (chunked, back-pressure-paused) replay rather
+    // than being replayed. Stamping it destroys the approval the user
+    // reconnected to answer.
+    it('does not stamp a LIVE permission prompt belonging to the REPLAYED session', () => {
+      seed(historicalPrompt('p1'), livePrompt('p2', 'req-2'));
+      // Positive control: prove the fixture is live BEFORE asserting it
+      // survives, so a malformed fixture fails rather than satisfying the
+      // assertion for free (#7409's lesson).
+      expect(
+        isLivePermissionPrompt((store.getState() as any).sessionStates.s2.messages[0], Date.now()),
+      ).toBe(true);
+
+      handleMessage({ type: 'history_replay_end', sessionId: 's2' }, ctx() as any);
+
+      const s2Prompt = (store.getState() as any).sessionStates.s2.messages[0];
+      expect(s2Prompt.answered).toBeUndefined();
+      expect(isLivePermissionPrompt(s2Prompt, Date.now())).toBe(true);
+    });
+
+    // --- the end-to-end scenario from #7410 ---------------------------------
+    //
+    // Protected twice over now (wrong session AND live), which is the point:
+    // this pins the user-visible regression, while the two guards above pin
+    // each mechanism independently.
     it("a background session's replay-end does not resolve the active session's LIVE prompt", () => {
-      seedTwoSessions();
-      // Positive control (#7409's lesson): prove the fixture really is a live
-      // prompt BEFORE asserting it survives, so a malformed fixture fails the
-      // test instead of satisfying it vacuously.
+      seed(livePrompt('p1', 'req-1'), historicalPrompt('p2'));
       expect(
         isLivePermissionPrompt((store.getState() as any).sessionStates.s1.messages[0], Date.now()),
       ).toBe(true);
@@ -3644,32 +3719,6 @@ describe('dashboard message-handler dispatch', () => {
       const s1Prompt = (store.getState() as any).sessionStates.s1.messages[0];
       expect(s1Prompt.answered).toBeUndefined();
       expect(isLivePermissionPrompt(s1Prompt, Date.now())).toBe(true);
-    });
-
-    it("stamps the REPLAYED session's own unanswered prompts", () => {
-      seedTwoSessions();
-
-      handleMessage({ type: 'history_replay_end', sessionId: 's2' }, ctx() as any);
-
-      expect((store.getState() as any).sessionStates.s2.messages[0].answered).toBe('(resolved)');
-    });
-
-    it('still stamps the active session when it is the one being replayed', () => {
-      seedTwoSessions();
-
-      handleMessage({ type: 'history_replay_end', sessionId: 's1' }, ctx() as any);
-
-      expect((store.getState() as any).sessionStates.s1.messages[0].answered).toBe('(resolved)');
-      // ...and the background session is left alone, the mirror of the first case.
-      expect((store.getState() as any).sessionStates.s2.messages[0].answered).toBeUndefined();
-    });
-
-    it('falls back to the active session when the frame omits sessionId', () => {
-      seedTwoSessions();
-
-      handleMessage({ type: 'history_replay_end' } as any, ctx() as any);
-
-      expect((store.getState() as any).sessionStates.s1.messages[0].answered).toBe('(resolved)');
     });
   });
 

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -3602,8 +3602,6 @@ describe('dashboard message-handler dispatch', () => {
   // so keyed to `activeSessionId` this silently dismissed a permission approval
   // the user was looking at, every time a second session reconnected.
   describe("history_replay_end: '(resolved)' sweep targeting (#7410)", () => {
-    const FUTURE = Date.now() + 600_000;
-
     /**
      * An AskUserQuestion-shaped prompt: `type: 'prompt'` with no `requestId`
      * and no `expiresAt`. `user_question` IS in the server's history ring
@@ -3627,7 +3625,27 @@ describe('dashboard message-handler dispatch', () => {
         type: 'prompt',
         content: 'Allow Write to src/index.ts?',
         requestId,
-        expiresAt: FUTURE,
+        // Computed per call, not once at describe-collection time: a slow suite
+        // would otherwise leave the fixture expired and silently non-live.
+        expiresAt: Date.now() + 600_000,
+        timestamp: 1,
+      } as any;
+    }
+
+    /**
+     * A permission prompt whose frame carried no `remainingMs`. `remainingMs`
+     * is `.optional()` in `ServerPermissionRequestSchema` and the shared parser
+     * maps an omitted value to `null`, so the client leaves `expiresAt`
+     * undefined — giving a genuinely LIVE, answerable prompt for which
+     * `isLivePermissionPrompt` is FALSE. This is the shape that made an earlier
+     * `!isLivePermissionPrompt(...)` predicate stamp a live approval.
+     */
+    function livePromptNoTtl(id: string, requestId: string) {
+      return {
+        id,
+        type: 'prompt',
+        content: 'Allow Bash: rm -rf /tmp/x?',
+        requestId,
         timestamp: 1,
       } as any;
     }
@@ -3719,6 +3737,38 @@ describe('dashboard message-handler dispatch', () => {
       const s1Prompt = (store.getState() as any).sessionStates.s1.messages[0];
       expect(s1Prompt.answered).toBeUndefined();
       expect(isLivePermissionPrompt(s1Prompt, Date.now())).toBe(true);
+    });
+
+    // The sweep keys off `requestId`, not liveness, and this is why. A
+    // permission frame may omit `remainingMs` (`.optional()` in the schema),
+    // which leaves `expiresAt` undefined and makes `isLivePermissionPrompt`
+    // false for a prompt the user can still answer. A liveness-based predicate
+    // stamps it; a `requestId`-based one cannot.
+    it('does not stamp a live permission prompt that has no expiresAt', () => {
+      seed(historicalPrompt('p1'), livePromptNoTtl('p2', 'req-2'));
+      const before = (store.getState() as any).sessionStates.s2.messages[0];
+      // Positive controls: it IS a permission prompt (has a requestId) and it
+      // is NOT recognised as live — i.e. exactly the gap being closed.
+      expect(before.requestId).toBe('req-2');
+      expect(before.expiresAt).toBeUndefined();
+      expect(isLivePermissionPrompt(before, Date.now())).toBe(false);
+
+      handleMessage({ type: 'history_replay_end', sessionId: 's2' }, ctx() as any);
+
+      expect((store.getState() as any).sessionStates.s2.messages[0].answered).toBeUndefined();
+    });
+
+    // `updateSession` no-ops on an id with no state. Stamping the active
+    // session instead — what the pre-fix code did — was never right for a frame
+    // naming a session this client does not track.
+    it('stamps nothing when the replayed session has no state', () => {
+      seed(historicalPrompt('p1'), historicalPrompt('p2'));
+
+      handleMessage({ type: 'history_replay_end', sessionId: 's-gone' }, ctx() as any);
+
+      const st = (store.getState() as any).sessionStates;
+      expect(st.s1.messages[0].answered).toBeUndefined();
+      expect(st.s2.messages[0].answered).toBeUndefined();
     });
   });
 

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -153,10 +153,6 @@ import {
   // (byte-identical wording with the mobile app).
   handleAppendMemoryResult as sharedAppendMemoryResult,
   formatMemoryAppendNotice,
-  // #7410 — the `history_replay_end` '(resolved)' sweep must not stamp a LIVE
-  // permission prompt. Imported rather than re-expressed inline so there is
-  // exactly one definition of "live permission prompt" in the codebase.
-  isLivePermissionPrompt,
 } from '@chroxy/store-core'
 import { PROTOCOL_VERSION } from '@chroxy/protocol'
 import { ServerByokCredentialsStatusSchema, ServerCredentialsStatusSchema, ServerCredentialTestResultSchema, ServerActivitySnapshotSchema, ServerActivityDeltaSchema, ServerCancelActivityAckSchema, ServerHostStatusSnapshotSchema, ServerRunnerStatusSnapshotSchema, ServerContainersStatusSnapshotSchema, ServerContainersActionAckSchema, ServerRepoRuntimeConfigSnapshotSchema, ServerByokPoolStatusSnapshotSchema, ServerByokPoolActionAckSchema, ServerHostPruneStatusSnapshotSchema, ServerHostPruneActionAckSchema, ServerSimulatorStatusSnapshotSchema, ServerSimulatorActionAckSchema, ServerEmulatorStatusSnapshotSchema, ServerEmulatorActionAckSchema, ServerWslStatusSnapshotSchema, ServerWslActionAckSchema, ServerIntegrationStatusSnapshotSchema, ServerSkillsInventorySnapshotSchema, ServerMailboxStatusSnapshotSchema, ServerExternalSessionsSnapshotSchema, ServerRepoEventsSnapshotSchema, ServerRepoEventsDeltaSchema, ServerGithubWebhookConfigSchema, ServerPermissionInputSchema, ServerPermissionAuditResultSchema, ServerIntegrationActionAckSchema, ServerSummarizeSessionResultSchema, ServerSessionPresetSnapshotSchema, ServerPairPendingSchema, ServerPairResolvedSchema, ServerBillingCanarySchema, BillingCanarySnapshotSchema, ServerSymbolsSnapshotSchema, ServerSymbolLocationSchema, ServerSearchResultsSchema, ServerReferencesResultSchema, ServerOrchestrationRunsSnapshotSchema, ServerOrchestrationRunSnapshotSchema, ServerOrchestrationRunDeltaSchema, ServerOrchestrationActionAckSchema, ServerGitCreatePrResultSchema, ServerMemoryStackResultSchema, ServerScheduledTasksSchema } from '@chroxy/protocol/schemas'
@@ -5238,30 +5234,45 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         // `updateSession` no-ops on an id with no state, which is the right
         // outcome for the "session vanished mid-replay" branch above.
         //
-        // LIVE permission prompts are excluded, and that follows from the wire
-        // contract rather than from taste: `permission_request` is in the
-        // server's `builtinTransient` list (`session-manager.js`), so it is
-        // NEVER written to the history ring buffer and can never arrive as a
-        // replayed entry. A live permission prompt sitting in `messages` at
-        // replay-end is therefore always a LIVE one that raced the replay —
-        // replay is chunked in 20-entry `setImmediate` batches with
-        // back-pressure pauses (`ws-history.js`), so that race is wide, and
-        // `reconcileReplayEnd`'s baseline slice deliberately keeps such
-        // entries. Stamping it destroys the pending approval the user
-        // reconnected to answer, which is the opposite of this sweep's premise
-        // ("anything in history is already resolved").
+        // Permission prompts are excluded by `requestId`, and that follows from
+        // the wire contract rather than from taste. Exactly two things produce
+        // a `type: 'prompt'` ChatMessage, and history splits them cleanly:
         //
-        // `user_question` prompts, by contrast, ARE in the ring buffer and are
-        // re-sent on every replay, so they stay stampable — and they carry no
-        // `requestId`/`expiresAt`, so `isLivePermissionPrompt` leaves them
-        // alone by construction. (A live AskUserQuestion that races a replay is
-        // indistinguishable from a replayed one on the wire; see #7420.)
+        //   - `permission_request` is in the server's `builtinTransient` list
+        //     (`session-manager.js`), so it is NEVER written to the history
+        //     ring buffer and can never arrive as a replayed entry. It is the
+        //     only producer that sets `requestId`.
+        //   - `user_question` IS in the ring buffer and is re-sent on every
+        //     replay (`store-core/handlers/user-question.ts`), and it sets no
+        //     `requestId`.
+        //
+        // So `!m.requestId` is precisely "could this have come from history?",
+        // which is the only question this sweep is entitled to ask. A prompt
+        // with a `requestId` present at replay-end always raced the replay
+        // instead of being replayed — and that is routine, not exotic:
+        // `replayHistory` sends its first 20-entry chunk synchronously and
+        // defers the rest, while `resendPendingPermissions` runs later in the
+        // same post-auth block (`ws-history.js`), so on any session with more
+        // than one chunk of history the re-sent permission lands BEFORE
+        // `history_replay_end`. `reconcileReplayEnd`'s baseline slice keeps it
+        // deliberately. Stamping it destroys the pending approval the user
+        // reconnected to answer — the opposite of this sweep's premise that
+        // anything in history is already resolved.
+        //
+        // NOT `isLivePermissionPrompt`: that also requires `expiresAt > now`,
+        // and `expiresAt` is only set when the frame carried `remainingMs`,
+        // which is `.optional()` in `ServerPermissionRequestSchema`. An emitter
+        // that omits it yields a live prompt with `requestId` and no
+        // `expiresAt` — not "live" by that predicate, and stamped. It would
+        // also stamp a `permission_expired` prompt, whose `answered` is left
+        // empty on purpose (it is a DECISION token and no decision was made).
+        // `requestId` has neither hole.
+        //
+        // Still open: a LIVE AskUserQuestion racing a replay is byte-identical
+        // to a replayed one, so nothing here can separate them — see #7420.
         if (endTargetId) {
-          // One `now` for the whole sweep so the `some` predicate and the `map`
-          // predicate cannot disagree across a millisecond boundary.
-          const sweepNow = Date.now();
           const isStampable = (m: ChatMessage): boolean =>
-            m.type === 'prompt' && !m.answered && !isLivePermissionPrompt(m, sweepNow);
+            m.type === 'prompt' && !m.answered && !m.requestId;
           updateSession(endTargetId, (ss) => {
             const hasUnansweredPrompts = ss.messages.some(isStampable);
             if (!hasUnansweredPrompts) return {};

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -153,6 +153,10 @@ import {
   // (byte-identical wording with the mobile app).
   handleAppendMemoryResult as sharedAppendMemoryResult,
   formatMemoryAppendNotice,
+  // #7410 — the `history_replay_end` '(resolved)' sweep must not stamp a LIVE
+  // permission prompt. Imported rather than re-expressed inline so there is
+  // exactly one definition of "live permission prompt" in the codebase.
+  isLivePermissionPrompt,
 } from '@chroxy/store-core'
 import { PROTOCOL_VERSION } from '@chroxy/protocol'
 import { ServerByokCredentialsStatusSchema, ServerCredentialsStatusSchema, ServerCredentialTestResultSchema, ServerActivitySnapshotSchema, ServerActivityDeltaSchema, ServerCancelActivityAckSchema, ServerHostStatusSnapshotSchema, ServerRunnerStatusSnapshotSchema, ServerContainersStatusSnapshotSchema, ServerContainersActionAckSchema, ServerRepoRuntimeConfigSnapshotSchema, ServerByokPoolStatusSnapshotSchema, ServerByokPoolActionAckSchema, ServerHostPruneStatusSnapshotSchema, ServerHostPruneActionAckSchema, ServerSimulatorStatusSnapshotSchema, ServerSimulatorActionAckSchema, ServerEmulatorStatusSnapshotSchema, ServerEmulatorActionAckSchema, ServerWslStatusSnapshotSchema, ServerWslActionAckSchema, ServerIntegrationStatusSnapshotSchema, ServerSkillsInventorySnapshotSchema, ServerMailboxStatusSnapshotSchema, ServerExternalSessionsSnapshotSchema, ServerRepoEventsSnapshotSchema, ServerRepoEventsDeltaSchema, ServerGithubWebhookConfigSchema, ServerPermissionInputSchema, ServerPermissionAuditResultSchema, ServerIntegrationActionAckSchema, ServerSummarizeSessionResultSchema, ServerSessionPresetSnapshotSchema, ServerPairPendingSchema, ServerPairResolvedSchema, ServerBillingCanarySchema, BillingCanarySnapshotSchema, ServerSymbolsSnapshotSchema, ServerSymbolLocationSchema, ServerSearchResultsSchema, ServerReferencesResultSchema, ServerOrchestrationRunsSnapshotSchema, ServerOrchestrationRunSnapshotSchema, ServerOrchestrationRunDeltaSchema, ServerOrchestrationActionAckSchema, ServerGitCreatePrResultSchema, ServerMemoryStackResultSchema, ServerScheduledTasksSchema } from '@chroxy/protocol/schemas'
@@ -5233,17 +5237,37 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         // omits `sessionId`, so the single-session case is unchanged; and
         // `updateSession` no-ops on an id with no state, which is the right
         // outcome for the "session vanished mid-replay" branch above.
+        //
+        // LIVE permission prompts are excluded, and that follows from the wire
+        // contract rather than from taste: `permission_request` is in the
+        // server's `builtinTransient` list (`session-manager.js`), so it is
+        // NEVER written to the history ring buffer and can never arrive as a
+        // replayed entry. A live permission prompt sitting in `messages` at
+        // replay-end is therefore always a LIVE one that raced the replay —
+        // replay is chunked in 20-entry `setImmediate` batches with
+        // back-pressure pauses (`ws-history.js`), so that race is wide, and
+        // `reconcileReplayEnd`'s baseline slice deliberately keeps such
+        // entries. Stamping it destroys the pending approval the user
+        // reconnected to answer, which is the opposite of this sweep's premise
+        // ("anything in history is already resolved").
+        //
+        // `user_question` prompts, by contrast, ARE in the ring buffer and are
+        // re-sent on every replay, so they stay stampable — and they carry no
+        // `requestId`/`expiresAt`, so `isLivePermissionPrompt` leaves them
+        // alone by construction. (A live AskUserQuestion that races a replay is
+        // indistinguishable from a replayed one on the wire; see #7420.)
         if (endTargetId) {
+          // One `now` for the whole sweep so the `some` predicate and the `map`
+          // predicate cannot disagree across a millisecond boundary.
+          const sweepNow = Date.now();
+          const isStampable = (m: ChatMessage): boolean =>
+            m.type === 'prompt' && !m.answered && !isLivePermissionPrompt(m, sweepNow);
           updateSession(endTargetId, (ss) => {
-            const hasUnansweredPrompts = ss.messages.some(
-              (m) => m.type === 'prompt' && !m.answered
-            );
+            const hasUnansweredPrompts = ss.messages.some(isStampable);
             if (!hasUnansweredPrompts) return {};
             return {
               messages: ss.messages.map((m) =>
-                m.type === 'prompt' && !m.answered
-                  ? { ...m, answered: '(resolved)' }
-                  : m
+                isStampable(m) ? { ...m, answered: '(resolved)' } : m
               ),
             };
           });

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -5215,22 +5215,40 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
           // Session vanished mid-replay — still settle the cursor.
           reconcileReplayEnd(endTargetId, [], endLatestSeq);
         }
+        // Mark all replayed prompts as answered — any prompt in history
+        // has already been resolved by the server.
+        //
+        // #7410 — keyed to `endTargetId`, NOT `activeSessionId`. The predicate
+        // matches LIVE prompts as well as historical ones:
+        // `isLivePermissionPrompt` is `type === 'prompt' && requestId &&
+        // expiresAt > now && !answered`, and AskUserQuestion emits
+        // `type: 'prompt'` too. Keyed to the active session, a BACKGROUND
+        // session's replay-end stamped '(resolved)' on a permission approval
+        // the user was looking at — silently dismissing it — and
+        // `subscribe_sessions` replays every background session, so that
+        // happened on every multi-session reconnect. Fourth instance of this
+        // mis-keying in this pair of files after #4909, #7340 and #7402.
+        //
+        // `endTargetId` already falls back to `activeSessionId` when the frame
+        // omits `sessionId`, so the single-session case is unchanged; and
+        // `updateSession` no-ops on an id with no state, which is the right
+        // outcome for the "session vanished mid-replay" branch above.
+        if (endTargetId) {
+          updateSession(endTargetId, (ss) => {
+            const hasUnansweredPrompts = ss.messages.some(
+              (m) => m.type === 'prompt' && !m.answered
+            );
+            if (!hasUnansweredPrompts) return {};
+            return {
+              messages: ss.messages.map((m) =>
+                m.type === 'prompt' && !m.answered
+                  ? { ...m, answered: '(resolved)' }
+                  : m
+              ),
+            };
+          });
+        }
       }
-      // Mark all replayed prompts as answered — any prompt in history
-      // has already been resolved by the server.
-      updateActiveSession((ss) => {
-        const hasUnansweredPrompts = ss.messages.some(
-          (m) => m.type === 'prompt' && !m.answered
-        );
-        if (!hasUnansweredPrompts) return {};
-        return {
-          messages: ss.messages.map((m) =>
-            m.type === 'prompt' && !m.answered
-              ? { ...m, answered: '(resolved)' }
-              : m
-          ),
-        };
-      });
       break;
 
     // --- User input echoed from other clients ---

--- a/packages/store-core/src/handlers/permission.ts
+++ b/packages/store-core/src/handlers/permission.ts
@@ -145,8 +145,10 @@ export const PERMISSION_ALREADY_ANSWERED_NOTICE =
  * #7388: that gate is now ONE predicate, `isPermissionRequestAnswered`
  * (pending-permissions.ts), which both clients call — keyed on the prompt's own
  * `answered` decision token via `isPermissionDecision`, NOT a defined-check,
- * because `history_replay_end` stamps the placeholder `'(resolved)'` on prompts
- * nobody answered. It previously WAS platform-specific (dashboard:
+ * because `history_replay_end` stamps the placeholder `'(resolved)'` on
+ * replayed prompts nobody answered (#7410 narrowed that sweep to the replayed
+ * session and to prompts with no `requestId`, but replayed `user_question`
+ * prompts are still stamped). It previously WAS platform-specific (dashboard:
  * `resolvedPermissions`; app: `answered`, #7380), which left the suppression
  * path — the one #7375 made routine — with no cross-client contract coverage,
  * because `resolvedPermissions` is not seedable by `FixtureInitialState`.

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -953,7 +953,9 @@ export {
 export {
   isLivePermissionPrompt,
   // #7380 — a REAL user decision, as opposed to `answered` merely being set
-  // (history_replay_end stamps '(resolved)' on prompts nobody answered).
+  // (history_replay_end stamps '(resolved)' on replayed prompts nobody
+  // answered; #7410 narrowed that sweep to the replayed session and to prompts
+  // with no `requestId`, but it still stamps replayed `user_question` prompts).
   isPermissionDecision,
   PERMISSION_DECISION_TOKENS,
   // #7388 — the ONE "was this permission already answered by a user?" gate,

--- a/packages/store-core/src/pending-permissions.ts
+++ b/packages/store-core/src/pending-permissions.ts
@@ -39,11 +39,17 @@ export type PermissionDecisionToken = (typeof PERMISSION_DECISION_TOKENS)[number
  * True iff `answered` is a real user decision.
  *
  * `answered` being merely SET is not that, which is the trap #7380's first draft
- * fell into: `history_replay_end` blanket-stamps `answered: '(resolved)'` on
- * every unanswered prompt in the active session, on the reasoning that anything
- * in replayed history is over. That placeholder is indistinguishable from a
- * decision under an `!== undefined` test — so a prompt the user never answered
- * reads as answered, and any behaviour gated that way misfires on it.
+ * fell into: `history_replay_end` stamps `answered: '(resolved)'` on unanswered
+ * prompts, on the reasoning that anything in replayed history is over. That
+ * placeholder is indistinguishable from a decision under an `!== undefined`
+ * test — so a prompt the user never answered reads as answered, and any
+ * behaviour gated that way misfires on it.
+ *
+ * #7410 narrowed that sweep twice — it now targets the session the frame is
+ * REPLAYING rather than the active one, and it skips any prompt carrying a
+ * `requestId` (permission prompts are transient server-side and can never be
+ * replayed, so one present at replay-end is live). This guard is still
+ * load-bearing: `user_question` prompts ARE replayed and are still stamped.
  *
  * Deliberately does NOT accept an arbitrary non-empty string: a future
  * placeholder would then quietly qualify too, which is the same bug again.
@@ -72,10 +78,11 @@ export function isPermissionDecision(answered: string | undefined | null): boole
  * `resolvedPermissions` — it is seedable by `FixtureInitialState`, so this path
  * can finally carry cross-client contract coverage.
  *
- * `isPermissionDecision`, NOT a defined-check: `history_replay_end` blanket-
- * stamps the placeholder `'(resolved)'` on every unanswered prompt in the
- * active session, and under `answered !== undefined` a prompt nobody touched
- * would read as answered — the inverse bug, caught in #7380's first draft.
+ * `isPermissionDecision`, NOT a defined-check: `history_replay_end` stamps the
+ * placeholder `'(resolved)'` on unanswered prompts in the session it is
+ * replaying (#7410; formerly the active one), and under `answered !== undefined`
+ * a prompt nobody touched would read as answered — the inverse bug, caught in
+ * #7380's first draft.
  *
  * Scans every session, not just the target one: the push-notification path
  * answers prompts in background sessions, which is why


### PR DESCRIPTION
## Summary

On `history_replay_end` both clients stamped `answered: '(resolved)'` on every unanswered prompt through `updateActiveSession`, which resolves `activeSessionId` and **ignores the frame's `sessionId`** — even though `endTargetId` is computed ~20 lines above in the same case body and was simply unused by this sweep.

That silently dismissed a live permission approval in whatever session the user was looking at, on **every multi-session reconnect** (`subscribe_sessions` replays every non-active session on every `session_list`).

Fixing it surfaced a second, independent defect in the same sweep — see "Two defects" below.

## Two defects, three commits

| Commit | Defect |
|---|---|
| `f3a8d75a0` | sweep keyed to `activeSessionId`, not the frame's `endTargetId` |
| `a11dc9bbb` | sweep stamped **live** prompts, not just replayed ones |
| `5fff69a33` | the liveness predicate itself had a hole — replaced with the wire contract |

### Defect 1 — wrong session

Fold the sweep into the existing `endTargetId` block, on both clients. `endTargetId` already falls back to `activeSessionId` when the frame omits `sessionId`, so the single-session case is unchanged; and `updateSession` no-ops on an id with no state — the right outcome for the "session vanished mid-replay" branch, where stamping the active session instead was never correct.

### Defect 2 — live prompts, and why the predicate is `requestId`

The sweep's premise is *"anything in replayed history is already resolved."* Its predicate was `type === 'prompt' && !answered`, which does not express that — it also matches prompts that were never in history at all.

The wire contract settles which prompts those are. Exactly **two** producers emit a `type: 'prompt'` ChatMessage, and history splits them cleanly:

| Producer | In the history ring buffer? | Sets `requestId`? |
|---|---|---|
| `permission_request` | **No** — in the server's `builtinTransient` list (`session-manager.js:3285`) | Yes |
| `user_question` | **Yes** — replayed on every reconnect (`store-core/handlers/user-question.ts`) | No |

So `!m.requestId` is precisely *"could this have come from history?"*, which is the only question this sweep is entitled to ask.

A prompt with a `requestId` present at replay-end always raced the replay rather than being replayed — and that is routine, not exotic. `replayHistory` sends its first 20-entry chunk synchronously and defers the rest through `setImmediate` with back-pressure pauses of up to 30s (`ws-history.js`), while `resendPendingPermissions` runs later in the same post-auth block. On any session with more than one chunk of history the re-sent permission lands *before* `history_replay_end`, and `reconcileReplayEnd`'s baseline slice keeps it deliberately.

**Why not `isLivePermissionPrompt`.** That was the first attempt (`a11dc9bbb`) and review found the hole. It additionally requires `expiresAt > now`, but `expiresAt` is only set when the frame carried `remainingMs` — and `remainingMs` is `.optional()` in `ServerPermissionRequestSchema`, with the shared parser mapping an omitted value to `null`. An emitter that omits it yields a genuinely live, answerable prompt with a `requestId` and no `expiresAt`, which that predicate reports as **not** live — so the sweep stamped it and #7410 recurred on that path. Latent rather than live today (no current emitter omits `remainingMs`), but the predicate was wrong, not lucky.

It also stamped `permission_expired` prompts, whose `answered` is deliberately left empty (*"it is a DECISION token and no decision was made"*) — and post-defect-1 it did so for every replayed background session, not just the active one. `requestId`-keying has neither hole.

**Still open:** a live `user_question` racing a replay is byte-identical to a replayed one, so nothing client-side can separate them. Filed as **#7420** and cross-referenced from the source comment.

## This is the last instance of the mis-keying family

Fourth after #4909 (`stoppedAt`), #7340 (`activeAgents`) and #7402 (`isPlanPending`). Every remaining `updateActiveSession` call in both handlers was audited:

| Site | Why it's correct |
|---|---|
| `server_error`, `stream_end` | the deliberate fallback branch of a target-keyed `if/else` |
| `server_status`, `append_memory_result`, `client_joined`, `client_left`, `web_task_error` | the message type carries no `sessionId` on the wire (verified against the Zod schemas in `packages/protocol`) |

There is no third copy of the sweep — store-core only references it in comments, four of which this PR corrects (they still described it as blanket-stamping the *active* session, and they are the canonical justification for `isPermissionDecision` existing, so a reader taking them at face value could conclude the #7380 guard was unnecessary).

## Proof the tests can fail

Seven tests per client, four mutations, **identical results on both clients**:

| Mutation | Failed | Which tests |
|---|---|---|
| keying reverted to `updateActiveSession` | 2 | keying guard + vanished-session |
| predicate reverted to the liveness check | 1 | the no-`expiresAt` case |
| permission exclusion removed entirely | 2 | both live-prompt cases |
| sweep deleted outright | 3 | the three stamping cases |

Each mutation is caught by exactly the test named after it, and no other.

Two deliberate test-design points:

- **The keying guard uses *historical* prompt fixtures on both sides.** With a live prompt in the active session it would pass with the keying reverted — the permission exclusion would protect it — and would therefore pin nothing. Correct keying is the only thing protecting the active session in that case.
- **Positive controls on every negative assertion.** The live-prompt tests assert `isLivePermissionPrompt` is *true* before dispatching; the no-`expiresAt` test asserts the fixture has a `requestId` and that `isLivePermissionPrompt` is *false* for it — i.e. the test states the exact gap it closes. A malformed fixture fails loudly instead of satisfying the assertion for free (#7409's lesson).

One test — "a background session's replay-end does not resolve the active session's LIVE prompt" — is protected by both mechanisms and cannot go red under any single mutation. It is a **scenario** test pinning the user-visible regression, not a guard, and its comment says so.

## Verification

| Package | Tests | Typecheck |
|---|---|---|
| `packages/app` | 211 passed (was 204) | `tsc --noEmit` clean |
| `packages/dashboard` | 306 passed (was 299) | clean |
| `packages/store-core` | 2174 passed | clean |

Note: the app's `message-handler.test.ts` prints "Jest did not exit one second after the test run has completed". That is **pre-existing** — the pristine `origin/main` file reproduces it at 204/204 — and is not introduced here.

Closes #7410