### PR TITLE
feat(models): re-enable claude-fable-5 in the model picker

### DIFF
--- a/docs/guides/model-overlay.md
+++ b/docs/guides/model-overlay.md
@@ -83,7 +83,7 @@ The overlay is watched and re-folded into the registry on change ([#5932](https:
 ## Notes & limits
 
 - **Secrets never belong here** (same posture as `config.json`) — the overlay only carries model metadata.
-- `claude-fable-5` is disallowed and **cannot be reintroduced** via the overlay ([#6219](https://github.com/blamechris/chroxy/issues/6219)).
+- `claude-fable-5` (Fable) is GA and selectable — it was banned as a preview in [#6219](https://github.com/blamechris/chroxy/issues/6219) and re-enabled once it shipped generally. The `DISALLOWED_MODEL_IDS` mechanism is retained (empty) so a future model can be excluded the same way.
 - Untagged entries are Claude-registry-scoped; use a `provider` field for other providers (see [Targeting a specific provider](#targeting-a-specific-provider-non-claude)). `pricing` overrides apply to Claude and DeepSeek (the providers that report per-token cost).
 - This complements, not replaces, the SDK's live `supportedModels()` push — a brand-new Claude model the SDK already knows about appears with no overlay at all; the overlay is for getting *ahead* of the build (or fixing a label/price) before the SDK or a release catches up.
 

--- a/packages/dashboard/src/components/ModelPickerModal.tsx
+++ b/packages/dashboard/src/components/ModelPickerModal.tsx
@@ -5,7 +5,7 @@
  * filter, and is keyboard-navigable (Esc/Tab via the shared Modal; Arrow keys to
  * move between options, Enter/click to select).
  *
- * Disallowed models (e.g. fable, #6219) are excluded upstream in the server
+ * Disallowed models are excluded upstream in the server (DISALLOWED_MODEL_IDS,
  * registry so they never reach `availableModels`; as a defensive forward-compat
  * hook this also renders any entry flagged `disabled` as a non-selectable row.
  */

--- a/packages/dashboard/src/components/ModelPickerModal.tsx
+++ b/packages/dashboard/src/components/ModelPickerModal.tsx
@@ -5,9 +5,10 @@
  * filter, and is keyboard-navigable (Esc/Tab via the shared Modal; Arrow keys to
  * move between options, Enter/click to select).
  *
- * Disallowed models are excluded upstream in the server (DISALLOWED_MODEL_IDS,
- * registry so they never reach `availableModels`; as a defensive forward-compat
- * hook this also renders any entry flagged `disabled` as a non-selectable row.
+ * Disallowed models (via `DISALLOWED_MODEL_IDS`) are excluded upstream in the
+ * server registry so they never reach `availableModels`; as a defensive
+ * forward-compat hook this also renders any entry flagged `disabled` as a
+ * non-selectable row.
  */
 import { useMemo, useState, useRef, useEffect, useCallback } from 'react'
 import { Modal } from './Modal'

--- a/packages/dashboard/src/lib/model-pricing.ts
+++ b/packages/dashboard/src/lib/model-pricing.ts
@@ -35,8 +35,8 @@ const CLAUDE_PRICING: Record<string, ModelPricing> = {
   // server-authoritative). They exist to remove the stale 3.x-era data and
   // keep the table right for any future consumer / if Claude is ever added to
   // that set. (#6233: the Opus head is claude-opus-4-8, matching the server
-  // registry since #6219. fable-5 is intentionally absent — the server now
-  // disallows it and filters it out of the registry entirely (#6219), so no
+  // registry since #6219. Claude pricing stays server-authoritative (this
+  // client table is not used for Claude — not in CLIENT_ESTIMATED_COST_PROVIDERS), so no
   // client ever sees it; broader single-source tracked under #5631. The `[1m]`
   // long-context variants are also absent: this flat
   // USD/1k table can't represent the >200K premium tier the server models in

--- a/packages/dashboard/src/lib/model-pricing.ts
+++ b/packages/dashboard/src/lib/model-pricing.ts
@@ -35,9 +35,9 @@ const CLAUDE_PRICING: Record<string, ModelPricing> = {
   // server-authoritative). They exist to remove the stale 3.x-era data and
   // keep the table right for any future consumer / if Claude is ever added to
   // that set. (#6233: the Opus head is claude-opus-4-8, matching the server
-  // registry since #6219. Claude pricing stays server-authoritative (this
-  // client table is not used for Claude — not in CLIENT_ESTIMATED_COST_PROVIDERS), so no
-  // client ever sees it; broader single-source tracked under #5631. The `[1m]`
+  // registry since #6219. This client table is not on any live Claude cost
+  // path — Claude is not in CLIENT_ESTIMATED_COST_PROVIDERS, so Claude cost
+  // stays server-authoritative; broader single-source tracked under #5631. The `[1m]`
   // long-context variants are also absent: this flat
   // USD/1k table can't represent the >200K premium tier the server models in
   // its `oneM.longContext` block (#4087), and no model carries a [1m] row here.

--- a/packages/server/src/claude-model-catalog.js
+++ b/packages/server/src/claude-model-catalog.js
@@ -104,7 +104,7 @@ export function claudeDeriveId(fullId) {
 //     derived via resolveClaudeContextWindow(fullId), so the derivation is
 //     byte-identical to the prior CLAUDE_FALLBACK_MODELS literals.
 //   pricing — base Anthropic rates in USD per million tokens
-//     {input, output, cacheRead, cacheWrite}. ABSENT (e.g. fable, shipped
+//     {input, output, cacheRead, cacheWrite}. ABSENT (a model shipped
 //     without verified pricing) emits NO pricing key, so resolveModelPricing
 //     returns null — never $0 — for it.
 //   oneM — the `[1m]` long-context variant's rates, including the `longContext`
@@ -138,9 +138,29 @@ const MODEL_METADATA = Object.freeze([
       },
     },
   }),
-  // #6219 — Fable (claude-fable-5) is disallowed for chroxy and removed from the
-  // roster. It is also filtered out of any SDK-returned list (DISALLOWED_MODEL_IDS
-  // in models.js) so it can't reappear in SDK/TUI modes, not just the CLI fallback.
+  // Fable (claude-fable-5) — GA and selectable (re-enabled after #6219, which
+  // banned it as a preview). 1M context (set explicitly; the fullId does not
+  // match the opus-version heuristic, which would wrongly default it to 200k).
+  // Rates: Anthropic API reference ($10/$50 in/out); cache at the standard
+  // 0.1x read / 1.25x write. Fable bills FLAT — no >200K premium (unlike Opus
+  // 4.x) — but it IS a 1M model, so updateModels synthesizes a `claude-fable-5[1m]`
+  // chip. Ship an explicit `oneM` block whose `longContext` equals the base rates:
+  // it keeps [1m] cost correct AND carries the `longContext` key the #4106 drift
+  // guard (models.js) requires, so the guard does not falsely warn "bills may lie"
+  // for a model whose bills do not lie. If Anthropic ever adds a Fable >200K
+  // premium, raise the longContext rates here.
+  Object.freeze({
+    shortId: 'fable', label: 'Fable', fullId: 'claude-fable-5',
+    contextWindow: 1_000_000,
+    pricing: { input: 10.00, output: 50.00, cacheRead: 1.00, cacheWrite: 12.50 },
+    oneM: {
+      input: 10.00, output: 50.00, cacheRead: 1.00, cacheWrite: 12.50,
+      longContext: {
+        thresholdInputTokens: 200_000,
+        input: 10.00, output: 50.00, cacheRead: 1.00, cacheWrite: 12.50,
+      },
+    },
+  }),
   Object.freeze({
     shortId: 'haiku', label: 'Haiku', fullId: 'claude-haiku-4-5',
     pricing: { input: 1.00, output: 5.00, cacheRead: 0.10, cacheWrite: 1.25 },

--- a/packages/server/src/models.js
+++ b/packages/server/src/models.js
@@ -23,15 +23,17 @@ const log = createLogger('models')
 // drift-guard read the imported CLAUDE_PRICING_USD_PER_MTOK / resolvePricingKey.
 export { DEFAULT_CONTEXT_WINDOW, ONE_M_SUFFIX, resolveClaudeContextWindow, claudeDeriveId, FALLBACK_MODELS }
 
-// #6219 — fullIds chroxy disallows regardless of source: the CLI fallback (gone
-// already, removed from MODEL_METADATA), the Agent SDK's supportedModels() push,
-// the disk cache, AND a user models-overlay.json. Fable (claude-fable-5) is
-// currently the only one. Keyed on the FULL id (not the short `fable` alias) so
-// the precise disallowed model is dropped without false-positiving an unrelated
-// overlay/SDK entry that merely uses `fable` as a short label. The short alias
-// can't resurface anyway — it only ever resolved to claude-fable-5, now removed.
-// The `[1m]` variant is also matched. Exported for tests + future enforcement.
-export const DISALLOWED_MODEL_IDS = Object.freeze(new Set(['claude-fable-5']))
+// fullIds chroxy disallows regardless of source (the Agent SDK's supportedModels()
+// push, the disk cache, and a user models-overlay.json). Keyed on the FULL id (not a
+// short alias) so a precise model is dropped without false-positiving an overlay/SDK
+// entry that merely reuses the alias; the `[1m]` variant is matched too.
+//
+// The Set is EMPTY on purpose. #6219 banned claude-fable-5 as a preview; it is now GA
+// (fleet doctrine skill-templates#236 scopes it to HIGH-tier orchestration with a
+// spend ceiling — allowed, not banned), so it was removed from the ban. The plumbing
+// (isDisallowedModelId + its call sites + the #6232 dangling-default guard) is retained
+// for a future disallow — do NOT delete it as dead code.
+export const DISALLOWED_MODEL_IDS = Object.freeze(new Set())
 
 /**
  * True when a model id resolves to a disallowed fullId, normalising the same id

--- a/packages/server/tests/claude-model-catalog.test.js
+++ b/packages/server/tests/claude-model-catalog.test.js
@@ -47,14 +47,29 @@ describe('claude-model-catalog (#6201 OCP characterization)', () => {
     })
   })
 
-  it('prices exactly the intended keys — fable absent, no unverified-pricing $0 (#6219)', () => {
+  it('prices exactly the intended keys — fable GA, no unverified-pricing $0 (#6219 revert)', () => {
     assert.deepEqual(Object.keys(CLAUDE_PRICING_USD_PER_MTOK).sort(), [
+      'claude-fable-5',
+      'claude-fable-5[1m]',
       'claude-haiku-4-5',
       'claude-opus-4-8',
       'claude-opus-4-8[1m]',
       'claude-sonnet-4-6',
     ])
-    assert.ok(!('claude-fable-5' in CLAUDE_PRICING_USD_PER_MTOK))
+    // Fable is a 1M model, so it carries an explicit `claude-fable-5[1m]` key.
+    // Its pricing is FLAT — the [1m] rates and the longContext tier equal the
+    // base rates (no >200K premium), which keeps cost correct AND gives the
+    // #4106 drift guard the longContext block it needs so it does not warn.
+    assert.ok('claude-fable-5' in CLAUDE_PRICING_USD_PER_MTOK)
+    assert.ok('claude-fable-5[1m]' in CLAUDE_PRICING_USD_PER_MTOK)
+    assert.deepEqual(CLAUDE_PRICING_USD_PER_MTOK['claude-fable-5'], {
+      input: 10.00, output: 50.00, cacheRead: 1.00, cacheWrite: 12.50,
+    })
+    assert.equal(CLAUDE_PRICING_USD_PER_MTOK['claude-fable-5[1m]'].input, 10.00)
+    assert.equal(
+      CLAUDE_PRICING_USD_PER_MTOK['claude-fable-5[1m]'].longContext.input, 10.00,
+      'fable is flat — the >200K longContext rate equals base',
+    )
   })
 
   it('keeps pricing entries (incl. the nested longContext premium) deep-frozen', () => {
@@ -69,6 +84,7 @@ describe('claude-model-catalog (#6201 OCP characterization)', () => {
     assert.deepStrictEqual([...CLAUDE_FALLBACK_MODELS], [
       { id: 'sonnet', label: 'Sonnet', fullId: 'claude-sonnet-4-6', contextWindow: 200_000 },
       { id: 'opus', label: 'Opus', fullId: 'claude-opus-4-8', contextWindow: 1_000_000 },
+      { id: 'fable', label: 'Fable', fullId: 'claude-fable-5', contextWindow: 1_000_000 },
       { id: 'haiku', label: 'Haiku', fullId: 'claude-haiku-4-5', contextWindow: 200_000 },
     ])
     assert.ok(Object.isFrozen(CLAUDE_FALLBACK_MODELS))

--- a/packages/server/tests/models-metadata-derivation.test.js
+++ b/packages/server/tests/models-metadata-derivation.test.js
@@ -36,7 +36,9 @@ const FALLBACK_MODELS_SNAPSHOT = [
 ]
 
 // CLAUDE_PRICING_USD_PER_MTOK snapshot. Fable is back (GA, #6219 revert) with
-// flat pricing — no >200K premium tier, so no `claude-fable-5[1m]` entry.
+// flat pricing — the `claude-fable-5[1m]` entry exists but its longContext
+// tier equals the base rates (no >200K premium). Priced keys are asserted
+// exhaustively in claude-model-catalog.test.js; this snapshot checks a subset.
 const CLAUDE_PRICING_SNAPSHOT = {
   'claude-sonnet-4-6': { input: 3.00, output: 15.00, cacheRead: 0.30, cacheWrite: 3.75 },
   'claude-opus-4-8': { input: 15.00, output: 75.00, cacheRead: 1.50, cacheWrite: 18.75 },

--- a/packages/server/tests/models-metadata-derivation.test.js
+++ b/packages/server/tests/models-metadata-derivation.test.js
@@ -23,18 +23,20 @@ import {
 // Verbatim pre-consolidation FALLBACK_MODELS (contextWindow values inlined to
 // what resolveClaudeContextWindow returned at authoring time, so a regression in
 // the heuristic ALSO trips this test, not just a far-away window test).
-// #6219 updated the intended roster: Opus head bumped 4-7 → 4-8, and Fable
-// (disallowed) removed. The snapshot tracks the CURRENT intended set — the proof
-// is still "the derived table deep-equals the declared literal", just against the
-// post-#6219 roster, not the original #5930 freeze.
+// #6219 originally removed Fable (disallowed); that ban was reverted (fable is
+// GA again, allowed not banned — see models.js DISALLOWED_MODEL_IDS comment),
+// so the snapshot restores its original slot between opus and haiku. The proof
+// is still "the derived table deep-equals the declared literal", just against
+// the current intended roster.
 const FALLBACK_MODELS_SNAPSHOT = [
   { id: 'sonnet', label: 'Sonnet', fullId: 'claude-sonnet-4-6', contextWindow: 200_000 },
   { id: 'opus', label: 'Opus', fullId: 'claude-opus-4-8', contextWindow: 1_000_000 },
+  { id: 'fable', label: 'Fable', fullId: 'claude-fable-5', contextWindow: 1_000_000 },
   { id: 'haiku', label: 'Haiku', fullId: 'claude-haiku-4-5', contextWindow: 200_000 },
 ]
 
-// CLAUDE_PRICING_USD_PER_MTOK snapshot. Fable is ABSENT (removed in #6219;
-// chroxy never shipped verified fable rates anyway — cost "unknown", never $0).
+// CLAUDE_PRICING_USD_PER_MTOK snapshot. Fable is back (GA, #6219 revert) with
+// flat pricing — no >200K premium tier, so no `claude-fable-5[1m]` entry.
 const CLAUDE_PRICING_SNAPSHOT = {
   'claude-sonnet-4-6': { input: 3.00, output: 15.00, cacheRead: 0.30, cacheWrite: 3.75 },
   'claude-opus-4-8': { input: 15.00, output: 75.00, cacheRead: 1.50, cacheWrite: 18.75 },
@@ -45,6 +47,7 @@ const CLAUDE_PRICING_SNAPSHOT = {
       input: 30.00, output: 150.00, cacheRead: 3.00, cacheWrite: 37.50,
     },
   },
+  'claude-fable-5': { input: 10.00, output: 50.00, cacheRead: 1.00, cacheWrite: 12.50 },
   'claude-haiku-4-5': { input: 1.00, output: 5.00, cacheRead: 0.10, cacheWrite: 1.25 },
 }
 
@@ -64,7 +67,7 @@ describe('#5930 model-metadata consolidation is a pure restructure', () => {
   it('FALLBACK_MODELS preserves the exact roster + order', () => {
     assert.deepStrictEqual(
       FALLBACK_MODELS.map((m) => m.id),
-      ['sonnet', 'opus', 'haiku'],
+      ['sonnet', 'opus', 'fable', 'haiku'],
     )
   })
 
@@ -85,9 +88,11 @@ describe('#5930 model-metadata consolidation is a pure restructure', () => {
     }
   })
 
-  it('fable is fully removed (#6219) — not in the roster, no pricing', () => {
-    assert.ok(!FALLBACK_MODELS.some((m) => m.id === 'fable' || m.fullId === 'claude-fable-5'))
-    assert.equal(getModelPricing('claude-fable-5'), null)
+  it('fable is GA and priced (#6219 revert) — present in the roster with flat pricing', () => {
+    assert.ok(FALLBACK_MODELS.some((m) => m.id === 'fable' && m.fullId === 'claude-fable-5'))
+    assert.deepStrictEqual(getModelPricing('claude-fable-5'), {
+      input: 10.00, output: 50.00, cacheRead: 1.00, cacheWrite: 12.50,
+    })
   })
 
   it('keeps pricing entries (incl. the nested longContext premium) deep-frozen', () => {

--- a/packages/server/tests/models-overlay-reload.test.js
+++ b/packages/server/tests/models-overlay-reload.test.js
@@ -10,6 +10,8 @@ import {
   watchModelsOverlay,
   getModels,
   _resetModelsOverlayForTests,
+  DISALLOWED_MODEL_IDS,
+  isDisallowedModelId,
 } from '../src/models.js'
 
 /**
@@ -52,12 +54,22 @@ describe('registry.applyOverlay (#5932)', () => {
     assert.ok(reg.getAllowedModelIds().has('fable-9'))
   })
 
-  it('#6219 — a disallowed fullId (claude-fable-5) cannot be re-added via overlay', () => {
+  it('#6219 revert — the disallow-overlay-row guard is retained but inert (DISALLOWED_MODEL_IDS is empty)', () => {
+    // computeFallbackModels() still skips any overlay row whose shortId/fullId
+    // resolves to a disallowed id (see models.js ~L499) — that mechanism is kept
+    // for a future disallow — but claude-fable-5's ban was reverted (GA again,
+    // not banned), so DISALLOWED_MODEL_IDS is now frozen EMPTY and there is no
+    // way to inject a synthetic banned id at runtime to exercise the skip
+    // branch. Pin the guard's precondition (nothing is disallowed) and the
+    // resulting behavior change: an overlay CAN re-add claude-fable-5 now.
+    assert.equal(DISALLOWED_MODEL_IDS.size, 0)
+    assert.equal(isDisallowedModelId('claude-fable-5'), false)
+
     const reg = makeRegistry()
     reg.applyOverlay(overlayMap({ 'claude-fable-5': { shortId: 'fable', label: 'Fable' } }))
-    assert.ok(!reg.getModels().some((m) => m.fullId === 'claude-fable-5'), 'disallowed overlay row must be skipped')
-    assert.ok(!reg.getAllowedModelIds().has('claude-fable-5'))
-    // An unrelated overlay id that merely uses `fable` as a label is unaffected.
+    assert.ok(reg.getModels().some((m) => m.fullId === 'claude-fable-5'), 'fable overlay row lands now that it is allowed')
+    assert.ok(reg.getAllowedModelIds().has('claude-fable-5'))
+    // An unrelated overlay id that merely uses `fable` as a label still lands too.
     reg.applyOverlay(overlayMap({ 'fable-9': { shortId: 'fable', label: 'Fable' } }))
     assert.ok(reg.getModels().some((m) => m.fullId === 'fable-9'), 'non-disallowed overlay row still lands')
   })

--- a/packages/server/tests/models-per-provider.test.js
+++ b/packages/server/tests/models-per-provider.test.js
@@ -82,8 +82,8 @@ describe('provider static metadata hooks', () => {
     const allowed = new Set(SdkSession.getAllowedModels())
     assert.ok(allowed.has('opus'))
     assert.ok(allowed.has('claude-opus-4-8'))
-    // #6219 — opus head bumped 4-7 → 4-8; fable removed/disallowed.
-    assert.ok(!allowed.has('claude-fable-5'))
+    // #6219 — opus head bumped 4-7 → 4-8. Fable's ban was reverted (GA again).
+    assert.ok(allowed.has('claude-fable-5'))
     assert.ok(!allowed.has('opus-4-6'))
     assert.ok(!allowed.has('claude-opus-4-6'))
   })
@@ -93,8 +93,8 @@ describe('provider static metadata hooks', () => {
     const allowed = new Set(CliSession.getAllowedModels())
     assert.ok(allowed.has('opus'))
     assert.ok(allowed.has('claude-opus-4-8'))
-    // #6219 — opus head bumped 4-7 → 4-8; fable removed/disallowed.
-    assert.ok(!allowed.has('claude-fable-5'))
+    // #6219 — opus head bumped 4-7 → 4-8. Fable's ban was reverted (GA again).
+    assert.ok(allowed.has('claude-fable-5'))
     assert.ok(!allowed.has('opus-4-6'))
     assert.ok(!allowed.has('claude-opus-4-6'))
   })
@@ -176,7 +176,7 @@ describe('createModelsRegistry(providerHooks)', () => {
   it('backward compat: no args => Claude-style defaults (FALLBACK_MODELS, claude- stripping)', () => {
     const r = createModelsRegistry()
     const ids = r.getModels().map(m => m.id).sort()
-    assert.deepEqual(ids, ['haiku', 'opus', 'sonnet']) // #6219 — fable removed
+    assert.deepEqual(ids, ['fable', 'haiku', 'opus', 'sonnet']) // #6219 revert — fable is GA again
     const converted = r.updateModels([
       { value: 'claude-opus-4-7', displayName: 'Opus 4.7', description: '' },
     ])

--- a/packages/server/tests/models.test.js
+++ b/packages/server/tests/models.test.js
@@ -199,12 +199,12 @@ describe('updateModels', () => {
       updateModels([
         { value: 'claude-opus-4-8', displayName: 'Opus 4.8', description: '' },
       ])
-      // Fable is a merged fallback (GA again, #6219 revert) whose own 1M window
-      // synthesizes a claude-fable-5[1m] chip with no pricing entry of its own
-      // (flat pricing, no oneM block) — that drift warning is expected and
-      // unrelated to this test, so scope the assertion to the opus-4-8[1m]
-      // variant this test is actually about.
-      const drift = warnings.filter(w => w.includes('pricing-table drift') && w.includes('claude-opus-4-8[1m]'))
+      // No 1M variant here should warn: opus-4-8[1m] has an explicit pricing
+      // entry with a longContext premium, and the merged fable fallback's
+      // claude-fable-5[1m] carries a flat longContext block too (#6219 revert),
+      // so the guard stays silent for BOTH. Assert zero drift warnings of any
+      // kind — the unscoped form is the stronger assertion.
+      const drift = warnings.filter(w => w.includes('pricing-table drift'))
       assert.equal(drift.length, 0, `unexpected drift warning: ${JSON.stringify(warnings)}`)
     })
 

--- a/packages/server/tests/models.test.js
+++ b/packages/server/tests/models.test.js
@@ -22,9 +22,9 @@ describe('FALLBACK_MODELS (default registry)', () => {
     }
   })
 
-  it('contains sonnet, opus, and haiku aliases', () => {
+  it('contains sonnet, opus, haiku, and fable aliases', () => {
     const ids = FALLBACK_MODELS.map(m => m.id).sort()
-    assert.deepEqual(ids, ['haiku', 'opus', 'sonnet']) // #6219 — fable removed
+    assert.deepEqual(ids, ['fable', 'haiku', 'opus', 'sonnet']) // #6219 revert — fable is GA again
   })
 
   it('each entry has id, label, fullId, and contextWindow', () => {
@@ -199,7 +199,12 @@ describe('updateModels', () => {
       updateModels([
         { value: 'claude-opus-4-8', displayName: 'Opus 4.8', description: '' },
       ])
-      const drift = warnings.filter(w => w.includes('pricing-table drift'))
+      // Fable is a merged fallback (GA again, #6219 revert) whose own 1M window
+      // synthesizes a claude-fable-5[1m] chip with no pricing entry of its own
+      // (flat pricing, no oneM block) — that drift warning is expected and
+      // unrelated to this test, so scope the assertion to the opus-4-8[1m]
+      // variant this test is actually about.
+      const drift = warnings.filter(w => w.includes('pricing-table drift') && w.includes('claude-opus-4-8[1m]'))
       assert.equal(drift.length, 0, `unexpected drift warning: ${JSON.stringify(warnings)}`)
     })
 
@@ -262,11 +267,11 @@ describe('updateModels', () => {
     assert.equal(result[1].fullId, 'claude-opus-4-6')
     assert.equal(result[1].contextWindow, 1_000_000)
 
-    // Fallback entries the SDK didn't list are appended (Opus 4.8, Haiku 4.5).
-    // #6219 — fable removed from the roster, so it is no longer merged.
+    // Fallback entries the SDK didn't list are appended (Opus 4.8, Fable, Haiku 4.5).
+    // #6219 revert — fable is GA again, so it IS merged like any other fallback.
     const fullIds = result.map(m => m.fullId)
     assert.ok(fullIds.includes('claude-opus-4-8'), 'opus 4.8 fallback should be merged in')
-    assert.ok(!fullIds.includes('claude-fable-5'), 'fable must not be merged (disallowed)')
+    assert.ok(fullIds.includes('claude-fable-5'), 'fable fallback should be merged in')
     assert.ok(fullIds.includes('claude-haiku-4-5'), 'haiku 4.5 fallback should be merged in')
 
     // 1M variants are synthesized for any 1M-context model that lacks one.
@@ -956,58 +961,75 @@ describe('isClaudeProvider — Claude-family provider allowlist', () => {
   })
 })
 
-// #6219 — Fable (claude-fable-5) is disallowed across ALL sources.
-describe('disallowed models (#6219)', () => {
+// #6219 revert — Fable (claude-fable-5)'s ban was lifted (GA, not disallowed).
+// DISALLOWED_MODEL_IDS is now frozen EMPTY; the plumbing (isDisallowedModelId +
+// its call sites + the #6232 dangling-default guard) is retained on purpose for
+// a future disallow — see the comment on DISALLOWED_MODEL_IDS in models.js. Since
+// the Set is frozen and empty, these tests can no longer inject a synthetic
+// banned id at runtime; they instead pin (a) the guard's precondition — nothing
+// is disallowed — and (b) the resulting revert behavior — fable flows through
+// every path unchanged, same as opus/haiku.
+describe('disallowed models (#6219 revert)', () => {
   beforeEach(() => resetModels())
   afterEach(() => resetModels())
 
-  it('isDisallowedModelId matches claude-fable-5 (and its [1m] variant), not allowed models', () => {
-    assert.ok(DISALLOWED_MODEL_IDS.has('claude-fable-5'))
-    assert.equal(isDisallowedModelId('claude-fable-5'), true)
-    assert.equal(isDisallowedModelId('claude-fable-5[1m]'), true)
-    // Dated SDK forms (claude-*-YYYYMMDD) and dated+[1m] also normalise + match.
-    assert.equal(isDisallowedModelId('claude-fable-5-20251201'), true)
-    assert.equal(isDisallowedModelId('claude-fable-5-20251201[1m]'), true)
+  it('DISALLOWED_MODEL_IDS is empty and frozen; isDisallowedModelId matches nothing', () => {
+    assert.ok(Object.isFrozen(DISALLOWED_MODEL_IDS))
+    assert.equal(DISALLOWED_MODEL_IDS.size, 0)
+    assert.equal(isDisallowedModelId('claude-fable-5'), false)
+    assert.equal(isDisallowedModelId('claude-fable-5[1m]'), false)
+    // Dated SDK forms (claude-*-YYYYMMDD) and dated+[1m] still normalise the
+    // same way — they just no longer resolve to a disallowed entry.
+    assert.equal(isDisallowedModelId('claude-fable-5-20251201'), false)
+    assert.equal(isDisallowedModelId('claude-fable-5-20251201[1m]'), false)
     assert.equal(isDisallowedModelId('claude-opus-4-8'), false)
     assert.equal(isDisallowedModelId('claude-opus-4-8-20251201'), false)
     assert.equal(isDisallowedModelId('claude-sonnet-4-6'), false)
-    // The bare short alias is NOT keyed (avoids clobbering unrelated overlay
-    // ids that merely use `fable` as a label) — only the real fullId is.
     assert.equal(isDisallowedModelId('fable'), false)
     assert.equal(isDisallowedModelId(undefined), false)
   })
 
-  it('fable is absent from FALLBACK_MODELS and the allowlist', () => {
-    assert.ok(!FALLBACK_MODELS.some((m) => m.fullId === 'claude-fable-5'))
-    assert.ok(!ALLOWED_MODEL_IDS.has('claude-fable-5'))
-    assert.ok(!ALLOWED_MODEL_IDS.has('fable'))
+  it('fable is present in FALLBACK_MODELS and the allowlist', () => {
+    assert.ok(FALLBACK_MODELS.some((m) => m.fullId === 'claude-fable-5'))
+    assert.ok(ALLOWED_MODEL_IDS.has('claude-fable-5'))
+    assert.ok(ALLOWED_MODEL_IDS.has('fable'))
   })
 
-  it('updateModels strips an SDK-returned claude-fable-5 (disallowed in SDK/TUI too)', () => {
+  it('updateModels no longer strips an SDK-returned claude-fable-5', () => {
     updateModels([
       { value: 'claude-sonnet-4-6', displayName: 'Default (Sonnet 4.6)', description: '' },
       { value: 'claude-fable-5', displayName: 'Fable 5', description: '' },
     ])
     const fullIds = getModels().map((m) => m.fullId)
-    assert.ok(!fullIds.includes('claude-fable-5'), 'SDK-returned fable must be filtered out')
-    assert.ok(!ALLOWED_MODEL_IDS.has('claude-fable-5'), 'fable must not enter the allowlist')
+    assert.ok(fullIds.includes('claude-fable-5'), 'SDK-returned fable is allowed again and must pass through')
+    assert.ok(ALLOWED_MODEL_IDS.has('claude-fable-5'), 'fable enters the allowlist')
     // A legitimate SDK model alongside it still lands.
     assert.ok(fullIds.includes('claude-sonnet-4-6'))
   })
 
-  it('does not leave defaultModelId pointing at a filtered-out disallowed model (#6232)', () => {
-    // SDK marks the disallowed model as "Default" — after filtering it out the
-    // default must re-resolve to a real model, never a dangling fable id.
+  it('the #6232 dangling-default guard is retained though currently unreachable (nothing gets filtered)', () => {
+    // #6232's original scenario (SDK marks the disallowed model "Default", it
+    // gets filtered by applyModels()'s disallow check, defaultModelId would
+    // otherwise dangle) can't be reproduced anymore: DISALLOWED_MODEL_IDS is
+    // frozen empty, so applyModels() never filters anything and the guard's
+    // "defaultPresent" branch is a no-op for every input today. What IS still
+    // true post-revert: marking fable "Default" resolves the registry's
+    // default TO fable — proving nothing strips it before defaultModelId is
+    // set (the guard's precondition — a disallowed default — never fires).
     updateModels([
       { value: 'claude-fable-5', displayName: 'Default (Fable 5)', description: '' },
       { value: 'claude-sonnet-4-6', displayName: 'Sonnet 4.6', description: '' },
     ])
     const def = getDefaultModelId()
     const fullIds = getModels().map((m) => m.fullId)
-    assert.ok(!fullIds.includes('claude-fable-5'), 'fable filtered out')
-    assert.notEqual(def, 'fable', 'default must not be the filtered-out disallowed short id')
-    assert.notEqual(def, 'claude-fable-5', 'default must not be the filtered-out disallowed fullId')
-    // The re-picked default resolves to a model that is actually in the list.
+    assert.ok(fullIds.includes('claude-fable-5'), 'fable is allowed again and stays in the list')
+    // The default resolves to a model that is actually in the list — and
+    // since nothing filtered fable out, that model IS fable (the one marked
+    // "Default"), not a re-picked stand-in.
     assert.ok(def != null && getModels().some((m) => m.id === def || m.fullId === def), 'default resolves to a present model')
+    // Default registry has no getModelMetadata() hook, so the SDK-derived id
+    // strips only the `claude-` prefix (like `opus-4-6` elsewhere) rather than
+    // using the fallback's static `fable` short alias.
+    assert.equal(def, 'fable-5', 'default resolves to the fable entry — the guard never fires because nothing is disallowed')
   })
 })


### PR DESCRIPTION
Re-enables `claude-fable-5` in chroxy's model picker. Fable was banned in #6219 when it was a preview; it is now GA and selectable — fleet doctrine (skill-templates#236) scopes it to HIGH-tier orchestration with a spend ceiling, i.e. allowed-with-a-guardrail, not banned.

## Changes

**Source (2 files)**
- `claude-model-catalog.js` — add the Fable row to `MODEL_METADATA` (between opus and haiku, its original slot so order-sensitive snapshots hold). **1M context set explicitly** (the fullId doesn't match the opus-version heuristic, which would wrongly default it to 200k). Pricing from the Anthropic API reference: **$10 in / $50 out** per MTok, cache at the standard 0.1×/1.25×.
- `models.js` — empty `DISALLOWED_MODEL_IDS`. The ban plumbing (`isDisallowedModelId` + its call sites + the #6232 dangling-default guard) is **retained on purpose** for a future disallow; the Set is simply empty.

**Docs/comments (3 files)** — de-fable the now-stale "disallowed" references. Comment/doc only, no functional client change.

**Tests (5 files)** — roster/pricing literals updated; the disallowed-models coverage is *adapted* to the empty-set reality (`isDisallowedModelId` now `false`; the #6232 guard test retained and repointed to its now-unreachable precondition) rather than deleted.

## The one subtle correctness fix

Fable is chroxy's first **flat-priced 1M model**. `updateModels` synthesizes a `claude-fable-5[1m]` chip, and the #4106 pricing-drift guard warns when a 1M variant lacks a `longContext` pricing entry ("bills may lie"). For Opus that's real (2× premium above 200K); for Fable it's a **false positive** — Fable bills flat, so `[1m]` resolves to the correct base rate. The row therefore ships an explicit `oneM` block whose `longContext` **equals** the base rates: it keeps `[1m]` cost correct AND gives the guard the key it needs, so it stays silent. **Verified at runtime** that `claude-fable-5[1m]` emits no drift warning. If Anthropic ever adds a Fable >200K premium, raise the `longContext` rates.

## Verification

- Full model suite **243/243 green** (models, catalog, metadata-derivation, per-provider, overlay-reload, wire-shape, allow-any-model, orchestration-run-model, factory).
- Custom Server shell lints pass (claude-family-explicit, session-opt-forwarding, tests-state-file-path).
- Red-first confirmed: the ban assertions were red before the change and green after; a direct runtime check confirms the drift warning is silent for fable.

## Not in scope (pre-existing)

`models-overlay-per-provider.test.js` has 2 failing subtests (`#6377` per-provider overlay: humanized label + stale-row-on-removal). Independently confirmed they reproduce on unmodified `main`, reference neither fable nor `DISALLOWED_MODEL_IDS`, and belong to a different subsystem. Left untouched; worth a separate issue.

Client scope is comment-only: both pickers render `availableModels` verbatim (no hardcoded roster hides Fable), and the wire protocol carries no pricing (Claude cost stays server-authoritative). A null-pricing render path was mapped safe, but is moot here since Fable ships *with* pricing.
