### PR TITLE
feat(dashboard): prefill the composer with the session's verified CI status

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -43,6 +43,7 @@ import { SessionBar, type SessionTabData, type SessionStatus } from './component
 import { formatTranscript } from './lib/transcript'
 import { extractRowSearchText } from './lib/transcriptSearch'
 import { runQueuedEdit } from './lib/edit-queued'
+import { runCiPrefill } from './lib/ci-prefill'
 import { inputBarBusyProps } from './lib/session-busy'
 import { ActivityIndicator, findInFlightToolUse } from './components/ActivityIndicator'
 import { CheckInChip } from './components/CheckInChip'
@@ -1636,6 +1637,26 @@ export function App() {
     [sendCancelQueued, activeSessionId, addInfoNotification],
   )
 
+  // #7423 — stage the session's verified CI status as a composer line. The
+  // decision logic (format + draft-clobber guard) lives in `runCiPrefill`; this
+  // supplies the same effects `onEditQueued` does, and deliberately shares its
+  // refusal shape. It NEVER sends: the user presses Enter, which is the whole
+  // point — #7426 already tells the agent unprompted when it witnessed the run
+  // settle, and this is the path for every case it structurally cannot cover
+  // (a run it never saw pending, a non-claude-tui session, a busy session whose
+  // wake was dropped, or simply asking a second time).
+  const handlePrefillSessionPrStatus = useCallback(() => {
+    runCiPrefill(sessionPrStatus, {
+      getDraft: () =>
+        (activeSessionId ? inputDraftsRef.current.get(activeSessionId) : '') ?? '',
+      setDraft: (next) => {
+        setInputDraftValue(next)
+        if (activeSessionId) inputDraftsRef.current.set(activeSessionId, next)
+      },
+      notify: addInfoNotification,
+    })
+  }, [sessionPrStatus, activeSessionId, addInfoNotification])
+
   // Per-session collapsed-paste storage (#3797). Each composer paste that
   // crosses the size threshold is stashed by id; the textarea sees only
   // the marker. Mirrors the draft-text per-session storage so switching
