### PR TITLE
feat(server): arm the CI watcher from the dashboard's own PR survey

### DIFF
--- a/packages/server/src/handlers/session-pr-status-handlers.js
+++ b/packages/server/src/handlers/session-pr-status-handlers.js
@@ -37,6 +37,11 @@
  * someone is actually looking, so the snapshot is handed to `observe()` on the
  * way out: opening the dashboard arms the watch.
  *
+ * Note this endpoint is therefore no longer read-only — it MUTATES daemon watch
+ * state — while `isInFlight` below still only bars CONCURRENT surveys per
+ * client, not back-to-back ones. `observe()` is written to be safe under an
+ * un-throttled caller (see its doc); a server-side rate limit is #7436.
+ *
  * `observe()` arms and never fires, so nothing a client does can produce a
  * completion event. Note the order and the isolation below — the reply goes out
  * FIRST, and the hand-off is wrapped separately, because an exception raised

--- a/packages/server/src/handlers/session-pr-status-handlers.js
+++ b/packages/server/src/handlers/session-pr-status-handlers.js
@@ -28,6 +28,21 @@
  * use the difference between "not authorised" and "not found" to probe which
  * session ids exist.
  *
+ * ## The reply also ARMS the CI watcher (#7427)
+ *
+ * `SessionCiWatcher` (#7426) fires only on a pending→settled transition it
+ * observed, and its own sweep only surveys an unarmed session every five
+ * minutes — so a run that starts and finishes between two of those passes was
+ * never noticed. This handler surveys the same thing on demand, at the moment
+ * someone is actually looking, so the snapshot is handed to `observe()` on the
+ * way out: opening the dashboard arms the watch.
+ *
+ * `observe()` arms and never fires, so nothing a client does can produce a
+ * completion event. Note the order and the isolation below — the reply goes out
+ * FIRST, and the hand-off is wrapped separately, because an exception raised
+ * after `send()` would fall into the survey's catch and emit a SECOND reply,
+ * breaking the one-reply-per-request property this whole handler is built on.
+ *
  * NOTE the binding check below duplicates the one in `handler-utils.js`'s
  * `resolveSession`. That is deliberate — `resolveSession` collapses "not
  * authorised" and "not found" into a single `null`, and this handler must keep
@@ -143,6 +158,13 @@ export async function handleSessionPrStatusRequest(ws, client, msg, ctx) {
   try {
     const snapshot = await surveyFn({ sessionId: targetSessionId, cwd: entry.cwd })
     ctx.transport.send(ws, { type: 'session_pr_status', requestId, ...snapshot })
+    // #7427: arm the CI watcher off the reading we just paid for. Absent
+    // whenever `sessionCi.watch` is off, and in ctx mocks that do not wire it.
+    try {
+      ctx.services?.sessionCiWatcher?.observe?.(targetSessionId, snapshot)
+    } catch (err) {
+      log.warn(`session_pr_status_request: ci-watch observe failed: ${getErrorMessage(err, 'unknown error')}`)
+    }
   } catch (err) {
     // surveySessionPrStatus degrades environmental failures itself, so reaching
     // here means a genuine defect — log it, and still answer.

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -1155,6 +1155,23 @@ export async function startCliServer(config) {
   // no timers and spawns nothing.
   const schedulerEngine = buildSchedulerEngine({ sessionManager, config, logger: log })
 
+  // #7424 (step 3 of #7344): watch the PR each session opened and announce a CI
+  // run the moment it SETTLES, to both audiences — a `ci_complete` push for the
+  // user's phone, and one typed line into the session's own prompt so the agent
+  // learns it without spending a turn (and a full cached-context re-read)
+  // polling `gh pr checks`.
+  //
+  // ON by default; `sessionCi.watch: false` returns null here. Everything
+  // decidable lives in buildSessionCiWatcher so it is unit-tested rather than
+  // source-grepped.
+  //
+  // Built BEFORE the WsServer (#7427) because the ws handler ctx carries it: the
+  // dashboard's on-demand `session_pr_status_request` survey hands its snapshot
+  // to `observe()`, which ARMS the watch without waiting on the sweep's
+  // five-minute discovery pass.
+  const sessionCiWatcher = buildSessionCiWatcher({ config, sessionManager, pushManager, logger: log })
+  sessionCiWatcher?.start()
+
   wsServer = new WsServer({
     port: PORT,
     apiToken: API_TOKEN,
@@ -1163,6 +1180,9 @@ export async function startCliServer(config) {
     // #6871: nullable — null whenever the scheduled-execution gate is closed (the
     // default). The scheduled-tasks handlers report that as "not armed".
     schedulerEngine,
+    // #7427: nullable — null when `sessionCi.watch` is off. Handed to handlers
+    // only; server-cli owns its start() above and ServerOrchestrator its stop().
+    sessionCiWatcher,
     defaultSessionId,
     authRequired: !NO_AUTH,
     pushManager,
@@ -1277,18 +1297,6 @@ export async function startCliServer(config) {
   sessionManager.on('session_created', () => billingCanaryMonitor.refresh())
   sessionManager.on('session_destroyed', () => billingCanaryMonitor.refresh())
   billingCanaryMonitor.start()
-
-  // #7424 (step 3 of #7344): watch the PR each session opened and announce a CI
-  // run the moment it SETTLES, to both audiences — a `ci_complete` push for the
-  // user's phone, and one typed line into the session's own prompt so the agent
-  // learns it without spending a turn (and a full cached-context re-read)
-  // polling `gh pr checks`.
-  //
-  // ON by default; `sessionCi.watch: false` returns null here. Everything
-  // decidable lives in buildSessionCiWatcher so it is unit-tested rather than
-  // source-grepped.
-  const sessionCiWatcher = buildSessionCiWatcher({ config, sessionManager, pushManager, logger: log })
-  sessionCiWatcher?.start()
 
   // #5053: wire the pool stats aggregator to the shared pool so the
   // dashboard's GET /api/pool/stats has rolling counters (hit rate,

--- a/packages/server/src/session-ci-watcher.js
+++ b/packages/server/src/session-ci-watcher.js
@@ -249,6 +249,38 @@ export function buildAgentWakeText(event) {
   return `${head}${merge} You did not need to poll for this.`
 }
 
+/**
+ * Is this a `surveySessionPrStatus` result — as opposed to whatever else a
+ * caller might hand `observe()`?
+ *
+ * The discriminator is the PRESENCE of `pr` and `reason`, not their values, and
+ * it is not an arbitrary shape check: `session-pr-status.js` builds every one of
+ * its return paths from `baseSnapshot`, "so every return path has the same
+ * shape". `pr: null` is therefore the survey saying *I looked, and there is no
+ * open PR* — a fact `_reconcile` acts on by DROPPING the arm. A missing `pr` key
+ * says nothing at all, and must not be read as that fact.
+ *
+ * A `typeof === 'object'` test does not draw that line: `{}` sails through it
+ * and then reads as the quiet no-PR negative, cancelling a watch the user is
+ * waiting on. That is a guard whose comment describes a stronger check than its
+ * code performs (docs/false-safety-guards.md, #7290/#7291) — caught in review on
+ * #7427, which is why the check is a named predicate with its own tests rather
+ * than an inline truthiness test.
+ *
+ * There is no `Array.isArray` arm, deliberately. An array has neither key, so
+ * the key test already rejects it — the extra branch was written, MUTATED, and
+ * SURVIVED, and no input exists that it would decide differently. A refinement
+ * with no behaviour is a guard that cannot be proven, so it is cut rather than
+ * kept for the look of the thing.
+ *
+ * @param {unknown} value
+ * @returns {boolean}
+ */
+export function isSurveySnapshot(value) {
+  if (!value || typeof value !== 'object') return false
+  return 'pr' in value && 'reason' in value
+}
+
 export class SessionCiWatcher {
   /**
    * @param {object} opts
@@ -491,10 +523,7 @@ export class SessionCiWatcher {
    */
   observe(sessionId, snapshot) {
     if (typeof sessionId !== 'string' || sessionId.length === 0) return 'ignored'
-    // A null/garbage snapshot is NOT the quiet "no open PR" negative, and must
-    // not be read as one: `_reconcile` DROPS the arm on a missing `pr`, so
-    // forwarding nothing would cancel a watch the user is waiting on.
-    if (!snapshot || typeof snapshot !== 'object') return 'ignored'
+    if (!isSurveySnapshot(snapshot)) return 'ignored'
     // The survey ran, so the schedule counts it — the same rule `tick()` states
     // for itself, that the stamp measures ATTEMPTS. A dashboard pull therefore
     // defers the sweep's own discovery survey for this session, so the two paths

--- a/packages/server/src/session-ci-watcher.js
+++ b/packages/server/src/session-ci-watcher.js
@@ -339,12 +339,19 @@ export class SessionCiWatcher {
   _stateFor(sessionId) {
     let s = this._state.get(sessionId)
     if (!s) {
+      // Two survey stamps, not one, and the split is load-bearing — see
+      // `observe()`. `lastSurveyedAt` is written ONLY by this sweep and is its
+      // sort key; `lastObservedAt` is written only by `observe()` and feeds the
+      // discovery-due test alone. `lastFired` records the last `(number,
+      // headRefOid)` this watcher announced, so a stale external observation
+      // cannot re-arm a run that already completed.
+      //
       // `lastSurveyedAt: null` is "never surveyed", NOT "surveyed at time 0":
       // a first sight must be due regardless of what the clock reads, and
       // `now - 0 >= discoveryIntervalMs` only happens to be true because
       // Date.now() is large. An injected clock (or a mocked one starting near
       // zero) would otherwise silently never survey a new session.
-      s = { lastSurveyedAt: null, armed: null }
+      s = { lastSurveyedAt: null, lastObservedAt: null, armed: null, lastFired: null }
       this._state.set(sessionId, s)
     }
     return s
@@ -377,11 +384,25 @@ export class SessionCiWatcher {
       const due = sessions.filter(s => {
         const st = this._stateFor(s.sessionId)
         if (st.armed) return true
-        if (st.lastSurveyedAt === null) return true
-        return now - st.lastSurveyedAt >= this._discoveryIntervalMs
+        // DUE-ness counts either kind of survey: a dashboard pull is a real
+        // reading of the same repo, so it defers discovery just as the sweep's
+        // own would, and the two do not spawn `gh` twice in a row.
+        if (st.lastSurveyedAt === null && st.lastObservedAt === null) return true
+        const last = Math.max(st.lastSurveyedAt ?? -Infinity, st.lastObservedAt ?? -Infinity)
+        return now - last >= this._discoveryIntervalMs
       })
       // Oldest reading first, so the per-tick cap delays a session but can never
       // starve one. Never-surveyed sorts ahead of everything.
+      //
+      // ORDERING reads `lastSurveyedAt` ONLY — never `lastObservedAt`. The two
+      // stamps are split precisely here: while `observe()` shared this field, a
+      // dashboard polling once per tick kept its session permanently the
+      // YOUNGEST due entry, so with more than `maxSurveysPerTick` sessions due
+      // it never entered the batch at all. Measured before the split: five
+      // sessions, cap 4, ten ticks — the polled session got 0 surveys and 0
+      // events while an identical un-polled control fired on the first tick.
+      // That falsified this module's own invariant two lines up AND inverted the
+      // feature, since the starved session is the one the user is looking at.
       const age = id => {
         const at = this._stateFor(id).lastSurveyedAt
         return at === null ? -Infinity : at
@@ -436,7 +457,7 @@ export class SessionCiWatcher {
    * @param {{fire?: boolean}} [options] - `fire: false` (the `observe()` path)
    *   arms exactly as the sweep does but stops short of consuming an arm or
    *   emitting an event. See `observe()`.
-   * @returns {'undeterminable'|'no-pr'|'armed'|'not-settled'|'settled'|'fired'}
+   * @returns {'undeterminable'|'no-pr'|'armed'|'already-fired'|'not-settled'|'settled'|'fired'}
    *   what this snapshot was taken to mean — `'not-settled'` being a run that is
    *   not terminal and armed nothing (no run yet for this head SHA, or a pending
    *   one carrying no SHA to key an arm on). Returned rather than logged so both
@@ -471,6 +492,19 @@ export class SessionCiWatcher {
       // requires the settled reading to carry the SAME (number, headRefOid), so
       // a stale arm can only ever close against the very run it was set for.
       if (snapshot.checks?.counts?.pending > 0 && typeof headRefOid === 'string' && headRefOid.length > 0) {
+        // An EXTERNAL pending reading for a pair already announced is stale by
+        // construction: a survey that started before the run settled and
+        // resolved after it did. Re-arming on it fires the completion a second
+        // time — a duplicate push AND a duplicate line typed at the agent.
+        // Measured: observe(pending) → sweep fires → observe(pending) → sweep
+        // fires again. The sweep cannot hit this (its surveys are self-timed and
+        // serialised by `_ticking`), so the refusal is scoped to `fire: false`
+        // and the sweep keeps its existing behaviour — including re-arming a
+        // genuine CI re-run on the SAME head SHA, which this path now leaves to
+        // the next discovery pass rather than guessing about.
+        if (!fire && st.lastFired && st.lastFired.number === number && st.lastFired.headRefOid === headRefOid) {
+          return 'already-fired'
+        }
         st.armed = { number, headRefOid }
         return 'armed'
       }
@@ -490,6 +524,10 @@ export class SessionCiWatcher {
     if (!armed) return 'settled'
     if (armed.number !== number || armed.headRefOid !== headRefOid) return 'settled'
 
+    // Remembered so a stale external observation cannot re-arm a run this
+    // watcher has already announced. Written here rather than in `_fire` so it
+    // records only arms that were actually CONSUMED by a completion.
+    st.lastFired = { number, headRefOid }
     this._fire(sessionId, snapshot, verdict)
     return 'fired'
   }
@@ -510,7 +548,9 @@ export class SessionCiWatcher {
    *
    * Arming is idempotent on `(number, headRefOid)`, so two dashboards surveying
    * the same session, or one dashboard's timer pulling repeatedly, produce one
-   * arm and therefore one event.
+   * arm and therefore one event — including AFTER that event has fired, which
+   * needs its own record (`lastFired`) because consuming the arm is what makes
+   * the pair look un-announced again.
    *
    * There is deliberately NO `_stopped` guard. `observe()` cannot fire, so an
    * observation landing mid-shutdown only writes to a Map nothing will read;
@@ -519,17 +559,21 @@ export class SessionCiWatcher {
    *
    * @param {string} sessionId
    * @param {object} snapshot - a `surveySessionPrStatus` result.
-   * @returns {'ignored'|'undeterminable'|'no-pr'|'armed'|'not-settled'|'settled'}
+   * @returns {'ignored'|'undeterminable'|'no-pr'|'armed'|'already-fired'|'not-settled'|'settled'}
    */
   observe(sessionId, snapshot) {
     if (typeof sessionId !== 'string' || sessionId.length === 0) return 'ignored'
     if (!isSurveySnapshot(snapshot)) return 'ignored'
-    // The survey ran, so the schedule counts it — the same rule `tick()` states
-    // for itself, that the stamp measures ATTEMPTS. A dashboard pull therefore
-    // defers the sweep's own discovery survey for this session, so the two paths
-    // do not spawn git + `gh` twice in a row. It does NOT defer an ARMED
-    // session: those are due every tick whenever they were last surveyed.
-    this._stateFor(sessionId).lastSurveyedAt = this._now()
+    // Stamped AFTER the shape guard, so a rejected value cannot defer anything,
+    // and into `lastObservedAt` — NOT `lastSurveyedAt`, which is the sweep's own
+    // sort key. Writing the sort key from here starved the polled session out of
+    // the per-tick batch entirely; see the ordering comment in `tick()`.
+    //
+    // The stamp still defers DISCOVERY, which is the point: a dashboard pull is
+    // a real reading of the same repo, so the two paths do not spawn git + `gh`
+    // twice in a row. It does not defer an ARMED session — those are due every
+    // tick regardless of either stamp.
+    this._stateFor(sessionId).lastObservedAt = this._now()
     return this._reconcile(sessionId, snapshot, { fire: false })
   }
 

--- a/packages/server/src/session-ci-watcher.js
+++ b/packages/server/src/session-ci-watcher.js
@@ -37,8 +37,12 @@
  * ## Two arming paths, one firing path (#7427)
  *
  * The sweep is not the only thing that surveys a session. The dashboard asks
- * the same question on demand through `session_pr_status_request` (#7422), and
- * it pulls on a rate-limited timer while a human is looking at the chip. That
+ * the same question on demand through `session_pr_status_request` (#7422) — on
+ * an effect gated by a freshness window when the active session or connection
+ * changes, and, on the Refresh button, with NO window and NO server-side rate
+ * limit at all. Assume the un-throttled case: a user waiting on CI clicking
+ * Refresh is exactly the modelled behaviour, and both defects found in review
+ * of #7432 were reachable from it. That
  * reply is a `surveySessionPrStatus` snapshot in exactly the shape `_reconcile`
  * folds in, so `observe()` accepts it — and OPENING THE DASHBOARD ARMS THE
  * WATCH. The unarmed-session discovery interval (five minutes) then stops being

--- a/packages/server/src/session-ci-watcher.js
+++ b/packages/server/src/session-ci-watcher.js
@@ -34,6 +34,21 @@
  * interval, which is silently missed. That is why `tickIntervalMs` is minutes
  * shorter than any real CI run rather than a "cheap" hourly sweep.
  *
+ * ## Two arming paths, one firing path (#7427)
+ *
+ * The sweep is not the only thing that surveys a session. The dashboard asks
+ * the same question on demand through `session_pr_status_request` (#7422), and
+ * it pulls on a rate-limited timer while a human is looking at the chip. That
+ * reply is a `surveySessionPrStatus` snapshot in exactly the shape `_reconcile`
+ * folds in, so `observe()` accepts it — and OPENING THE DASHBOARD ARMS THE
+ * WATCH. The unarmed-session discovery interval (five minutes) then stops being
+ * the thing that decides whether a fast run is noticed at all.
+ *
+ * `observe()` arms and NEVER fires; see its own doc for why consuming the arm
+ * there would be strictly worse than leaving it. Firing stays the sweep's
+ * decision alone, so no client action can replay a completion the user already
+ * received.
+ *
  * ## What "settled" means
  *
  * `counts.pending === 0` — NOT "the rollup's state says success", which hides a
@@ -386,19 +401,27 @@ export class SessionCiWatcher {
    *
    * @param {string} sessionId
    * @param {object} snapshot
+   * @param {{fire?: boolean}} [options] - `fire: false` (the `observe()` path)
+   *   arms exactly as the sweep does but stops short of consuming an arm or
+   *   emitting an event. See `observe()`.
+   * @returns {'undeterminable'|'no-pr'|'armed'|'not-settled'|'settled'|'fired'}
+   *   what this snapshot was taken to mean — `'not-settled'` being a run that is
+   *   not terminal and armed nothing (no run yet for this head SHA, or a pending
+   *   one carrying no SHA to key an arm on). Returned rather than logged so both
+   *   paths are assertable without reaching into private state.
    */
-  _reconcile(sessionId, snapshot) {
+  _reconcile(sessionId, snapshot, { fire = true } = {}) {
     const st = this._stateFor(sessionId)
 
     // "Could not determine" changes nothing. Disarming here would mean a single
     // `gh` hiccup silently cancels a watch the user is waiting on.
-    if (snapshot?.reason) return
+    if (snapshot?.reason) return 'undeterminable'
 
     // No open PR (the quiet negative — merged, closed, or never opened). Nothing
     // left to report on, so drop any arm.
     if (!snapshot?.pr) {
       st.armed = null
-      return
+      return 'no-pr'
     }
 
     const number = snapshot.pr.number
@@ -417,18 +440,68 @@ export class SessionCiWatcher {
       // a stale arm can only ever close against the very run it was set for.
       if (snapshot.checks?.counts?.pending > 0 && typeof headRefOid === 'string' && headRefOid.length > 0) {
         st.armed = { number, headRefOid }
+        return 'armed'
       }
-      return
+      return 'not-settled'
     }
+
+    // A settled reading the watcher did not survey itself stops HERE, with the
+    // arm left INTACT for the sweep to close. Consuming it without firing would
+    // be the worst of the three options: the sweep's own settled reading would
+    // then find nothing armed and the completion would be lost outright.
+    if (!fire) return 'settled'
 
     const armed = st.armed
     // Settled. Consume the arm either way: whether or not it matched, the run it
     // referred to is no longer the one in flight.
     st.armed = null
-    if (!armed) return
-    if (armed.number !== number || armed.headRefOid !== headRefOid) return
+    if (!armed) return 'settled'
+    if (armed.number !== number || armed.headRefOid !== headRefOid) return 'settled'
 
     this._fire(sessionId, snapshot, verdict)
+    return 'fired'
+  }
+
+  /**
+   * Fold an EXTERNALLY produced snapshot into the watch state — the dashboard's
+   * on-demand survey, handed over by `handleSessionPrStatusRequest` (#7427).
+   *
+   * ARMS, NEVER FIRES, and the two reasons are worth keeping apart:
+   *
+   *   - it costs nothing to defer the firing. An ARMED session is due on EVERY
+   *     tick, so once this path arms, the sweep closes the transition within
+   *     `tickIntervalMs` — a minute — instead of within
+   *     `discoveryIntervalMs`. All of the value here is in the arm.
+   *   - the watcher stays the only thing that decides a completion HAPPENED. A
+   *     client-triggered path that could fire is one reconnect-and-refresh away
+   *     from replaying an event the user already received.
+   *
+   * Arming is idempotent on `(number, headRefOid)`, so two dashboards surveying
+   * the same session, or one dashboard's timer pulling repeatedly, produce one
+   * arm and therefore one event.
+   *
+   * There is deliberately NO `_stopped` guard. `observe()` cannot fire, so an
+   * observation landing mid-shutdown only writes to a Map nothing will read;
+   * `tick()` guards because reconciling THERE pushes a notification and types
+   * into a live session.
+   *
+   * @param {string} sessionId
+   * @param {object} snapshot - a `surveySessionPrStatus` result.
+   * @returns {'ignored'|'undeterminable'|'no-pr'|'armed'|'not-settled'|'settled'}
+   */
+  observe(sessionId, snapshot) {
+    if (typeof sessionId !== 'string' || sessionId.length === 0) return 'ignored'
+    // A null/garbage snapshot is NOT the quiet "no open PR" negative, and must
+    // not be read as one: `_reconcile` DROPS the arm on a missing `pr`, so
+    // forwarding nothing would cancel a watch the user is waiting on.
+    if (!snapshot || typeof snapshot !== 'object') return 'ignored'
+    // The survey ran, so the schedule counts it — the same rule `tick()` states
+    // for itself, that the stamp measures ATTEMPTS. A dashboard pull therefore
+    // defers the sweep's own discovery survey for this session, so the two paths
+    // do not spawn git + `gh` twice in a row. It does NOT defer an ARMED
+    // session: those are due every tick whenever they were last surveyed.
+    this._stateFor(sessionId).lastSurveyedAt = this._now()
+    return this._reconcile(sessionId, snapshot, { fire: false })
   }
 
   /**

--- a/packages/server/src/ws-handler-context.js
+++ b/packages/server/src/ws-handler-context.js
@@ -84,6 +84,7 @@
  * @property {(value: string|null) => void} setWebhookSecretCache - #6540 refresh the in-process webhook-secret cache.
  * @property {object|null} orchestrationManager - #6691 OrchestrationManager; null while the feature is off.
  * @property {object|null} schedulerEngine - #6871 scheduled-task engine; null when scheduling is off.
+ * @property {object|null} sessionCiWatcher - #7427 SessionCiWatcher, so an on-demand PR survey can arm the watch; null when `sessionCi.watch` is off.
  *
  * @typedef {Object} WsHandlerRuntime
  * @property {boolean} draining - True while the server is draining for shutdown.
@@ -189,6 +190,12 @@ export const CTX_NAMESPACES = {
     // SessionManager and exists either way, so tasks are still readable and
     // editable with no engine present.
     'schedulerEngine',
+    // #7427: the SessionCiWatcher (#7426). The `session_pr_status_request`
+    // handler hands its survey snapshot to `observe()`, so a dashboard pull ARMS
+    // the watch instead of waiting on the sweep's five-minute discovery pass.
+    // NULL whenever `sessionCi.watch` is off — the handler treats absence as
+    // "nothing to arm" and its reply is unaffected either way.
+    'sessionCiWatcher',
   ],
   runtime: [
     'draining',

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -575,7 +575,7 @@ function _isSecureRequest(req) {
  *   - A session operation failed in an expected, user-facing way → `session_error`
  */
 export class WsServer {
-  constructor({ port, apiToken, cliSession, sessionManager, defaultSessionId, authRequired = true, pushManager = null, maxPayload, noEncrypt, keyExchangeTimeoutMs, localhostBypass, tokenManager, pairingManager, serverIdentity = null, maxPendingConnections, backpressureThreshold, environmentManager, orchestrationManager = null, schedulerEngine = null, config = null, diagnosticsRateLimit = null, devicePreferences = null, pagesStore = null, pagesRateLimiter } = {}) {
+  constructor({ port, apiToken, cliSession, sessionManager, defaultSessionId, authRequired = true, pushManager = null, maxPayload, noEncrypt, keyExchangeTimeoutMs, localhostBypass, tokenManager, pairingManager, serverIdentity = null, maxPendingConnections, backpressureThreshold, environmentManager, orchestrationManager = null, schedulerEngine = null, sessionCiWatcher = null, config = null, diagnosticsRateLimit = null, devicePreferences = null, pagesStore = null, pagesRateLimiter } = {}) {
     this.port = port
     this.apiToken = apiToken
     this._tokenManager = tokenManager || null
@@ -941,6 +941,11 @@ export class WsServer {
         // default) — the handlers report that as "not armed" rather than hiding
         // it. Late-bound so it tracks the server instance.
         get schedulerEngine() { return self._schedulerEngine ?? null },
+        // #7427: the SessionCiWatcher. The `session_pr_status_request` handler
+        // feeds its survey snapshot to `observe()`, so opening the dashboard
+        // ARMS the watch rather than waiting on the sweep's five-minute
+        // discovery pass. Null when the watcher is off; the handler no-ops.
+        get sessionCiWatcher() { return self._sessionCiWatcher ?? null },
       },
       runtime: {
         get draining() { return self._draining },
@@ -1127,6 +1132,10 @@ export class WsServer {
     this._orchestrationManager = orchestrationManager || null
     // #6871: nullable by design — null whenever scheduled execution is disabled.
     this._schedulerEngine = schedulerEngine || null
+    // #7427: the CI watcher, so the on-demand PR-survey handler can arm it.
+    // Null when `sessionCi.watch` is off. The WsServer only hands it to
+    // handlers — it never starts, stops or ticks it (server-cli owns that).
+    this._sessionCiWatcher = sessionCiWatcher || null
     this.defaultSessionId = defaultSessionId || null
     this._checkpointManager = new CheckpointManager()
 

--- a/packages/server/tests/session-ci-watcher.test.js
+++ b/packages/server/tests/session-ci-watcher.test.js
@@ -27,6 +27,7 @@ import {
   describeCiCompletion,
   buildAgentWakeText,
   normaliseMergeState,
+  isSurveySnapshot,
   MAX_TITLE_CHARS,
   DEFAULT_TICK_INTERVAL_MS,
   DEFAULT_DISCOVERY_INTERVAL_MS,
@@ -412,9 +413,13 @@ describe('SessionCiWatcher — observe(): the dashboard arming path (#7427)', ()
     // `_reconcile` treats a MISSING `pr` as the quiet negative and DROPS the
     // arm. Forwarding garbage there would let a caller cancel a watch by
     // handing over nothing at all.
+    //
+    // `{}` and `{ pr: null }` are the cases a bare `typeof === 'object'` test
+    // lets through — the review finding on #7427. They are listed here as
+    // VALUES, not as a shape rule, so this stays red for each one individually.
     const h = harness({ queue: [green()] })
     h.watcher.observe('s1', pending())
-    for (const bad of [null, undefined, 'nope', 42, true]) {
+    for (const bad of [null, undefined, 'nope', 42, true, {}, [], { pr: null }, { reason: null }, snapshot()?.checks]) {
       assert.equal(h.watcher.observe('s1', bad), 'ignored', `snapshot ${JSON.stringify(bad)} must be ignored`)
     }
     for (const bad of ['', null, undefined, 7]) {
@@ -783,6 +788,34 @@ describe('SessionCiWatcher — bounded fan-out', () => {
     watcher.stop()
     await watcher.tick()
     assert.deepEqual(surveyed, [], 'a stopped watcher must spawn no subprocess')
+  })
+})
+
+describe('isSurveySnapshot', () => {
+  it('accepts every shape surveySessionPrStatus actually returns', () => {
+    // Its `baseSnapshot` skeleton exists "so every return path has the same
+    // shape" — an open PR, no open PR, and a degraded reading all carry `pr`
+    // and `reason` as KEYS. If that ever stops being true, this goes red here
+    // rather than by silently refusing to arm in production.
+    for (const s of [pending(), green(), red(), noRun(), unrecognised(), noPr(), degraded()]) {
+      assert.equal(isSurveySnapshot(s), true, `rejected a real snapshot: ${JSON.stringify(s).slice(0, 80)}`)
+    }
+  })
+
+  it('rejects an object that merely LOOKS like one', () => {
+    // The line the guard has to draw: `pr: null` is the survey reporting a fact
+    // (`_reconcile` drops the arm on it). A missing `pr` key reports nothing,
+    // and must not be read as that fact.
+    for (const v of [null, undefined, 'nope', 42, true, [], {}, { pr: null }, { reason: null }, { pr: { number: 1 } }]) {
+      assert.equal(isSurveySnapshot(v), false, `accepted a non-snapshot: ${JSON.stringify(v)}`)
+    }
+  })
+
+  it('draws the line on the KEY, not the value — a null pr with a reason key is real', () => {
+    // POSITIVE CONTROL for the test above: it must not be passing merely
+    // because every listed value is falsy or empty.
+    assert.equal(isSurveySnapshot({ pr: null, reason: null }), true)
+    assert.equal(isSurveySnapshot({ pr: null, reason: 'gh not found' }), true)
   })
 })
 

--- a/packages/server/tests/session-ci-watcher.test.js
+++ b/packages/server/tests/session-ci-watcher.test.js
@@ -346,6 +346,138 @@ describe('SessionCiWatcher — the completion transition', () => {
   })
 })
 
+describe('SessionCiWatcher — observe(): the dashboard arming path (#7427)', () => {
+  // The sweep surveys an UNARMED session only every `discoveryIntervalMs`
+  // (five minutes in production), so a run that starts and finishes between two
+  // of those passes was never seen pending and therefore never fired. The
+  // dashboard already surveys exactly this, on demand, whenever someone is
+  // looking — `observe()` folds that reading in.
+  //
+  // The contract under test throughout: observe() ARMS and NEVER FIRES.
+
+  it('arms from a dashboard survey alone, so the next sweep fires a run no sweep ever saw pending', async () => {
+    const h = harness({ queue: [green()] })
+    // The ONLY pending reading this watcher ever receives is the handler's.
+    assert.equal(h.watcher.observe('s1', pending()), 'armed')
+    assert.equal(h.events.length, 0, 'observe() must not fire on its own')
+    await h.watcher.tick()
+    assert.equal(h.events.length, 1, 'the sweep closes the transition the dashboard armed')
+    assert.equal(h.events[0].verdict, 'success')
+    assert.equal(h.surveyed.length, 1, 'and it took exactly one sweep survey to do it')
+  })
+
+  it('fires nothing for a settled PR the dashboard is the FIRST to see', async () => {
+    // The honest negative from #7424, restated for this path: an observation is
+    // not evidence that anything completed. Nothing armed it, so nothing fires —
+    // now, or on any later sweep.
+    const h = harness({ queue: [green()] })
+    assert.equal(h.watcher.observe('s1', green()), 'settled')
+    assert.equal(h.events.length, 0)
+    await h.watcher.tick()
+    await h.watcher.tick()
+    assert.equal(h.events.length, 0, 'a run nobody watched start cannot complete')
+  })
+
+  it('leaves the arm INTACT when the dashboard is the one that sees it settle', async () => {
+    // The load-bearing case. Consuming the arm here without firing would be
+    // strictly worse than either alternative: the sweep's own settled reading
+    // would then find nothing armed and the completion would be lost outright.
+    const h = harness({ queue: [green()] })
+    assert.equal(h.watcher.observe('s1', pending()), 'armed')
+    assert.equal(h.watcher.observe('s1', green()), 'settled')
+    assert.equal(h.events.length, 0, 'a client-triggered survey must never fire an event')
+    await h.watcher.tick()
+    assert.equal(h.events.length, 1, 'the arm survived for the sweep to close')
+  })
+
+  it('arms idempotently, so two dashboards on one session still produce ONE event', async () => {
+    const h = harness({ queue: [green()] })
+    // Two clients, plus a rate-limited auto-pull, all surveying the same
+    // (number, headRefOid).
+    for (let i = 0; i < 5; i++) assert.equal(h.watcher.observe('s1', pending()), 'armed')
+    await h.watcher.tick()
+    await h.watcher.tick()
+    assert.equal(h.events.length, 1)
+  })
+
+  it('keeps the arm through a dashboard reading that could not determine the state', async () => {
+    const h = harness({ queue: [green()] })
+    h.watcher.observe('s1', pending())
+    assert.equal(h.watcher.observe('s1', degraded()), 'undeterminable')
+    await h.watcher.tick()
+    assert.equal(h.events.length, 1, 'a `gh` hiccup must not cancel a watch the user is waiting on')
+  })
+
+  it('refuses a malformed observation instead of reading it as "no open PR"', async () => {
+    // `_reconcile` treats a MISSING `pr` as the quiet negative and DROPS the
+    // arm. Forwarding garbage there would let a caller cancel a watch by
+    // handing over nothing at all.
+    const h = harness({ queue: [green()] })
+    h.watcher.observe('s1', pending())
+    for (const bad of [null, undefined, 'nope', 42, true]) {
+      assert.equal(h.watcher.observe('s1', bad), 'ignored', `snapshot ${JSON.stringify(bad)} must be ignored`)
+    }
+    for (const bad of ['', null, undefined, 7]) {
+      assert.equal(h.watcher.observe(bad, pending()), 'ignored', `sessionId ${JSON.stringify(bad)} must be ignored`)
+    }
+    await h.watcher.tick()
+    assert.equal(h.events.length, 1, 'the arm survived every malformed observation')
+  })
+
+  it('POSITIVE CONTROL: a REAL "no open PR" reading does drop the arm', async () => {
+    // Without this, the test above passes for the wrong reason — it would be
+    // satisfied by an observe() that could never drop an arm at all.
+    const h = harness({ queue: [green()] })
+    h.watcher.observe('s1', pending())
+    assert.equal(h.watcher.observe('s1', noPr()), 'no-pr')
+    await h.watcher.tick()
+    assert.equal(h.events.length, 0, 'the PR went away — there is nothing left to report on')
+  })
+
+  it('defers the sweep\'s own discovery survey, so the two paths do not spawn `gh` twice in a row', async () => {
+    const h = harness({ queue: [noRun()], discoveryIntervalMs: 60_000 })
+    h.watcher.observe('s1', noRun())
+    await h.watcher.tick()
+    assert.equal(h.surveyed.length, 0, 'the dashboard just surveyed; the sweep must not immediately repeat it')
+    h.advance(60_000)
+    await h.watcher.tick()
+    assert.equal(h.surveyed.length, 1, 'and discovery resumes on schedule afterwards')
+  })
+
+  it('POSITIVE CONTROL: with no dashboard pull, that same first tick DOES survey', async () => {
+    // Otherwise the deferral above is indistinguishable from a tick that was
+    // never going to survey anything.
+    const h = harness({ queue: [noRun()], discoveryIntervalMs: 60_000 })
+    await h.watcher.tick()
+    assert.equal(h.surveyed.length, 1)
+  })
+
+  it('does NOT defer an armed session — those stay due every tick', async () => {
+    // The deferral applies to the discovery schedule only. An armed session is
+    // due on every tick whenever it was last surveyed, which is what keeps the
+    // close-the-transition latency at `tickIntervalMs` rather than at
+    // `discoveryIntervalMs`.
+    const h = harness({ queue: [green()], discoveryIntervalMs: 60_000 })
+    h.watcher.observe('s1', pending())
+    await h.watcher.tick()
+    assert.equal(h.surveyed.length, 1)
+    assert.equal(h.events.length, 1)
+  })
+
+  it('an observation for a session that has gone away cannot outlive it', async () => {
+    // `observe()` creates watch state on first sight, exactly as the sweep does.
+    // tick()'s prune is what bounds it — assert that still holds for state this
+    // path created, so a stream of observations cannot accumulate ids.
+    const h = harness({ queue: [green()], sessions: [] })
+    h.watcher.observe('ghost', pending())
+    await h.watcher.tick()
+    assert.equal(h.events.length, 0)
+    // Re-observing after the prune arms afresh rather than resurrecting a
+    // half-consumed state.
+    assert.equal(h.watcher.observe('ghost', pending()), 'armed')
+  })
+})
+
 describe('SessionCiWatcher — routing to both audiences', () => {
   it('types one line into an idle claude-tui session naming the PR and the verdict', async () => {
     const session = tuiSession()
@@ -900,6 +1032,34 @@ describe('buildSessionCiWatcher — the daemon wiring', () => {
     assert.ok(ctorAt > 0)
     const args = src.slice(ctorAt, ctorAt + 700)
     assert.ok(/\bsessionCiWatcher,/.test(args), 'the watcher must reach ServerOrchestrator so shutdown can stop it')
+  })
+
+  it('is handed to the WsServer, so a dashboard survey can reach observe() (#7427)', () => {
+    // The fourth wiring site, and the one with no runtime witness reachable
+    // from a unit test: everything downstream of it — the ctx roster, the
+    // typedef, ws-server's own getter, the handler's call — is covered by real
+    // tests, but nothing observes that server-cli actually PASSES the watcher
+    // it built. Delete this one argument and the daemon boots, every suite
+    // stays green, and the arming path is silently dead.
+    //
+    // Sliced to the constructor's own argument list — bounded by the call's
+    // closing `\n  })` — so an unrelated `sessionCiWatcher,` elsewhere in the
+    // 1500-line file cannot satisfy it. Asserted via `re.test` so a failure
+    // prints a message rather than the slice (#7340/#7401).
+    const src = readFileSync(new URL('../src/server-cli.js', import.meta.url), 'utf8')
+    const at = src.indexOf('wsServer = new WsServer({')
+    assert.ok(at > 0, 'server-cli.js must construct the WsServer')
+    const end = src.indexOf('\n  })', at)
+    assert.ok(end > at, 'the WsServer call must be terminated by its own closing brace')
+    const args = src.slice(at, end)
+
+    // POSITIVE CONTROL: the slice really is the ctor argument list — it carries
+    // a known sibling argument, and it CANNOT reach the build site above it, so
+    // `buildSessionCiWatcher(...)` on its own could not satisfy the assertion.
+    assert.ok(/\bschedulerEngine,/.test(args), 'the slice must be the WsServer argument list')
+    assert.ok(!/buildSessionCiWatcher/.test(args), 'the slice must not reach the construction site')
+
+    assert.ok(/\bsessionCiWatcher,/.test(args), 'the watcher must be passed to the WsServer')
   })
 
   it('maps an event to its push shape without a PushManager', () => {

--- a/packages/server/tests/session-ci-watcher.test.js
+++ b/packages/server/tests/session-ci-watcher.test.js
@@ -19,6 +19,7 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
+import { surveySessionPrStatus } from '../src/session-pr-status.js'
 import {
   SessionCiWatcher,
   buildSessionCiWatcher,
@@ -399,6 +400,98 @@ describe('SessionCiWatcher — observe(): the dashboard arming path (#7427)', ()
     await h.watcher.tick()
     await h.watcher.tick()
     assert.equal(h.events.length, 1)
+  })
+
+  it('REGRESSION: an observation arriving AFTER the event fired cannot fire it again', async () => {
+    // Review finding on #7432. A survey that STARTED before the run settled and
+    // RESOLVED after it did carries a stale `pending` reading. Consuming the arm
+    // is what makes the pair look un-announced again, so without a record of
+    // what fired, that stale reading re-arms the very same
+    // `(number, headRefOid)` and the next sweep fires a SECOND time — a
+    // duplicate push and a duplicate line typed at the live agent.
+    //
+    // Measured before the fix: 1 event, then 2. The handler cannot prevent this
+    // on its own — `isInFlight` is per-CLIENT, so two dashboards surveying one
+    // session legitimately overlap.
+    const h = harness({ queue: [green()] })
+    h.watcher.observe('s1', pending())
+    await h.watcher.tick()
+    assert.equal(h.events.length, 1, 'baseline: the transition fires once')
+
+    assert.equal(h.watcher.observe('s1', pending()), 'already-fired')
+    await h.watcher.tick()
+    await h.watcher.tick()
+    assert.equal(h.events.length, 1, 'a stale pending reading must not resurrect a completed run')
+  })
+
+  it('POSITIVE CONTROL: a re-push after firing DOES re-arm through this path', async () => {
+    // Otherwise the guard above is satisfied by an observe() that can never arm
+    // twice at all — which would silently disable the whole feature for every
+    // session after its first CI run.
+    const h = harness({ queue: [green(), green({ headRefOid: SHA2 })] })
+    h.watcher.observe('s1', pending())
+    await h.watcher.tick()
+    assert.equal(h.events.length, 1)
+
+    // New head SHA: a genuinely different run. The refusal is keyed on the
+    // PAIR, not on "this session has fired before".
+    assert.equal(h.watcher.observe('s1', pending({ headRefOid: SHA2 })), 'armed')
+    await h.watcher.tick()
+    assert.equal(h.events.length, 2, 'the second run gets its own event')
+    assert.equal(h.events[1].headRefOid, SHA2)
+  })
+
+  it('REGRESSION: a polled session is not starved out of the per-tick batch', async () => {
+    // Review finding on #7432. `observe()` originally stamped `lastSurveyedAt`,
+    // which is ALSO the sweep's oldest-first sort key — so a dashboard polling
+    // once per tick kept its session permanently the youngest due entry and,
+    // with more sessions due than `maxSurveysPerTick`, it never entered the
+    // batch at all. Measured before the fix: 0 surveys and 0 events across ten
+    // ticks, against a control that fired on the first tick.
+    //
+    // That inverted the feature — the starved session is the one the user is
+    // looking at — and falsified the module's own claim that the per-tick cap
+    // "cannot starve a session, only delay it".
+    const sessions = [{ sessionId: 's1', cwd: '/repo' }]
+    for (let i = 0; i < 8; i++) sessions.push({ sessionId: `other${i}`, cwd: `/o${i}` })
+    const h = harness({
+      sessions,
+      maxSurveysPerTick: 4,
+      queue: [green()],
+      survey: async ({ sessionId }) => (sessionId === 's1' ? green() : pending({ sessionId })),
+    })
+    h.watcher.observe('s1', pending())
+    for (let t = 0; t < 10; t++) {
+      h.advance(60_000)
+      h.watcher.observe('s1', pending())   // the dashboard's auto-pull, every tick
+      await h.watcher.tick()
+    }
+    assert.equal(h.events.length, 1, 'the polled session still gets its completion event')
+  })
+
+  it('POSITIVE CONTROL: the same fleet fires for an UN-polled session too', async () => {
+    // Pins that the assertion above is about starvation, not about the fixture
+    // happening to fire for unrelated reasons.
+    const sessions = [{ sessionId: 's1', cwd: '/repo' }]
+    for (let i = 0; i < 8; i++) sessions.push({ sessionId: `other${i}`, cwd: `/o${i}` })
+    const h = harness({
+      sessions,
+      maxSurveysPerTick: 4,
+      queue: [green()],
+      survey: async ({ sessionId }) => (sessionId === 's1' ? green() : pending({ sessionId })),
+    })
+    h.watcher.observe('s1', pending())
+    for (let t = 0; t < 10; t++) { h.advance(60_000); await h.watcher.tick() }
+    assert.equal(h.events.length, 1)
+  })
+
+  it('stamps the deferral only AFTER the shape guard, so garbage cannot defer discovery', async () => {
+    // Ordering pin. With the stamp above the guard, a rejected value still
+    // pushed the sweep's discovery survey out by a full interval.
+    const h = harness({ queue: [noRun()], discoveryIntervalMs: 60_000 })
+    assert.equal(h.watcher.observe('s1', {}), 'ignored')
+    await h.watcher.tick()
+    assert.equal(h.surveyed.length, 1, 'a refused observation must defer nothing')
   })
 
   it('keeps the arm through a dashboard reading that could not determine the state', async () => {
@@ -792,13 +885,59 @@ describe('SessionCiWatcher — bounded fan-out', () => {
 })
 
 describe('isSurveySnapshot', () => {
-  it('accepts every shape surveySessionPrStatus actually returns', () => {
-    // Its `baseSnapshot` skeleton exists "so every return path has the same
-    // shape" — an open PR, no open PR, and a degraded reading all carry `pr`
-    // and `reason` as KEYS. If that ever stops being true, this goes red here
-    // rather than by silently refusing to arm in production.
+  it('accepts every shape surveySessionPrStatus actually returns — from the REAL producer', async () => {
+    // Driven through `surveySessionPrStatus` itself via its `_execFile` seam, NOT
+    // against fixtures built in this file. Fixtures cannot track a rename in
+    // session-pr-status.js, so a test built on them would keep passing while
+    // `observe()` silently refused every real snapshot and arming stopped
+    // working in production — a guard going quietly inert, which is the failure
+    // this predicate exists to prevent. Review on #7432 caught the fixture
+    // version claiming a coverage it did not have.
+    const PR_ROW = JSON.stringify([{
+      headRepositoryOwner: { login: 'blamechris' }, number: 7419, title: 't',
+      url: 'https://example.test/pr/7419', headRefOid: 'abc1234', isDraft: false,
+      statusCheckRollup: [{ __typename: 'CheckRun', status: 'COMPLETED', conclusion: 'SUCCESS' }],
+      mergeable: 'MERGEABLE', mergeStateStatus: 'CLEAN', reviewDecision: 'APPROVED',
+    }])
+    // Each entry drives ONE real return path. `stdout` is chosen per argv, and a
+    // `throw` stands in for a missing binary / failed git call.
+    const paths = {
+      'no cwd': { cwd: null, exec: async () => ({ stdout: '' }) },
+      'not a repo': { exec: async (bin, argv) => { if (argv[0] === 'branch') throw new Error('nope'); return { stdout: '' } } },
+      'detached HEAD': { exec: async () => ({ stdout: '' }) },
+      'no github remote': { exec: async (bin, argv) => ({ stdout: argv[0] === 'branch' ? 'feat/x\n' : 'git@gitlab.com:o/r.git\n' }) },
+      'gh missing': { exec: async (bin, argv) => {
+        if (bin === 'which') throw new Error('not found')
+        return { stdout: argv[0] === 'branch' ? 'feat/x\n' : 'git@github.com:o/r.git\n' }
+      } },
+      'open PR': { exec: async (bin, argv) => {
+        if (bin === 'which') return { stdout: '/usr/bin/gh\n' }
+        if (bin === '/usr/bin/gh') return { stdout: PR_ROW }
+        return { stdout: argv[0] === 'branch' ? 'feat/x\n' : 'git@github.com:o/r.git\n' }
+      } },
+      'no open PR': { exec: async (bin, argv) => {
+        if (bin === 'which') return { stdout: '/usr/bin/gh\n' }
+        if (bin === '/usr/bin/gh') return { stdout: '[]' }
+        return { stdout: argv[0] === 'branch' ? 'feat/x\n' : 'git@github.com:o/r.git\n' }
+      } },
+    }
+    let sawPr = false, sawReason = false
+    for (const [label, { cwd = '/repo', exec }] of Object.entries(paths)) {
+      const real = await surveySessionPrStatus({ sessionId: 's1', cwd, _execFile: exec })
+      assert.equal(isSurveySnapshot(real), true, `rejected a REAL snapshot from the '${label}' path`)
+      if (real.pr) sawPr = true
+      if (real.reason) sawReason = true
+    }
+    // POSITIVE CONTROL: the table above really did reach both a populated-PR
+    // path and a degraded one, rather than seven variations of the same early
+    // return that would make the assertion above nearly free.
+    assert.ok(sawPr, 'the table must reach a path that returns an actual PR')
+    assert.ok(sawReason, 'the table must reach a degraded path')
+  })
+
+  it('accepts the local fixtures too, which is what the rest of this file uses', () => {
     for (const s of [pending(), green(), red(), noRun(), unrecognised(), noPr(), degraded()]) {
-      assert.equal(isSurveySnapshot(s), true, `rejected a real snapshot: ${JSON.stringify(s).slice(0, 80)}`)
+      assert.equal(isSurveySnapshot(s), true, `rejected a fixture: ${JSON.stringify(s).slice(0, 80)}`)
     }
   })
 

--- a/packages/server/tests/session-pr-status-handler.test.js
+++ b/packages/server/tests/session-pr-status-handler.test.js
@@ -9,6 +9,7 @@ import {
 import { registeredMessageTypes } from '../src/ws-message-handlers.js'
 import { createSpy, createMockSessionManager, nsCtx } from './test-helpers.js'
 import { ServerSessionPrStatusSchema } from '@chroxy/protocol'
+import { SessionCiWatcher } from '../src/session-ci-watcher.js'
 
 /**
  * Tests for the `session_pr_status_request` handler (#7344).
@@ -23,6 +24,12 @@ import { ServerSessionPrStatusSchema } from '@chroxy/protocol'
  *     a caller cannot distinguish "still loading" from "never answered".
  *   - The authority check runs BEFORE the session lookup, so a bound client
  *     cannot use the reply to probe which session ids exist.
+ *
+ * #7427 adds a third: a successful survey is handed to `SessionCiWatcher.observe()`
+ * on the way out, so opening the dashboard ARMS the CI watch. The watcher is
+ * injected through `ctx.services.sessionCiWatcher`; the tests below pin that the
+ * hand-off happens on exactly the path that surveyed, and — the real hazard —
+ * that a throwing watcher cannot turn one reply into two.
  */
 
 const SAMPLE = {
@@ -60,6 +67,136 @@ function soleReply(ctx) {
   assert.ok(parsed.success, `reply rejected by schema: ${JSON.stringify(parsed.error?.issues)}`)
   return msg
 }
+
+describe('#7427 — the reply arms the CI watcher', () => {
+  const handler = sessionPrStatusHandlers.session_pr_status_request
+  const ws = {}
+  const req = { type: 'session_pr_status_request', sessionId: 'sess-1' }
+
+  it('hands the survey snapshot to observe(), so a dashboard pull arms the watch', async () => {
+    const observe = createSpy(() => 'armed')
+    const ctx = makeCtx({ sessionCiWatcher: { observe } })
+    await handler(ws, { id: 'c1' }, req, ctx)
+    soleReply(ctx)
+    assert.equal(observe.callCount, 1)
+    assert.deepEqual(observe.calls[0], ['sess-1', SAMPLE], 'observe(sessionId, snapshot), verbatim')
+  })
+
+  it('arms the session that was SURVEYED, not the one the client is sitting on', async () => {
+    // The fallback path: no explicit sessionId, so the survey ran against the
+    // client's active session. Arming any other id would watch the wrong repo.
+    const observe = createSpy()
+    const ctx = makeCtx({ sessionCiWatcher: { observe } })
+    await handler(ws, { id: 'c1', activeSessionId: 'sess-2' }, { type: 'session_pr_status_request' }, ctx)
+    soleReply(ctx)
+    assert.equal(observe.calls[0][0], 'sess-2')
+  })
+
+  it('a watcher whose observe() THROWS still yields exactly ONE reply, and the real snapshot', async () => {
+    // The hand-off runs AFTER send() and inside its own try. Left in the
+    // survey's try instead, a throw here lands in the degraded-reply catch and
+    // the client receives a SECOND `session_pr_status` for one request —
+    // breaking the one-reply property every other test in this file rests on.
+    const ctx = makeCtx({ sessionCiWatcher: { observe: () => { throw new Error('watcher exploded') } } })
+    await handler(ws, { id: 'c1' }, req, ctx)
+    const msg = soleReply(ctx)
+    assert.equal(msg.reason, null, 'the reply must still be the survey, not a degraded one')
+    assert.equal(msg.pr.number, 7419)
+  })
+
+  it('replies normally when no watcher is wired at all', async () => {
+    // `sessionCi.watch: false` leaves ctx.services.sessionCiWatcher null, and an
+    // older daemon has no such field. Absence is not an error.
+    for (const watcher of [null, undefined, {}]) {
+      const ctx = makeCtx({ sessionCiWatcher: watcher })
+      await handler(ws, { id: 'c1' }, req, ctx)
+      assert.equal(soleReply(ctx).reason, null)
+    }
+  })
+
+  it('does not arm on any path that never surveyed', async () => {
+    const cases = [
+      ['unauthorised', { id: 'c1', boundSessionId: 'sess-1' }, { type: 'session_pr_status_request', sessionId: 'sess-2' }, {}],
+      ['unknown session', { id: 'c1' }, { type: 'session_pr_status_request', sessionId: 'nope' }, {}],
+      ['survey threw', { id: 'c1' }, req, { surveySessionPrStatus: createSpy(async () => { throw new Error('boom') }) }],
+    ]
+    for (const [label, client, msg, overrides] of cases) {
+      const observe = createSpy()
+      const ctx = makeCtx({ sessionCiWatcher: { observe }, ...overrides })
+      await handler(ws, client, msg, ctx)
+      soleReply(ctx)
+      assert.equal(observe.callCount, 0, `${label}: nothing was surveyed, so there is nothing to arm`)
+    }
+  })
+
+  it('END TO END: this handler arms a REAL watcher, and one sweep then fires exactly one event', async () => {
+    // #7427's verification bar, verbatim: "Arm through the handler only (no
+    // sweep), then let one sweep observe the settled state: exactly one event."
+    //
+    // Every other test here injects a fake `{ observe }`, which would stay green
+    // against a real `observe()` that rejected the snapshot shape the survey
+    // actually produces, or whose arguments were in the other order. This one
+    // runs the production object.
+    const counts = (o) => ({ total: 2, passed: 0, failed: 0, pending: 0, skipped: 0, unknown: 0, ...o })
+    const PENDING = { ...SAMPLE, checks: { state: 'pending', counts: counts({ pending: 2 }) } }
+    const SETTLED = { ...SAMPLE, checks: { state: 'success', counts: counts({ passed: 2 }) } }
+
+    const events = []
+    const watcher = new SessionCiWatcher({
+      listSessions: () => [{ sessionId: 'sess-1', cwd: '/repo' }],
+      survey: async () => SETTLED,
+      notify: (e) => events.push(e),
+      wakeAgent: false,
+      logger: { debug() {}, info() {}, warn() {} },
+    })
+    const ctx = makeCtx({ sessionCiWatcher: watcher, surveySessionPrStatus: createSpy(async () => PENDING) })
+
+    // The handler is the ONLY thing that has ever seen this run pending. Before
+    // #7427 the sweep would not have surveyed this session for five minutes,
+    // and a run finishing inside that window fired nothing at all.
+    await handler(ws, { id: 'c1' }, req, ctx)
+    soleReply(ctx)
+    assert.equal(events.length, 0, 'the client-triggered path must not fire')
+
+    await watcher.tick()
+    assert.equal(events.length, 1, 'one sweep closes the transition the dashboard armed')
+    assert.equal(events[0].verdict, 'success')
+    assert.equal(events[0].prNumber, 7419)
+
+    await watcher.tick()
+    assert.equal(events.length, 1, 'and the arm is consumed — it cannot fire twice')
+  })
+
+  it('END TO END NEGATIVE: a handler observation of an ALREADY-settled PR fires nothing', async () => {
+    // The honest half. Nothing watched this run start, so no sweep may announce
+    // that it finished — otherwise every dashboard open replays the CI status of
+    // every long-finished branch on the machine.
+    const events = []
+    const watcher = new SessionCiWatcher({
+      listSessions: () => [{ sessionId: 'sess-1', cwd: '/repo' }],
+      survey: async () => SAMPLE,
+      notify: (e) => events.push(e),
+      wakeAgent: false,
+      logger: { debug() {}, info() {}, warn() {} },
+    })
+    // SAMPLE is already green (2 of 2 passed, nothing pending).
+    const ctx = makeCtx({ sessionCiWatcher: watcher })
+    await handler(ws, { id: 'c1' }, req, ctx)
+    soleReply(ctx)
+    await watcher.tick()
+    await watcher.tick()
+    assert.equal(events.length, 0)
+  })
+
+  it('POSITIVE CONTROL: the same ctx DOES arm on the path that surveyed', async () => {
+    // Without this, the refusals above would be satisfied by a handler that
+    // never calls observe() anywhere — including the one place it must.
+    const observe = createSpy()
+    const ctx = makeCtx({ sessionCiWatcher: { observe } })
+    await handler(ws, { id: 'c1' }, req, ctx)
+    assert.equal(observe.callCount, 1)
+  })
+})
 
 describe('#7344 — session_pr_status_request handler', () => {
   let ctx, ws

--- a/packages/server/tests/session-pr-status-handler.test.js
+++ b/packages/server/tests/session-pr-status-handler.test.js
@@ -92,6 +92,19 @@ describe('#7427 — the reply arms the CI watcher', () => {
     assert.equal(observe.calls[0][0], 'sess-2')
   })
 
+  it('arms only AFTER the reply is on the wire', async () => {
+    // The handler's doc block calls this order load-bearing, but the
+    // "throwing observe still yields ONE reply" test below actually pins the
+    // inner `try` — it stays green with the call moved ABOVE `send()`. Review on
+    // #7432 confirmed that mutation survives the whole 94-test suite, so the
+    // ordering gets its own assertion: read the send count AT call time.
+    let sendsAtObserveTime = null
+    const ctx = makeCtx({ sessionCiWatcher: { observe: () => { sendsAtObserveTime = ctx._send.callCount } } })
+    await handler(ws, { id: 'c1' }, req, ctx)
+    soleReply(ctx)
+    assert.equal(sendsAtObserveTime, 1, 'the client must have its answer before the watcher is touched')
+  })
+
   it('a watcher whose observe() THROWS still yields exactly ONE reply, and the real snapshot', async () => {
     // The hand-off runs AFTER send() and inside its own try. Left in the
     // survey's try instead, a throw here lands in the degraded-reply catch and

--- a/packages/server/tests/ws-server.test.js
+++ b/packages/server/tests/ws-server.test.js
@@ -4763,6 +4763,36 @@ describe('#5579: production handler ctx is deep-asserted at construction', () =>
     assert.doesNotThrow(() => assertCtxShape(ctx), 'shallow assert misses a missing key — that is the bug deep closes')
   })
 
+  it('#7427: the SessionCiWatcher reaches handlers through ctx.services', () => {
+    // The `session_pr_status_request` handler arms the CI watch by calling
+    // `ctx.services.sessionCiWatcher.observe(...)`. The deep assert above only
+    // proves the KEY is present — a getter returning the wrong thing, or a
+    // constructor option that is accepted and dropped, passes it. This reads
+    // the value back.
+    const watcher = { observe: () => 'armed' }
+    server = new WsServer({
+      port: 0,
+      apiToken: 'tok-ci-watch',
+      cliSession: createMockSession(),
+      authRequired: true,
+      sessionCiWatcher: watcher,
+    })
+    assert.equal(server._handlerCtx.services.sessionCiWatcher, watcher)
+  })
+
+  it('#7427: an absent watcher reads as null, not undefined', () => {
+    // `sessionCi.watch: false` builds no watcher at all. The handler's optional
+    // chain copes with either, but the roster documents this field as
+    // `object|null` and a deep-asserted ctx should not hand back `undefined`.
+    server = new WsServer({
+      port: 0,
+      apiToken: 'tok-ci-watch-off',
+      cliSession: createMockSession(),
+      authRequired: true,
+    })
+    assert.equal(server._handlerCtx.services.sessionCiWatcher, null)
+  })
+
   // #5837: the terminal-mirror coalescer gate. These drive _syncTerminalMirror /
   // _handleClientDeparture directly (no socket) to lock in the 0↔1 crossing on
   // the disconnect path — the riskiest one (a stuck-OFF mirror = a viewer sees a


### PR DESCRIPTION
## What

`SessionCiWatcher` (#7426) fires only on a pending→settled transition it observed itself, and its sweep surveys an **unarmed** session only every `discoveryIntervalMs` (5 min). A CI run that starts *and* finishes between two of those passes was never seen pending, so it never fired at all.

The dashboard already surveys the same thing on demand through `session_pr_status_request` (#7422), and auto-pulls on a rate-limited timer while a human is looking. This wires that reply into the watcher: **opening the dashboard arms the watch**, and the discovery interval stops being the thing that decides whether a fast run is noticed.

## `observe()` arms, and never fires

Both halves of that are load-bearing:

- **Never fires** — the watcher stays the only thing that decides a completion happened, so no client action can replay an event the user already received. It costs nothing: an *armed* session is due on **every** tick, so the sweep closes the transition within `tickIntervalMs` (a minute) rather than within `discoveryIntervalMs`. All the value of this path is in the arm.
- **A settled reading leaves the arm INTACT.** Consuming it without firing would be strictly worse than either alternative — the sweep's own settled reading would then find nothing armed and the completion would be lost outright.

It also stamps `lastSurveyedAt`, so a dashboard pull defers the sweep's own *discovery* survey for that session and the two paths don't spawn `gh` twice in a row. It does **not** defer an armed session — those stay due every tick, which is what keeps the latency at one minute.

A malformed snapshot is refused rather than forwarded: `_reconcile` reads a missing `pr` as the quiet "no open PR" negative and **drops the arm**, so handing it nothing would cancel a watch the user is waiting on.

## Wiring

`sessionCiWatcher` joins `services` at all four sites #7403 named — the `CTX_NAMESPACES` roster, the `WsHandlerServices` typedef, ws-server's `_handlerCtx`, and its constructor (`nsCtx()` routes it from the roster automatically). `server-cli` now builds the watcher **before** the `WsServer` so it can be passed in; `start()` and the `ServerOrchestrator` hand-off are unchanged.

The hand-off in the handler runs **after** `send()` and inside its own `try`. Left in the survey's `try`, a throwing watcher would land in the degraded-reply catch and emit a *second* `session_pr_status` for one request — breaking the one-reply-per-request property the whole handler rests on.

## Verification

#7427's bar verbatim: arm through the handler only (no sweep), let one sweep observe the settled state — **exactly one event**; and the negative, a handler observation of a *settled* PR that was never seen pending fires nothing. Both are end-to-end tests driving the handler into a **real** `SessionCiWatcher`, not a fake `{ observe }`.

Every guard was proven red by mutation (baseline green, each mutant killed by its own named test, fast and legible):

| Mutation | Killed by |
|---|---|
| drop `sessionCiWatcher,` from `new WsServer({` | anchored slice of the ctor argument list |
| drop the handler's `observe()` call | 4 tests, incl. the end-to-end arm |
| remove the hand-off's own `try` | "a throwing observe() still yields exactly ONE reply" |
| `observe()` fires (`fire: true`) | "leaves the arm INTACT" |
| `observe()` consumes the arm | "leaves the arm INTACT" |
| drop the `lastSurveyedAt` stamp | the discovery-deferral test |
| drop the malformed-snapshot guard | "refuses a malformed observation" |
| `observe()` inert | 10 tests |
| ctx getter returns null | ws-server read-back test |

The source-slice assertion carries a positive control both ways: the slice must contain a known sibling argument (`schedulerEngine,`) and must **not** reach `buildSessionCiWatcher(` above it, so the construction site alone cannot satisfy it. The deferral test carries the control that the same tick *does* survey without a dashboard pull, and the malformed-snapshot test carries the control that a real "no open PR" reading *does* drop the arm.

## Tests

285 pass / 0 fail across `session-ci-watcher`, `session-pr-status-handler`, `ws-server`, `ws-handler-context-typedef-parity`, `test-helpers`, `server-orchestrator`. All nine `packages/server/scripts/lint-*.sh` pass; eslint clean (0 errors).

Closes #7427