@@ -2341,6 +2362,7 @@ export function App() {
         sessionPrStatus={sessionPrStatus}
         sessionPrStatusLoading={sessionPrStatusLoading}
         onRefreshSessionPrStatus={refreshSessionPrStatus}
+        onPrefillSessionPrStatus={handlePrefillSessionPrStatus}
       />
 
       {/* Sidebar */}

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -1597,6 +1597,11 @@ export function App() {
   // be added to `evictSessionComposerState()` so the `sessions[]`
   // reconciliation effect can clean it up on server-driven removal.
   const inputDraftsRef = useRef<Map<string, string>>(new Map())
+  // #7423 — the EXACT text the CI prefill last staged per session. Its only job
+  // is to let a second prefill click refresh a line the user has not touched;
+  // any edit makes the draft theirs and the action refuses again. Per-session,
+  // so it obeys the #3977 reconciliation invariant below.
+  const ciPrefillStagedRef = useRef<Map<string, string>>(new Map())
   const [inputDraftValue, setInputDraftValue] = useState('')
   const handleDraftChange = useCallback((text: string) => {
     setInputDraftValue(text)
@@ -1649,9 +1654,14 @@ export function App() {
     runCiPrefill(sessionPrStatus, {
       getDraft: () =>
         (activeSessionId ? inputDraftsRef.current.get(activeSessionId) : '') ?? '',
+      getLastStaged: () =>
+        (activeSessionId ? ciPrefillStagedRef.current.get(activeSessionId) : null) ?? null,
       setDraft: (next) => {
         setInputDraftValue(next)
-        if (activeSessionId) inputDraftsRef.current.set(activeSessionId, next)
+        if (activeSessionId) {
+          inputDraftsRef.current.set(activeSessionId, next)
+          ciPrefillStagedRef.current.set(activeSessionId, next)
+        }
       },
       notify: addInfoNotification,
     })
@@ -1681,6 +1691,7 @@ export function App() {
     inputDraftsRef.current.delete(sessionId)
     pastedTextBlocksRef.current.delete(sessionId)
     pastedTextNextIdRef.current.delete(sessionId)
+    ciPrefillStagedRef.current.delete(sessionId)
   }
 
   // #3977: reconcile per-session composer refs against the live `sessions[]`
@@ -1714,6 +1725,11 @@ export function App() {
       if (!liveIds.has(id)) evictSessionComposerState(id)
     }
     for (const id of pastedTextNextIdRef.current.keys()) {
+      if (!liveIds.has(id)) evictSessionComposerState(id)
+    }
+    // #7423: sending clears the draft entry while this ref still holds the text
+    // that was sent, so it can outlive its draft and needs its own pass too.
+    for (const id of ciPrefillStagedRef.current.keys()) {
       if (!liveIds.has(id)) evictSessionComposerState(id)
     }
   }, [sessions])

--- a/packages/dashboard/src/components/AppHeader.tsx
+++ b/packages/dashboard/src/components/AppHeader.tsx
@@ -108,6 +108,9 @@ export interface AppHeaderProps {
   sessionPrStatus: ServerSessionPrStatusMessage | null
   sessionPrStatusLoading?: boolean
   onRefreshSessionPrStatus: () => void
+  // #7423 — stage the snapshot as a status line in the composer. PREFILL
+  // ONLY; the user presses Enter. Optional so the chip is usable without it.
+  onPrefillSessionPrStatus?: () => void
 }
 
 export function AppHeader(props: AppHeaderProps) {
@@ -212,6 +215,7 @@ export function AppHeader(props: AppHeaderProps) {
           status={props.sessionPrStatus}
           loading={props.sessionPrStatusLoading}
           onRefresh={props.onRefreshSessionPrStatus}
+          onPrefill={props.onPrefillSessionPrStatus}
         />
         {/* #4890 — Slack-style intervention notifications widget. Bell
             with unread badge → dropdown listing every intervention alert

--- a/packages/dashboard/src/components/SessionCiChip.test.tsx
+++ b/packages/dashboard/src/components/SessionCiChip.test.tsx
@@ -176,4 +176,42 @@ describe('SessionCiChip', () => {
     render(<SessionCiChip status={null} loading onRefresh={vi.fn()} />)
     expect(screen.getByTestId('session-ci-chip')).toBeTruthy()
   })
+
+  // #7423 — the prefill action. Its formatting and its refusal logic live in
+  // `lib/ci-prefill`; what the chip owns is WHEN the affordance is offered.
+  it('offers the prefill action for every check state that has a PR, not just green', () => {
+    for (const checks of [
+      { state: 'success', counts: { total: 21, passed: 21, failed: 0, pending: 0, skipped: 0, unknown: 0 } },
+      { state: 'failure', counts: { total: 3, passed: 0, failed: 3, pending: 0, skipped: 0, unknown: 0 } },
+      { state: 'pending', counts: { total: 3, passed: 1, failed: 0, pending: 2, skipped: 0, unknown: 0 } },
+      { state: 'none', counts: { total: 0, passed: 0, failed: 0, pending: 0, skipped: 0, unknown: 0 } },
+    ] as ServerSessionPrStatusMessage['checks'][]) {
+      const { unmount } = render(<SessionCiChip status={status({ checks })} onRefresh={vi.fn()} onPrefill={vi.fn()} />)
+      expect(screen.queryByTestId('session-ci-chip-prefill')).toBeTruthy()
+      unmount()
+    }
+  })
+
+  it('calls onPrefill on click', () => {
+    const onPrefill = vi.fn()
+    render(<SessionCiChip status={status()} onRefresh={vi.fn()} onPrefill={onPrefill} />)
+    fireEvent.click(screen.getByTestId('session-ci-chip-prefill'))
+    expect(onPrefill).toHaveBeenCalledTimes(1)
+  })
+
+  it('withholds the prefill action when there is no PR to describe', () => {
+    // Both pr:null branches — the quiet negative and cannot-determine. Neither
+    // is verified state worth handing an agent.
+    const { unmount } = render(<SessionCiChip status={status({ pr: null, checks: null, merge: null, reason: null })} onRefresh={vi.fn()} onPrefill={vi.fn()} />)
+    expect(screen.queryByTestId('session-ci-chip-prefill')).toBeNull()
+    unmount()
+
+    render(<SessionCiChip status={status({ pr: null, checks: null, merge: null, reason: 'gh not found' })} onRefresh={vi.fn()} onPrefill={vi.fn()} />)
+    expect(screen.queryByTestId('session-ci-chip-prefill')).toBeNull()
+  })
+
+  it('omits the action entirely when no handler is supplied', () => {
+    render(<SessionCiChip status={status()} onRefresh={vi.fn()} />)
+    expect(screen.queryByTestId('session-ci-chip-prefill')).toBeNull()
+  })
 })

--- a/packages/dashboard/src/components/SessionCiChip.tsx
+++ b/packages/dashboard/src/components/SessionCiChip.tsx
@@ -37,6 +37,13 @@ export interface SessionCiChipProps {
   loading?: boolean
   /** Re-request the snapshot. */
   onRefresh: () => void
+  /**
+   * Stage this snapshot as a status line in the composer (#7423). PREFILL ONLY —
+   * the user presses Enter. Omit it and the action is not offered; it is also
+   * withheld whenever there is no PR, because "no open PR" is not verified state
+   * worth handing an agent.
+   */
+  onPrefill?: () => void
 }
 
 /** Visual severity, which is NOT the same question as "is it settled". */
@@ -109,7 +116,7 @@ export function formatMergeState(merge: ServerSessionPrStatusMessage['merge']): 
   return `merge: ${status.toLowerCase()}`
 }
 
-export function SessionCiChip({ status, loading = false, onRefresh }: SessionCiChipProps) {
+export function SessionCiChip({ status, loading = false, onRefresh, onPrefill }: SessionCiChipProps) {
   const refresh = (
     <button
       type="button"
@@ -198,6 +205,21 @@ export function SessionCiChip({ status, loading = false, onRefresh }: SessionCiC
         <span className="session-ci-chip__merge" data-testid="session-ci-chip-merge">
           {mergeLabel}
         </span>
+      )}
+      {onPrefill && (
+        // Offered for EVERY state that has a PR — a failing or pending run is
+        // exactly what a user most wants to hand the agent, so this must not be
+        // gated on the tone.
+        <button
+          type="button"
+          className="session-ci-chip__prefill"
+          data-testid="session-ci-chip-prefill"
+          onClick={onPrefill}
+          aria-label="Insert this CI status into the message box"
+          title="Insert this CI status into the message box (does not send)"
+        >
+          {'↳'}
+        </button>
       )}
       {refresh}
     </span>

--- a/packages/dashboard/src/lib/ci-prefill-wiring.test.ts
+++ b/packages/dashboard/src/lib/ci-prefill-wiring.test.ts
@@ -1,0 +1,112 @@
+/**
+ * #7423 — the CI prefill must actually be WIRED, not merely implemented.
+ *
+ * `onPrefill` is optional on `SessionCiChipProps` and `onPrefillSessionPrStatus`
+ * is optional on `AppHeaderProps` — deliberately, so the chip is usable without
+ * the action. The cost of that is that deleting either wiring line **type-checks
+ * and leaves the whole suite green while the button silently disappears**: the
+ * chip renders, every unit test that passes `onPrefill` directly still passes,
+ * and nothing observes the App-level composition. That is the "a guard wired to
+ * only some of its callers" shape in `docs/false-safety-guards.md` — correct for
+ * every input it sees, never reached by the real one.
+ *
+ * So this file pins the composition itself, in the same spirit as
+ * `input-bar-busy-wiring.test.ts` (#7378) and `hooks/notificationPermissionWiring.test.ts`.
+ *
+ * ANCHORED, not a file-wide grep. Each assertion slices the region it cares
+ * about — the `<SessionCiChip …>` element in AppHeader, the `<AppHeader …>`
+ * element in App.tsx, the `runCiPrefill` call's effects bag — and asserts within
+ * it. A whole-file search for `onPrefill` would be satisfiable by the prop
+ * declaration alone, which is exactly the line that survives deleting the wiring.
+ *
+ * Every assertion collapses to a boolean before comparing, never
+ * `expect(src).toMatch(...)`: a failing match against a 2,400-line source file
+ * carries the entire file as the error payload, which has wedged the runner
+ * elsewhere in this repo (#7340).
+ */
+import { describe, it, expect } from 'vitest'
+import { existsSync, readFileSync } from 'node:fs'
+import path from 'node:path'
+
+// Resolved RELATIVE TO THIS FILE, matching the package's other source-level
+// wiring guards. `process.cwd()` would make the guard depend on where the runner
+// was invoked from.
+const APP_TSX = path.resolve(__dirname, '..', 'App.tsx')
+const APP_HEADER_TSX = path.resolve(__dirname, '..', 'components', 'AppHeader.tsx')
+
+function read(file: string): string {
+  expect(existsSync(file), `${file} should exist`).toBe(true)
+  return readFileSync(file, 'utf8')
+}
+
+/**
+ * The text of the first JSX element opening with `<${tag}`, up to its closing
+ * `/>`. Returns null when the element is absent — which the callers assert on,
+ * so a renamed component fails loudly instead of scanning an empty string and
+ * passing.
+ */
+function jsxElement(src: string, tag: string): string | null {
+  const start = src.indexOf(`<${tag}`)
+  if (start === -1) return null
+  const end = src.indexOf('/>', start)
+  if (end === -1) return null
+  return src.slice(start, end + 2)
+}
+
+describe('#7423 CI prefill wiring', () => {
+  it('AppHeader passes onPrefill to SessionCiChip', () => {
+    const element = jsxElement(read(APP_HEADER_TSX), 'SessionCiChip')
+    expect(element, 'AppHeader should render a <SessionCiChip … /> element').not.toBeNull()
+    expect(element!.includes('onPrefill={props.onPrefillSessionPrStatus}')).toBe(true)
+  })
+
+  it('positive control: the slice is the element, not the whole file', () => {
+    // If `jsxElement` ever returned the entire source, the assertion above would
+    // pass on the prop DECLARATION alone — the one line that survives deleting
+    // the wiring. Pin that it does not reach the declaration.
+    const element = jsxElement(read(APP_HEADER_TSX), 'SessionCiChip')!
+    expect(element.includes('onPrefillSessionPrStatus?: () => void')).toBe(false)
+    expect(element.length).toBeLessThan(600)
+  })
+
+  it('App.tsx passes a handler to AppHeader', () => {
+    const element = jsxElement(read(APP_TSX), 'AppHeader')
+    expect(element, 'App.tsx should render an <AppHeader … /> element').not.toBeNull()
+    expect(element!.includes('onPrefillSessionPrStatus={handlePrefillSessionPrStatus}')).toBe(true)
+  })
+
+  it('the handler calls runCiPrefill with every effect the helper needs', () => {
+    const src = read(APP_TSX)
+    const start = src.indexOf('const handlePrefillSessionPrStatus')
+    expect(start, 'App.tsx should define handlePrefillSessionPrStatus').toBeGreaterThan(-1)
+    // Bounded by the next top-level `const`-with-comment boundary rather than
+    // the file end, so the assertions below cannot be satisfied by an unrelated
+    // callback further down.
+    const body = src.slice(start, start + 900)
+
+    // The helper is CALLED — a handler that formatted the line itself would
+    // bypass the draft-clobber guard entirely.
+    expect(body.includes('runCiPrefill(sessionPrStatus, {')).toBe(true)
+    // Both halves of the draft write. Dropping the ref write leaves the staged
+    // text invisible to the session-switch restore effect, so switching tabs and
+    // back would silently discard it.
+    expect(body.includes('inputDraftsRef.current.set(activeSessionId, next)')).toBe(true)
+    expect(body.includes('setInputDraftValue(next)')).toBe(true)
+    // The stale-line refresh path. Without `getLastStaged` every second click
+    // refuses, and the composer keeps a reading the chip has superseded.
+    expect(body.includes('getLastStaged:')).toBe(true)
+    expect(body.includes('ciPrefillStagedRef.current.set(activeSessionId, next)')).toBe(true)
+    // The refusal has to reach the user; a silent no-op reads as a broken button.
+    expect(body.includes('notify: addInfoNotification')).toBe(true)
+  })
+
+  it('the staged-line ref obeys the #3977 per-session eviction invariant', () => {
+    const src = read(APP_TSX)
+    const start = src.indexOf('const evictSessionComposerState')
+    expect(start, 'App.tsx should define evictSessionComposerState').toBeGreaterThan(-1)
+    const body = src.slice(start, src.indexOf('}', start) + 1)
+    // Unbounded growth over a long-lived dashboard process is the failure this
+    // invariant exists to prevent.
+    expect(body.includes('ciPrefillStagedRef.current.delete(sessionId)')).toBe(true)
+  })
+})

--- a/packages/dashboard/src/lib/ci-prefill.test.ts
+++ b/packages/dashboard/src/lib/ci-prefill.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, vi } from 'vitest'
+import { formatCiPrefill, runCiPrefill, CI_PREFILL_BUSY_NOTICE } from './ci-prefill'
+import type { ServerSessionPrStatusMessage } from '@chroxy/protocol'
+
+/**
+ * #7423 — the composer prefill line.
+ *
+ * The line is read by a MODEL that will act on it, so the assertions that carry
+ * weight are the negative ones: it must not say "green" for a run still going,
+ * must not omit the merge state beside a green one, and must not imply
+ * readiness. Every negative is paired with a positive control, because a
+ * formatter that returned the empty string would otherwise pass all of them.
+ */
+
+function status(overrides: Partial<ServerSessionPrStatusMessage> = {}): ServerSessionPrStatusMessage {
+  return {
+    type: 'session_pr_status',
+    requestId: null,
+    sessionId: 's1',
+    generatedAt: '2026-08-27T00:00:00.000Z',
+    branch: 'feat/x',
+    repo: { owner: 'blamechris', name: 'chroxy' },
+    pr: { number: 7423, title: 'feat: x', url: 'https://github.com/blamechris/chroxy/pull/7423', headRefOid: '5fff69ab1c2d3e4', isDraft: false },
+    checks: { state: 'success', counts: { total: 21, passed: 21, failed: 0, pending: 0, skipped: 0, unknown: 0 } },
+    merge: { mergeable: 'MERGEABLE', mergeStateStatus: 'CLEAN', reviewDecision: 'APPROVED' },
+    reason: null,
+    ...overrides,
+  } as ServerSessionPrStatusMessage
+}
+
+/**
+ * Words that would let a reader (or a model) conclude the PR can be merged.
+ * The whole feature exists because 21/21 green sat beside `BLOCKED`.
+ */
+const READINESS_WORDS = /\b(ready|mergeable|good to go|safe to merge|all clear|looks good)\b/i
+
+describe('formatCiPrefill — what the line must never say', () => {
+  it('does not call a still-running rollup green', () => {
+    const text = formatCiPrefill(status({
+      checks: { state: 'pending', counts: { total: 21, passed: 12, failed: 0, pending: 9, skipped: 0, unknown: 0 } },
+    }))
+    expect(text).not.toMatch(/green/i)
+    // Positive control: it still produced a line, and still named the pending run.
+    expect(text).toContain('checks still running')
+    expect(text).toContain('9 pending')
+  })
+
+  it('reports check state and merge state as separate facts when they diverge', () => {
+    // The motivating case: everything green, merge BLOCKED on a review thread.
+    const text = formatCiPrefill(status({
+      merge: { mergeable: 'MERGEABLE', mergeStateStatus: 'BLOCKED', reviewDecision: 'REVIEW_REQUIRED' },
+    })) as string
+    expect(text).toContain('checks green')
+    expect(text).toContain('merge state BLOCKED')
+    expect(text).not.toMatch(READINESS_WORDS)
+  })
+
+  it('positive control: READINESS_WORDS can actually match, so the assertion above is not free', () => {
+    expect('the PR is ready to merge').toMatch(READINESS_WORDS)
+  })
+
+  it('renders "no checks ran" for state none rather than omitting the clause', () => {
+    // An absent check clause beside a PR number reads as nothing-to-report, and
+    // `none` is emphatically not a pass.
+    const text = formatCiPrefill(status({
+      checks: { state: 'none', counts: { total: 0, passed: 0, failed: 0, pending: 0, skipped: 0, unknown: 0 } },
+    })) as string
+    expect(text).toContain('no checks ran on 5fff69a —')
+    expect(text).not.toMatch(/green|passed/i)
+  })
+
+  it('never omits the merge clause, even when the merge state is null', () => {
+    const text = formatCiPrefill(status({
+      merge: { mergeable: null, mergeStateStatus: null, reviewDecision: null },
+    })) as string
+    expect(text).toContain('merge state unknown')
+    // The optional clauses are OMITTED, not rendered empty — 'review null' in a
+    // prompt line is worse than no review clause at all.
+    expect(text).not.toContain('review')
+  })
+
+  it('still renders a line, and no green, when the checks block itself is absent', () => {
+    const text = formatCiPrefill(status({ checks: null })) as string
+    expect(text).toContain('check state unavailable')
+    expect(text).toContain('merge state CLEAN')
+    expect(text).not.toMatch(/green|passed/i)
+  })
+
+  it('spells out that UNKNOWN means recomputing, not unblocked', () => {
+    const text = formatCiPrefill(status({
+      merge: { mergeable: null, mergeStateStatus: 'UNKNOWN', reviewDecision: null },
+    })) as string
+    expect(text).toContain('merge state UNKNOWN (GitHub is still recomputing)')
+  })
+})
+
+describe('formatCiPrefill — the cases the user most needs to relay', () => {
+  it('positive control: a FAILING run prefills too', () => {
+    // A prefill that only armed on green would pass every negative test above
+    // while silently dropping the case with the most urgency.
+    const text = formatCiPrefill(status({
+      checks: { state: 'failure', counts: { total: 21, passed: 18, failed: 3, pending: 0, skipped: 0, unknown: 0 } },
+      merge: { mergeable: 'CONFLICTING', mergeStateStatus: 'DIRTY', reviewDecision: null },
+    })) as string
+    expect(text).toContain('checks failing')
+    expect(text).toContain('3 failed')
+    expect(text).toContain('merge state DIRTY')
+  })
+
+  it('names the head SHA the verdict describes', () => {
+    expect(formatCiPrefill(status())).toContain('PR #7423 (head 5fff69a)')
+  })
+
+  it('drops the head clause rather than printing a fake SHA when there is none', () => {
+    const text = formatCiPrefill(status({
+      pr: { number: 7423, title: null, url: null, headRefOid: null, isDraft: false },
+    })) as string
+    expect(text).toContain('PR #7423:')
+    expect(text).not.toContain('head ')
+  })
+
+  it('carries the review decision and the draft flag when present', () => {
+    const text = formatCiPrefill(status({
+      pr: { number: 7423, title: null, url: null, headRefOid: 'abc1234def', isDraft: true },
+      merge: { mergeable: null, mergeStateStatus: 'BLOCKED', reviewDecision: 'CHANGES_REQUESTED' },
+    })) as string
+    expect(text).toContain('review CHANGES_REQUESTED')
+    expect(text).toContain('PR is a draft')
+  })
+
+  it('surfaces a partial reading in the line itself, not only in a tooltip', () => {
+    const text = formatCiPrefill(status({ reason: 'gh rate limit exceeded' })) as string
+    expect(text).toContain('note: gh rate limit exceeded')
+  })
+
+  it('keeps the unrecognised bucket visible', () => {
+    const text = formatCiPrefill(status({
+      checks: { state: 'unknown', counts: { total: 5, passed: 2, failed: 0, pending: 0, skipped: 0, unknown: 3 } },
+    })) as string
+    expect(text).toContain('3 unrecognised')
+    expect(text).toContain('check state unrecognised')
+  })
+
+  it('omits the unrecognised clause when there is nothing unrecognised', () => {
+    expect(formatCiPrefill(status())).not.toContain('unrecognised')
+  })
+
+  it('omits the draft and note clauses when they do not apply', () => {
+    const text = formatCiPrefill(status()) as string
+    expect(text).not.toContain('draft')
+    expect(text).not.toContain('note:')
+  })
+
+  it('returns null when there is no verified state to relay', () => {
+    expect(formatCiPrefill(null)).toBeNull()
+    // The quiet negative (no open PR) and cannot-determine both yield nothing:
+    // "this branch has no open PR" is not state worth handing an agent.
+    expect(formatCiPrefill(status({ pr: null, checks: null, merge: null }))).toBeNull()
+    expect(formatCiPrefill(status({ pr: null, checks: null, merge: null, reason: 'gh not found' }))).toBeNull()
+  })
+})
+
+describe('runCiPrefill', () => {
+  function effects(draft = '') {
+    return {
+      getDraft: vi.fn(() => draft),
+      setDraft: vi.fn(),
+      notify: vi.fn(),
+      focusComposer: vi.fn(),
+    }
+  }
+
+  it('stages the line in the composer and never sends it', () => {
+    const fx = effects()
+    const staged = runCiPrefill(status(), fx)
+    expect(staged).not.toBeNull()
+    expect(fx.setDraft).toHaveBeenCalledTimes(1)
+    expect(fx.setDraft).toHaveBeenCalledWith(staged)
+    expect(fx.focusComposer).toHaveBeenCalledTimes(1)
+    expect(fx.notify).not.toHaveBeenCalled()
+  })
+
+  it('refuses rather than clobbering an in-progress draft', () => {
+    const fx = effects('half a thought about the refactor')
+    expect(runCiPrefill(status(), fx)).toBeNull()
+    expect(fx.setDraft).not.toHaveBeenCalled()
+    expect(fx.notify).toHaveBeenCalledWith(CI_PREFILL_BUSY_NOTICE)
+  })
+
+  it('treats a whitespace-only draft as empty', () => {
+    const fx = effects('   \n  ')
+    expect(runCiPrefill(status(), fx)).not.toBeNull()
+    expect(fx.setDraft).toHaveBeenCalledTimes(1)
+    expect(fx.notify).not.toHaveBeenCalled()
+  })
+
+  it('does nothing at all — not even a notice — when there is no PR', () => {
+    const fx = effects()
+    expect(runCiPrefill(status({ pr: null, checks: null, merge: null }), fx)).toBeNull()
+    expect(fx.setDraft).not.toHaveBeenCalled()
+    expect(fx.notify).not.toHaveBeenCalled()
+  })
+
+  it('checks the draft only after it has a line to stage', () => {
+    // Order matters: a no-PR click must not produce the busy notice just
+    // because the user happened to be typing.
+    const fx = effects('typing')
+    runCiPrefill(status({ pr: null, checks: null, merge: null }), fx)
+    expect(fx.notify).not.toHaveBeenCalled()
+  })
+})

--- a/packages/dashboard/src/lib/ci-prefill.test.ts
+++ b/packages/dashboard/src/lib/ci-prefill.test.ts
@@ -108,14 +108,14 @@ describe('formatCiPrefill — the cases the user most needs to relay', () => {
   })
 
   it('names the head SHA the verdict describes', () => {
-    expect(formatCiPrefill(status())).toContain('PR #7423 (head 5fff69a)')
+    expect(formatCiPrefill(status())).toContain('PR #7423 (head 5fff69a) as of')
   })
 
   it('drops the head clause rather than printing a fake SHA when there is none', () => {
     const text = formatCiPrefill(status({
       pr: { number: 7423, title: null, url: null, headRefOid: null, isDraft: false },
     })) as string
-    expect(text).toContain('PR #7423:')
+    expect(text).toContain('PR #7423 as of')
     expect(text).not.toContain('head ')
   })
 
@@ -149,6 +149,22 @@ describe('formatCiPrefill — the cases the user most needs to relay', () => {
     const text = formatCiPrefill(status()) as string
     expect(text).not.toContain('draft')
     expect(text).not.toContain('note:')
+  })
+
+  it('says WHEN the reading was taken, so a stale snapshot cannot pass as current', () => {
+    // The snapshot only refreshes on a session switch, a reconnect, or the
+    // chip's Refresh — nothing pushes it. A tab left open holds an old rollup,
+    // and this line states it in the present tense to a model that will act on
+    // it, so the timestamp is the only thing making the staleness visible.
+    const text = formatCiPrefill(status({ generatedAt: '2026-08-27T00:00:00.000Z' })) as string
+    expect(text).toContain('as of 2026-08-27T00:00:00.000Z')
+  })
+
+  it('omits the "as of" clause rather than inventing a time it does not have', () => {
+    const text = formatCiPrefill(status({ generatedAt: '' })) as string
+    expect(text).not.toContain('as of')
+    // Positive control: the rest of the line is unaffected.
+    expect(text).toContain('checks green')
   })
 
   it('returns null when there is no verified state to relay', () => {
@@ -192,6 +208,43 @@ describe('runCiPrefill', () => {
     expect(runCiPrefill(status(), fx)).not.toBeNull()
     expect(fx.setDraft).toHaveBeenCalledTimes(1)
     expect(fx.notify).not.toHaveBeenCalled()
+  })
+
+  it('refreshes a line it staged itself, so the composer cannot disagree with the chip', () => {
+    // The sharp case: prefill, hit Refresh (the chip flips pending -> failure),
+    // click prefill again. Refusing there leaves the SUPERSEDED line in the
+    // composer, and that is what gets sent.
+    const first = formatCiPrefill(status({
+      checks: { state: 'pending', counts: { total: 3, passed: 1, failed: 0, pending: 2, skipped: 0, unknown: 0 } },
+    })) as string
+    const fx = { ...effects(first), getLastStaged: vi.fn(() => first) }
+    const second = runCiPrefill(status({
+      checks: { state: 'failure', counts: { total: 3, passed: 1, failed: 2, pending: 0, skipped: 0, unknown: 0 } },
+    }), fx)
+    expect(second).not.toBeNull()
+    expect(second).not.toBe(first)
+    expect(fx.setDraft).toHaveBeenCalledWith(second)
+    expect(fx.notify).not.toHaveBeenCalled()
+  })
+
+  it('still refuses once the user has EDITED the line it staged', () => {
+    // Exact equality, never a prefix or shape match: an appended question makes
+    // the draft theirs, and theirs is never overwritten.
+    const staged = formatCiPrefill(status()) as string
+    const fx = {
+      ...effects(staged + ' — can you look at the failure?'),
+      getLastStaged: vi.fn(() => staged),
+    }
+    expect(runCiPrefill(status(), fx)).toBeNull()
+    expect(fx.setDraft).not.toHaveBeenCalled()
+    expect(fx.notify).toHaveBeenCalledWith(CI_PREFILL_BUSY_NOTICE)
+  })
+
+  it('refuses a non-empty draft when no getLastStaged is supplied at all', () => {
+    // The effect is optional; omitting it must fail CLOSED, never open.
+    const fx = effects('something the user typed')
+    expect(runCiPrefill(status(), fx)).toBeNull()
+    expect(fx.notify).toHaveBeenCalledWith(CI_PREFILL_BUSY_NOTICE)
   })
 
   it('does nothing at all — not even a notice — when there is no PR', () => {

--- a/packages/dashboard/src/lib/ci-prefill.ts
+++ b/packages/dashboard/src/lib/ci-prefill.ts
@@ -54,6 +54,9 @@ import type { ServerSessionPrStatusMessage } from '@chroxy/protocol'
 /** Short SHA length, matching the chip's tooltip. */
 const SHA_CHARS = 7
 
+/** The line's opening words — the single place the subject is spelled. */
+export const CI_PREFILL_PREFIX = 'CI status for PR #'
+
 /**
  * The notice shown when the composer already holds a draft. Same fail-shape as
  * `EDIT_QUEUED_BUSY_NOTICE`: refuse rather than clobber, and say so.
@@ -134,21 +137,49 @@ function mergeClause(merge: ServerSessionPrStatusMessage['merge']): string {
 export function formatCiPrefill(status: ServerSessionPrStatusMessage | null): string | null {
   if (!status || !status.pr) return null
   const sha = shortSha(status.pr.headRefOid)
-  const subject = sha === null ? `PR #${status.pr.number}` : `PR #${status.pr.number} (head ${sha})`
+  // Everything after CI_PREFILL_PREFIX, which already carries the "PR #".
+  const head = sha === null ? `${status.pr.number}` : `${status.pr.number} (head ${sha})`
+  // WHEN the reading was taken, always. The snapshot refreshes on a session
+  // switch, a reconnect, or the chip's Refresh — nothing pushes it — so a tab
+  // left open for half an hour holds a half-hour-old rollup, and this line
+  // states it in the present tense to a model that will act on it. Without the
+  // timestamp the staleness is invisible in exactly the artefact that leaves
+  // the dashboard. `generatedAt` is passed through verbatim rather than
+  // rendered relative: no `Date` parsing in a pure formatter, and a UTC instant
+  // is unambiguous to both readers.
+  const readAt = typeof status.generatedAt === 'string' && status.generatedAt.length > 0
+    ? status.generatedAt
+    : null
+  const subject = readAt === null ? head : `${head} as of ${readAt}`
   const clauses = [checksClause(status.checks, sha), mergeClause(status.merge)]
   const reviewDecision = status.merge?.reviewDecision
   if (reviewDecision) clauses.push(`review ${reviewDecision}`)
   if (status.pr.isDraft) clauses.push('PR is a draft')
-  // A partial reading says so. The chip carries it in a tooltip; a prompt line
-  // has nowhere to hide it, and a caveat the model cannot see is a caveat that
-  // did not happen.
+  // A partial reading says so: the chip can hide a caveat in a tooltip, a prompt
+  // line cannot, and a caveat the model never sees is a caveat that did not
+  // happen.
+  //
+  // UNREACHABLE against today's server, deliberately kept. Every
+  // `snapshot.reason = ...` path in `session-pr-status.js` leaves `pr` null, and
+  // this function returns before here in that case — so no current daemon can
+  // produce a `pr` + `reason` snapshot, and the test below covers a state the
+  // server does not emit. It stays because the SCHEMA permits the pairing
+  // (`reason` is independent of `pr`) and a dashboard talks to daemons it did
+  // not ship with; dropping a partial-reading caveat on the floor is the worse
+  // failure. Labelled rather than silently believed to be live coverage.
   if (status.reason) clauses.push(`note: ${status.reason}`)
-  return `CI status for ${subject}: ${clauses.join(' — ')}`
+  return `${CI_PREFILL_PREFIX}${subject}: ${clauses.join(' — ')}`
 }
 
 export interface CiPrefillEffects {
   /** Current composer draft text (untrimmed). */
   getDraft: () => string
+  /**
+   * The EXACT text this helper last staged for this session, or null. Supplying
+   * it lets a second click refresh a line the user has not touched; omitting it
+   * makes every non-empty draft a refusal, which is the safe default.
+   */
+  getLastStaged?: () => string | null
   /** Stage `text` in the composer. Never sends. */
   setDraft: (text: string) => void
   /** Surface a non-blocking notice (the draft-would-be-clobbered guard). */
@@ -170,9 +201,17 @@ export function runCiPrefill(
 ): string | null {
   const text = formatCiPrefill(status)
   if (text === null) return null
+  const draft = fx.getDraft()
   // Guard: never clobber an in-progress draft. #7423 is explicit that the
   // composer keeps what the user typed, or the action is refused.
-  if (fx.getDraft().trim().length > 0) {
+  //
+  // The ONE exception is a line this helper staged and the user has not since
+  // edited: refusing there leaves the composer holding a reading the chip has
+  // already superseded, and the stale line is what gets sent. The test is exact
+  // equality against the last staged text, never a prefix or shape match — a
+  // user who appended "…can you look at the failure?" has made it theirs, and
+  // that must still refuse.
+  if (draft.trim().length > 0 && draft !== fx.getLastStaged?.()) {
     fx.notify(CI_PREFILL_BUSY_NOTICE)
     return null
   }

--- a/packages/dashboard/src/lib/ci-prefill.ts
+++ b/packages/dashboard/src/lib/ci-prefill.ts
@@ -62,8 +62,12 @@ export const CI_PREFILL_BUSY_NOTICE =
   'Composer already has a draft — clear or send it before inserting the CI status.'
 
 /**
- * State word for the check clause. Never 'green' for anything but `success`,
- * and `none` is handled by the caller because it carries no useful counts.
+ * State word for the check clause. Never 'green' for anything but `success`.
+ *
+ * `none` deliberately has NO row here: `checksClause` returns before reaching
+ * this map, because a head that produced no run has no counts worth printing —
+ * and a missing row would otherwise fall through to the `??` default and label
+ * it "unrecognised", which is a different (and wrong) claim.
  */
 const CHECK_VERB: Record<string, string> = {
   pending: 'checks still running',

--- a/packages/dashboard/src/lib/ci-prefill.ts
+++ b/packages/dashboard/src/lib/ci-prefill.ts
@@ -1,0 +1,178 @@
+/**
+ * ci-prefill — turn a `session_pr_status` snapshot into one factual line, and
+ * stage it in the composer WITHOUT sending it (#7423, step 2 of #7344).
+ *
+ * ## Why this exists after #7426 already tells the agent automatically
+ *
+ * #7426's `SessionCiWatcher` fires on a pending→settled transition it observed
+ * ITSELF, and its agent half is a keystroke injection gated by `session-wake.js`.
+ * Four things follow, and each is a case where the agent is never told:
+ *
+ *   1. **A run it never saw pending never fires.** That is deliberate honesty,
+ *      not a bug — but it means a daemon restart, a session attached after CI
+ *      started, or a run that begins and ends inside one discovery interval all
+ *      leave the agent with nothing.
+ *   2. **The wake is claude-tui only.** Every other provider gets the push and
+ *      no injected line at all.
+ *   3. **A busy session drops the wake.** `_fire` consumes the arm before
+ *      waking, so a `busy` outcome is logged and never retried.
+ *   4. **It fires once per `(pr, headRefOid)`.** A user who wants to ask about
+ *      the same state a second time has no path.
+ *
+ * So this is the USER-driven path over the same reading: they are looking at the
+ * chip, they want to hand the agent what it says, and they press Enter
+ * themselves. It is not a fallback for a broken watcher — it is the half that
+ * keeps the human in the loop by construction.
+ *
+ * ## What the line must never say
+ *
+ * The same contract the chip and the schema hold, restated because a prompt line
+ * is read by a model that will act on it:
+ *
+ *   - **Check state and merge state are separate clauses.** The session that
+ *     motivated #7344 had 21/21 green while `mergeStateStatus` was `BLOCKED`.
+ *     No word in the output implies readiness, mergeability, or "done".
+ *   - **`state: 'none'` is not a green.** It renders as "no checks ran on
+ *     <sha>", never as an omitted clause — an absent clause beside a PR number
+ *     reads as nothing-to-report.
+ *   - **A failing snapshot prefills too.** A prefill that only armed on green
+ *     would pass a naive test while dropping the case the user most needs to
+ *     relay.
+ *
+ * ## Deliberately NOT included: the unresolved-thread count
+ *
+ * #7423's example line carries "0 unresolved threads", which `session_pr_status`
+ * does not have — it needs a GraphQL `reviewThreads` read. That is not paid for
+ * here: since #7426 the same survey runs on a daemon-side sweep across every
+ * session, so adding a second `gh` call to it would multiply the cost of a
+ * background poll to enrich a string that only a click builds. `reviewDecision`
+ * (already on the snapshot) carries the review state in the meantime. See the
+ * follow-on issue for the on-demand shape.
+ */
+import type { ServerSessionPrStatusMessage } from '@chroxy/protocol'
+
+/** Short SHA length, matching the chip's tooltip. */
+const SHA_CHARS = 7
+
+/**
+ * The notice shown when the composer already holds a draft. Same fail-shape as
+ * `EDIT_QUEUED_BUSY_NOTICE`: refuse rather than clobber, and say so.
+ */
+export const CI_PREFILL_BUSY_NOTICE =
+  'Composer already has a draft — clear or send it before inserting the CI status.'
+
+/**
+ * State word for the check clause. Never 'green' for anything but `success`,
+ * and `none` is handled by the caller because it carries no useful counts.
+ */
+const CHECK_VERB: Record<string, string> = {
+  pending: 'checks still running',
+  failure: 'checks failing',
+  success: 'checks green',
+  unknown: 'check state unrecognised',
+}
+
+function shortSha(headRefOid: string | null): string | null {
+  if (typeof headRefOid !== 'string' || headRefOid.length === 0) return null
+  return headRefOid.slice(0, SHA_CHARS)
+}
+
+/**
+ * The check clause. Counts are rendered in full for every state except `none`,
+ * rather than per-state selections, so no branch can silently omit the number a
+ * reader needs (the `formatChecks` lesson: a fully-skipped rollup once read as
+ * "0/5 green" because only `passed` was shown).
+ */
+function checksClause(
+  checks: ServerSessionPrStatusMessage['checks'],
+  sha: string | null,
+): string {
+  if (!checks) return 'check state unavailable'
+  const { state, counts } = checks
+  if (state === 'none') {
+    // Explicit, and never omitted: no run exists for this head. Absence of
+    // failure is not a pass.
+    return sha === null ? 'no checks ran on this head' : `no checks ran on ${sha}`
+  }
+  const verb = CHECK_VERB[state] ?? 'check state unrecognised'
+  const parts = [
+    `${counts.passed} passed`,
+    `${counts.failed} failed`,
+    `${counts.pending} pending`,
+    `${counts.skipped} skipped`,
+  ]
+  if (counts.unknown > 0) parts.push(`${counts.unknown} unrecognised`)
+  return `${verb} (${parts.join(', ')} of ${counts.total})`
+}
+
+/**
+ * The merge clause. Always rendered when there is a PR — its absence beside a
+ * green check clause is read as "nothing blocking", which is the one impression
+ * this whole feature exists to avoid giving.
+ */
+function mergeClause(merge: ServerSessionPrStatusMessage['merge']): string {
+  const status = merge?.mergeStateStatus
+  if (!status) return 'merge state unknown'
+  // GitHub reports UNKNOWN while recomputing after a base change. Passed
+  // through with the reason so it does not read as "no blocker".
+  if (status === 'UNKNOWN') return 'merge state UNKNOWN (GitHub is still recomputing)'
+  return `merge state ${status}`
+}
+
+/**
+ * Build the composer line for a snapshot.
+ *
+ * Returns `null` when there is nothing verified to relay — no snapshot, or no
+ * PR (whether that is the quiet negative or a survey that could not find out).
+ * A caller must not offer the action in that case; a line saying "this branch
+ * has no open PR" is not state worth handing an agent.
+ */
+export function formatCiPrefill(status: ServerSessionPrStatusMessage | null): string | null {
+  if (!status || !status.pr) return null
+  const sha = shortSha(status.pr.headRefOid)
+  const subject = sha === null ? `PR #${status.pr.number}` : `PR #${status.pr.number} (head ${sha})`
+  const clauses = [checksClause(status.checks, sha), mergeClause(status.merge)]
+  const reviewDecision = status.merge?.reviewDecision
+  if (reviewDecision) clauses.push(`review ${reviewDecision}`)
+  if (status.pr.isDraft) clauses.push('PR is a draft')
+  // A partial reading says so. The chip carries it in a tooltip; a prompt line
+  // has nowhere to hide it, and a caveat the model cannot see is a caveat that
+  // did not happen.
+  if (status.reason) clauses.push(`note: ${status.reason}`)
+  return `CI status for ${subject}: ${clauses.join(' — ')}`
+}
+
+export interface CiPrefillEffects {
+  /** Current composer draft text (untrimmed). */
+  getDraft: () => string
+  /** Stage `text` in the composer. Never sends. */
+  setDraft: (text: string) => void
+  /** Surface a non-blocking notice (the draft-would-be-clobbered guard). */
+  notify: (message: string) => void
+  /** Optional: focus the composer after staging. */
+  focusComposer?: () => void
+}
+
+/**
+ * Decide + apply what clicking the chip's prefill action should do.
+ *
+ * Pure control flow over injected effects, mirroring `runQueuedEdit`. Returns
+ * the staged text, or `null` when nothing was staged, so a caller (and a test)
+ * can tell "refused" from "wrote".
+ */
+export function runCiPrefill(
+  status: ServerSessionPrStatusMessage | null,
+  fx: CiPrefillEffects,
+): string | null {
+  const text = formatCiPrefill(status)
+  if (text === null) return null
+  // Guard: never clobber an in-progress draft. #7423 is explicit that the
+  // composer keeps what the user typed, or the action is refused.
+  if (fx.getDraft().trim().length > 0) {
+    fx.notify(CI_PREFILL_BUSY_NOTICE)
+    return null
+  }
+  fx.setDraft(text)
+  fx.focusComposer?.()
+  return text
+}

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -13537,6 +13537,7 @@ a.session-ci-chip__pr:focus-visible {
   padding-left: 6px;
 }
 
+.session-ci-chip__prefill,
 .session-ci-chip__refresh {
   display: inline-flex;
   align-items: center;
@@ -13554,6 +13555,8 @@ a.session-ci-chip__pr:focus-visible {
   line-height: 1;
 }
 
+.session-ci-chip__prefill:hover:not(:disabled),
+.session-ci-chip__prefill:focus-visible:not(:disabled),
 .session-ci-chip__refresh:hover:not(:disabled),
 .session-ci-chip__refresh:focus-visible:not(:disabled) {
   color: var(--text-heading);


### PR DESCRIPTION
Step 2 of #7344 — *display → prefill → automatic event*. Step 1 shipped in
#7422, step 3 in #7426.

## The question this was filed against, answered first

#7423 was filed before #7426 landed, and #7426 now hands the agent a CI-completion
line automatically, unprompted. So the first job was deciding whether this is
redundant. It is not, and the reason is structural rather than a matter of taste:
`SessionCiWatcher` fires only on a pending→settled transition **it observed
itself**, and its agent half is a claude-tui keystroke injection gated by
`session-wake.js`. The agent is therefore told nothing when —

1. **the run was never seen pending** — a daemon restart, a session attached
   mid-run, or a run that starts and finishes inside one `discoveryIntervalMs`.
   That is deliberate honesty in #7426, not a bug, and #7427 narrows it without
   closing it;
2. **the provider is not claude-tui** — every other provider gets the push and no
   injected line at all;
3. **the session was busy at fire time** — `_fire` consumes the arm *before*
   waking, so a `busy` outcome is logged and never retried;
4. **the user wants to ask a second time** — the watcher fires once per
   `(pr, headRefOid)`.

This is the user-driven path over those cases. It also does the thing #7426
cannot by design: it keeps the human in the loop by construction, because it
**never sends** — it stages the line and the user presses Enter.

## What it does

The chip gains an action (`↳`) that stages one factual line in the composer:

```
CI status for PR #7423 (head 5fff69a): checks green (21 passed, 0 failed, 0 pending, 0 skipped of 21) — merge state BLOCKED — review REVIEW_REQUIRED
```

The line holds the same contracts the chip and the schema hold, restated because
a prompt line is read by a **model that will act on it**:

- **check state and merge state are separate clauses.** The case that motivated
  #7344 had 21/21 green while `mergeStateStatus` was `BLOCKED`;
- **`state: 'none'` renders as "no checks ran on `<sha>`"**, never as an omitted
  clause — an absent check clause beside a PR number reads as nothing-to-report;
- **no word implies readiness.** Asserted against a `READINESS_WORDS` regex that
  has its own positive control, so the assertion is not free;
- **a failing or pending snapshot prefills exactly as a green one does.** A
  prefill armed only on green would pass every negative test while dropping the
  case with the most urgency;
- **optional clauses are omitted, not rendered empty** — `review null` in a
  prompt line is worse than no review clause.

The never-clobber guard mirrors `runQueuedEdit` (#6628): a non-empty draft means
**refuse and say so**, not overwrite. And a no-PR snapshot produces nothing at
all — not even the busy notice — because "this branch has no open PR" is not
verified state worth handing an agent.

## Files

| File | What |
|---|---|
| `packages/dashboard/src/lib/ci-prefill.ts` | Pure formatter + the guard, over injected effects — same shape as `lib/edit-queued.ts` |
| `SessionCiChip.tsx` | The action. Offered for every check state that **has a PR**, never gated on tone |
| `App.tsx` / `AppHeader.tsx` | Wiring through the existing per-session draft refs |
| `theme/components.css` | The control, sharing the refresh button's 44px tap-target floor |

## Deliberately not included

#7423's example line carries an unresolved-thread count. It needs a GraphQL
`reviewThreads` read, and since #7426 the same survey runs on a **daemon-side
sweep across every session** — so adding a second `gh` call there would multiply
the cost of a background poll to enrich a string only a click builds.
`reviewDecision` (already on the snapshot, already in the line) carries the
review state meanwhile. Filed as **#7430** with the on-demand shape, including
the requirement that a missing count must not render as `0`.

## Verification

**15 mutants, all red** (the whole list re-run after each change, per the #7426
lesson that adding a guard can silently un-test the one beside it):

| # | Mutation | Killed by |
|---|---|---|
| M1 | `state === 'none'` branch deleted | "renders 'no checks ran' rather than omitting the clause" |
| M2 | `!checks` guard deleted | "still renders a line, and no green, when the checks block is absent" |
| M3 | merge clause returns `''` when null | "never omits the merge clause" |
| M4 | `UNKNOWN` parenthetical dropped | "spells out that UNKNOWN means recomputing" |
| M5 | `!status \|\| !status.pr` weakened to `!status` | "returns null when there is no verified state" |
| M6 | clobber guard deleted | "refuses rather than clobbering an in-progress draft" |
| M7 | `.trim()` dropped from the guard | "treats a whitespace-only draft as empty" |
| M8 | draft checked *before* formatting | "checks the draft only after it has a line to stage" |
| M9 | unknown-count clause always shown | "omits the unrecognised clause when there is nothing unrecognised" |
| M10 | review clause always shown | "never omits the merge clause…" (absence control) |
| M11 | draft clause always shown | "omits the draft and note clauses when they do not apply" |
| M12 | note clause always shown | same |
| M13 | `SHA_CHARS` 7 → 8 | "names the head SHA the verdict describes" |
| M14 | action rendered with no handler | "omits the action entirely when no handler is supplied" |
| M15 | action gated on a green tone | "offers the prefill action for every check state that has a PR" |

Full dashboard suite: **305 files / 5324 tests pass**. Typecheck clean. Build clean.

Closes #7423