### PR TITLE
fix(server): restart a Stopped claude-cli session on the next input (#7438)

### DIFF
--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -2156,6 +2156,13 @@ export class CliSession extends BaseSession {
     try {
       this.start()
     } catch (err) {
+      // Re-arm the latch: start() threw synchronously (spawn/arg failure) BEFORE
+      // any child or container launch, so nothing was started. Without this the
+      // latch stays consumed and the next sendMessage would only enqueue — never
+      // retry the restart — re-stranding the follow-up behind a start-time error
+      // (the exact #7438 failure mode). Re-arming lets the next user input retry;
+      // it is not a loop — a retry only happens on a fresh send.
+      this._stoppedByUser = true
       ;(this._log || log).error(`Restart after stop failed: ${err.message}`)
       this.emit('error', { message: `Failed to restart the stopped Claude process: ${err.message}` })
     }

--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -433,6 +433,13 @@ export class CliSession extends BaseSession {
     // Single-use: set by interrupt(), cleared by _handleChildClose / destroy.
     // The flag itself is declared+initialized on BaseSession (#5375).
 
+    // #7438: latched by the intentional-stop branch of _handleChildClose when
+    // that stop leaves us with no child, and consumed by the next sendMessage
+    // (_restartAfterStop). It is what makes a stopped session restartable —
+    // see _restartAfterStop for why the restart is gated on this rather than
+    // on "the child is gone".
+    this._stoppedByUser = false
+
     // Hook manager (shared module)
     this._hookManager = (this._port) ? createPermissionHookManager(this, { settingsPath }) : null
 
@@ -478,6 +485,11 @@ export class CliSession extends BaseSession {
    * Start the persistent Claude process. Call once after construction.
    */
   start() {
+    // #7438: the session is running again by any route (first start, backoff
+    // respawn, model-switch respawn, restart-on-input), so the stop latch is
+    // spent. Cleared FIRST so a throw below cannot leave it armed.
+    this._stoppedByUser = false
+
     // Register permission hook before starting the process (only once, not on respawn)
     if (this._hookManager && this._respawnCount === 0) {
       this._hookManager.register()
@@ -643,10 +655,20 @@ export class CliSession extends BaseSession {
     log.info('Process started, ready for messages')
     this.emit('ready', { sessionId: null, model: this.model, tools: [] })
 
-    // Dequeue the next pending message if not already busy.
-    // sendMessage() sets _isBusy, so the loop sends at most one message.
-    // Remaining items stay in the queue and are drained one-by-one via
-    // _clearMessageState() after each result.
+    this._drainPendingQueue()
+  }
+
+  /**
+   * Warmup drain: dequeue the next pending message if not already busy.
+   * sendMessage() sets _isBusy, so the loop sends at most one message.
+   * Remaining items stay in the queue and are drained one-by-one via
+   * _clearMessageState() after each result.
+   *
+   * Called at the end of every _spawnPersistentProcess — i.e. this is what
+   * delivers a message queued while the process was down, whether it went down
+   * for a crash, a model switch, or a user Stop (#7438).
+   */
+  _drainPendingQueue() {
     while (this._pendingQueue.length > 0 && !this._isBusy) {
       const pending = this._pendingQueue.shift()
       // #4828: session-scoped when init has fired (dequeue can race with
@@ -726,6 +748,10 @@ export class CliSession extends BaseSession {
       // pre-init or during respawn — both can race with the binding).
       ;(this._log || log).info(`Process not ready, queuing message (queue depth: ${this._pendingQueue.length + 1})`)
       this._pendingQueue.push({ prompt, attachments, options })
+      // #7438: a user Stop leaves no child and no respawn, so without this the
+      // message just queued would sit there forever. Restart lazily, now that
+      // the user has asked for more work; the warmup drain delivers it.
+      this._restartAfterStop()
       return
     }
 
@@ -1976,6 +2002,12 @@ export class CliSession extends BaseSession {
     if (wasIntentionalStop) {
       // #4828: session-scoped if init had fired before the stop.
       ;(this._log || log).info(`Process exited (code ${code}) after user stop`)
+      // #7438: NOT a respawn — the user asked for this child to stop and it
+      // stays stopped. This only records that the session is stoppable-but-
+      // revivable, so the next sendMessage can bring it back (see
+      // _restartAfterStop). Stop halts the turn; it must not end the session's
+      // ability to answer the follow-up.
+      this._stoppedByUser = true
       this.emit('stopped', { code })
       return
     }
@@ -2079,6 +2111,54 @@ export class CliSession extends BaseSession {
     ;(this._log || log).info(`Process exited (code ${code}), scheduling respawn`)
     this.emit('error', { message: 'Claude process exited unexpectedly, restarting...' })
     this._scheduleRespawn()
+  }
+
+  /**
+   * #7438 — restart-on-next-input for a session the user Stopped.
+   *
+   * Stop (interrupt → SIGINT → child exits) deliberately does NOT respawn
+   * (#4602): respawning at stop time fights the thing the user just asked for.
+   * But nothing else restarted the child either, so the next sendMessage hit
+   * the `!_processReady` branch, pushed into `_pendingQueue` — and stranded
+   * there forever, because the queue only drains on a start() warmup or after a
+   * `result`, and with no child neither can ever fire. The follow-up was
+   * silently eaten and the 4th one discarded outright ("queue full"). Stop
+   * ended the conversation instead of interrupting a turn.
+   *
+   * So the respawn is lazy: it happens here, when the user actually asks for
+   * more work. start() passes `--resume this._sessionId`, so the new child
+   * re-attaches to the SAME claude conversation rather than starting cold, and
+   * its warmup drain delivers the queued message.
+   *
+   * Gated on `_stoppedByUser` rather than on the broader "there is no child",
+   * deliberately: every OTHER way to lose a child either already owns its own
+   * restart (a crash schedules a backoff respawn; a model switch runs
+   * _killAndRespawn) or is a considered terminal give-up — the respawn cap, the
+   * rate cap, `resume_unknown_exhausted`. Typing into one of those must not
+   * re-arm a flapping session behind the cap that just stopped it.
+   */
+  _restartAfterStop() {
+    if (!this._stoppedByUser) return
+    if (this._destroying) return
+    if (this._respawning) return
+    if (this._respawnScheduled) return
+    // A child already exists — whoever spawned it owns the warmup drain.
+    if (this._child) return
+
+    ;(this._log || log).info('Restarting the stopped claude process to deliver a new message')
+    // Consume the latch BEFORE starting, not inside start(): DockerSession
+    // overrides start() and defers super.start() behind an async container
+    // launch, so a second message arriving in that window would otherwise see
+    // `_stoppedByUser` still armed and no child yet, and start a SECOND
+    // container. Single-shot here makes the restart at-most-once regardless of
+    // what a subclass's start() does or how long it takes.
+    this._stoppedByUser = false
+    try {
+      this.start()
+    } catch (err) {
+      ;(this._log || log).error(`Restart after stop failed: ${err.message}`)
+      this.emit('error', { message: `Failed to restart the stopped Claude process: ${err.message}` })
+    }
   }
 
   /** Interrupt the current message (send SIGINT to child process) */

--- a/packages/server/tests/cli-session-intentional-stop.test.js
+++ b/packages/server/tests/cli-session-intentional-stop.test.js
@@ -18,6 +18,13 @@ import { CliSession } from '../src/cli-session.js'
  *   2. `interrupt()` sets `_intentionalStop = true` before sending SIGINT.
  *   3. `_handleChildClose` skips the error emit + respawn when the flag is
  *      set, emits a quiet `stopped` event, and clears the flag.
+ *      NB (#7438): "no respawn" here means no respawn AT STOP TIME — the user
+ *      asked for this child to stop and it stays stopped. It does not mean the
+ *      session is finished: the stop latches `_stoppedByUser`, and the NEXT
+ *      sendMessage restarts the child with `--resume <id>` so the follow-up is
+ *      answered on the same conversation. That half of the spec is pinned by
+ *      cli-session-restart-on-input.test.js; the two are complements, not
+ *      contradictions.
  *   4. A subsequent natural exit (flag already cleared) still triggers the
  *      original respawn-with-error path — regression guard.
  *   5. The existing `_respawning` skip path remains independent of the new
@@ -97,7 +104,7 @@ describe('_handleChildClose after intentional stop', () => {
 
     assert.equal(errorEvents.length, 0, 'no error emit on intentional stop')
     assert.equal(stoppedEvents.length, 1, 'should emit a single stopped event')
-    assert.equal(respawnScheduled, 0, 'no respawn on intentional stop')
+    assert.equal(respawnScheduled, 0, 'no respawn AT STOP TIME (#7438: the next input restarts it)')
     assert.equal(session._intentionalStop, false, 'flag must reset for next cycle')
     assert.equal(session._respawnTimer, null, 'no respawn timer left behind')
   })

--- a/packages/server/tests/cli-session-restart-on-input.test.js
+++ b/packages/server/tests/cli-session-restart-on-input.test.js
@@ -127,6 +127,50 @@ describe('#7438 — Stop then a follow-up restarts the session', () => {
     )
   })
 
+  it('re-arms after a synchronous start() failure so the next input can retry, not strand forever', () => {
+    const session = createRunningSession()
+    // The catch path emits 'error'; an EventEmitter with no 'error' listener
+    // throws (Node special-case). Production always has one (session-manager);
+    // give the bare test session one so we assert on state, not the throw.
+    const errors = []
+    session.on('error', (e) => errors.push(e))
+    session.interrupt()
+    session._handleChildClose(0)
+    assert.equal(session._stoppedByUser, true, 'stop latches the session as user-stopped')
+
+    // start() throws synchronously (e.g. spawn/arg resolution failure) — no child.
+    session._spawnPersistentProcess = () => { throw new Error('spawn boom') }
+    session.sendMessage('follow-up after a failed restart')
+
+    // The consumed latch must be RE-ARMED, and the message queued (not lost),
+    // so a later working restart can still deliver it. Without the re-arm the
+    // latch stays false and every future send only enqueues — the #7438 bug
+    // behind a start-time exception.
+    assert.equal(session._child, null, 'a failed start leaves no child')
+    assert.equal(session._stoppedByUser, true, 're-armed so the next input retries')
+    assert.equal(session._pendingQueue.length, 1, 'the follow-up is queued, not dropped')
+    assert.equal(errors.length, 1, 'the start failure is surfaced as an error event')
+
+    // Next input, start() now works: restart succeeds and drains the follow-up.
+    session._spawnPersistentProcess = (args) => {
+      const child = createMockChild()
+      session.spawns.push({ args, child })
+      session._child = child
+      session._processReady = true
+      session._drainPendingQueue()
+    }
+    session.sendMessage('second input')
+    assert.equal(session.spawns.length, 1, 'the retry restarts the child')
+    assert.notEqual(session._child, null, 'the session is alive again after the retry')
+    // The restart delivers the previously-stranded follow-up (the point of the
+    // re-arm); the second input may remain queued behind the now-busy turn,
+    // which is normal mid-turn queueing, so assert delivery, not an empty queue.
+    assert.ok(
+      sentPrompts(session._child).includes('follow-up after a failed restart'),
+      'the follow-up stranded by the failed start is delivered on the retry',
+    )
+  })
+
   it('restarts exactly once when several follow-ups arrive after a Stop', () => {
     const session = createRunningSession()
 

--- a/packages/server/tests/cli-session-restart-on-input.test.js
+++ b/packages/server/tests/cli-session-restart-on-input.test.js
@@ -1,0 +1,240 @@
+import { describe, it, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { EventEmitter } from 'node:events'
+import { Writable, Readable } from 'node:stream'
+import { CliSession } from '../src/cli-session.js'
+
+/**
+ * #7438 — a claude-cli session the user Stopped must come back to life on the
+ * NEXT input instead of eating it.
+ *
+ * Stop sends SIGINT (interrupt()), the `claude -p` child exits, and
+ * `_handleChildClose` takes the intentional-stop branch: no error toast, no
+ * respawn *at stop time* — that part is correct and is pinned by
+ * cli-session-intentional-stop.test.js. The bug was what happened next: the
+ * following `sendMessage` hit the `!_processReady` branch, pushed into
+ * `_pendingQueue`, and nothing ever drained it again (the only two drain sites
+ * are the start() warmup and the post-`result` drain, and neither could fire
+ * with no child). Follow-ups stranded forever; the 4th was discarded outright.
+ *
+ * The spec these tests pin — the complement of the intentional-stop file:
+ *   1. Stop does NOT respawn; the next input DOES (with `--resume <id>`, so the
+ *      same claude conversation continues rather than starting cold).
+ *   2. The queued follow-up is delivered by the warmup drain, not stranded.
+ *   3. Exactly one restart — a respawn already scheduled / in flight, or a
+ *      destroyed session, owns the restart and must not be doubled.
+ *
+ * SPAWN SEAM: `_spawnPersistentProcess` is stubbed per-session. We never
+ * `mock.module('child_process')` — `node --test` runs files concurrently and
+ * that patch leaks process-wide into unrelated subprocess-spawning suites (see
+ * the note at the top of windows-cmd-routing.test.js). The stub reproduces only
+ * what the real spawn boundary does at the point the child becomes usable
+ * (attach child, flip `_processReady`) and then calls the PRODUCTION warmup
+ * drain, `_drainPendingQueue()`, so the delivery assertion exercises real code.
+ */
+
+// #6027: destroy() every constructed session so the sendMessage-armed
+// _hardTimeout/_streamStallTimeout don't outlive the suite.
+const _createdSessions = []
+afterEach(() => {
+  for (const s of _createdSessions) {
+    // Null the mock child first: destroy() otherwise arms a 3s forceKillTimer
+    // cleared only by a real child's 'close' event, which the mock never emits.
+    s._child = null
+    try { const r = s.destroy(); if (r && typeof r.catch === 'function') r.catch(() => {}) } catch {}
+  }
+  _createdSessions.length = 0
+})
+
+function createMockChild() {
+  const child = new EventEmitter()
+  child.writes = []
+  child.stdin = new Writable({ write(chunk, enc, cb) { child.writes.push(chunk.toString()); cb() } })
+  child.stdout = new Readable({ read() {} })
+  child.stderr = new Readable({ read() {} })
+  child.pid = 12345
+  child.kill = (sig) => { child._lastKillSignal = sig; return true }
+  child.killed = false
+  return child
+}
+
+function createSession(opts = {}) {
+  const session = new CliSession({ cwd: '/tmp', ...opts })
+  _createdSessions.push(session)
+  // Recorded spawn attempts: { args, child }.
+  session.spawns = []
+  session._spawnPersistentProcess = (args) => {
+    const child = createMockChild()
+    session.spawns.push({ args, child })
+    session._child = child
+    session._processReady = true
+    session._drainPendingQueue()
+  }
+  return session
+}
+
+/** A session mid-conversation: a live child, ready, with a known resume id. */
+function createRunningSession(opts = {}) {
+  const session = createSession(opts)
+  session._child = createMockChild()
+  session._processReady = true
+  session._sessionId = 'conv-7438'
+  return session
+}
+
+/** Text of the user prompts written to a spawned child's stdin. */
+function sentPrompts(child) {
+  return child.writes
+    .map((line) => { try { return JSON.parse(line) } catch { return null } })
+    .filter((m) => m && m.type === 'user')
+    .map((m) => m.message.content.map((b) => b.text || '').join(''))
+}
+
+describe('#7438 — Stop then a follow-up restarts the session', () => {
+  it('respawns on the next input after a user Stop and resumes the same conversation', () => {
+    const session = createRunningSession()
+
+    // The real Stop path: SIGINT, then the child exits.
+    session.interrupt()
+    session._handleChildClose(0)
+    assert.equal(session._child, null, 'stop leaves no child')
+    assert.equal(session._processReady, false, 'stop leaves the session not ready')
+    assert.equal(session.spawns.length, 0, 'Stop itself must NOT respawn (#4602)')
+
+    session.sendMessage('follow-up after stop')
+
+    assert.equal(session.spawns.length, 1, 'the next input must restart the child')
+    const args = session.spawns[0].args
+    const idx = args.indexOf('--resume')
+    assert.ok(idx >= 0, `restart must pass --resume (argv: ${args.join(' ')})`)
+    assert.equal(args[idx + 1], 'conv-7438', 'restart must resume the SAME claude conversation')
+  })
+
+  it('delivers the queued follow-up on warmup instead of stranding it', () => {
+    const session = createRunningSession()
+
+    session.interrupt()
+    session._handleChildClose(0)
+
+    session.sendMessage('follow-up after stop')
+
+    assert.equal(session._pendingQueue.length, 0, 'follow-up must not be stranded in _pendingQueue')
+    assert.equal(session.spawns.length, 1)
+    assert.deepEqual(
+      sentPrompts(session.spawns[0].child),
+      ['follow-up after stop'],
+      'the follow-up must reach the respawned child',
+    )
+  })
+
+  it('restarts exactly once when several follow-ups arrive after a Stop', () => {
+    const session = createRunningSession()
+
+    session.interrupt()
+    session._handleChildClose(0)
+
+    session.sendMessage('first follow-up')
+    session.sendMessage('second follow-up')
+    session.sendMessage('third follow-up')
+
+    assert.equal(session.spawns.length, 1, 'only one restart for the whole burst')
+    assert.equal(session._pendingQueue.length, 0, 'nothing stranded in the pending queue')
+  })
+})
+
+describe('#7438 — restart-on-input does not double-start', () => {
+  // Each case arms the stop latch as well, so the assertion is on the guard
+  // named in its title and NOT on the latch alone — without this the tests
+  // would pass with every one of those guards deleted.
+  it('does not start when a backoff respawn is already scheduled', () => {
+    const session = createRunningSession()
+    // Stop, then the restarted child died and armed the backoff timer.
+    session._child = null
+    session._processReady = false
+    session._stoppedByUser = true
+    session._respawnScheduled = true
+
+    session.sendMessage('queued during backoff')
+
+    assert.equal(session.spawns.length, 0, 'the scheduled respawn owns the restart')
+    assert.equal(session._pendingQueue.length, 1, 'message waits for that respawn to drain it')
+  })
+
+  it('does not start while a kill-and-respawn is in flight', () => {
+    const session = createRunningSession()
+    // Stop, then a model switch raced in and is bringing its own child up.
+    session._child = null
+    session._processReady = false
+    session._stoppedByUser = true
+    session._respawning = true
+
+    session.sendMessage('queued during model switch')
+
+    assert.equal(session.spawns.length, 0, '_killAndRespawn owns the restart')
+    assert.equal(session._pendingQueue.length, 1)
+  })
+
+  it('restarts at most once even when start() comes up asynchronously', () => {
+    // DockerSession overrides start() and defers the real spawn behind an async
+    // container launch, so `_child` stays null across the whole window. The
+    // latch — not the child — is what makes the restart at-most-once.
+    const session = createRunningSession()
+    session._child = null
+    session._processReady = false
+    session._stoppedByUser = true
+
+    let starts = 0
+    session.start = () => { starts++ }
+
+    session.sendMessage('first follow-up')
+    session.sendMessage('second follow-up')
+
+    assert.equal(starts, 1, 'a slow start() must not be re-entered by the next message')
+    assert.equal(session._pendingQueue.length, 2, 'both messages wait for that one start')
+  })
+
+  it('does not start a destroyed session', () => {
+    const session = createRunningSession()
+    session._child = null
+    session._processReady = false
+    session._stoppedByUser = true
+    session._destroying = true
+
+    session.sendMessage('after destroy')
+
+    assert.equal(session.spawns.length, 0, 'a destroyed session must never respawn')
+  })
+
+  it('does not start when a child is already up but still warming', () => {
+    const session = createRunningSession()
+    // Stop latched, but something already spawned a child; its warmup owns the
+    // drain. Restarting here would leave two live claude processes.
+    session._processReady = false
+    session._stoppedByUser = true
+
+    session.sendMessage('queued during warmup')
+
+    assert.equal(session.spawns.length, 0, 'a live child needs no restart')
+    assert.equal(session._pendingQueue.length, 1, 'the existing warmup drain delivers it')
+  })
+
+  it('leaves a crashed (non-stop) dead session to the respawn machinery', () => {
+    const session = createRunningSession()
+
+    // A natural crash: no interrupt() first, so this is NOT a user stop.
+    // The close path emits the "exited unexpectedly" error — absorb it so the
+    // EventEmitter default does not turn it into an unhandled throw.
+    session.on('error', () => {})
+    let respawnScheduled = 0
+    session._scheduleRespawn = () => { respawnScheduled++ }
+    session._handleChildClose(1)
+    assert.equal(respawnScheduled, 1, 'a crash still schedules a respawn')
+
+    // The stubbed _scheduleRespawn left no timer, so the dead-child state looks
+    // identical to a stop — the restart must still be driven by the crash path,
+    // not by input, or an exhausted/flapping session would be re-armed by typing.
+    session.sendMessage('after crash')
+
+    assert.equal(session.spawns.length, 0, 'a crash is the respawn machinery\'s job, not sendMessage\'s')
+  })
+})


### PR DESCRIPTION
Fixes the confirmed-critical Stop bug (#7438): a claude-cli session was dead after **Stop** — any follow-up stranded in `_pendingQueue` and was never answered. Reproduced live on current main (`8cf5dd01`).

## Root cause
Stop → `interrupt()` SIGINTs the `claude -p` child → `_handleChildClose` intentional-stop branch nulls the child and does not respawn (correct at stop time). But the next `sendMessage` then queues into `_pendingQueue`, which only drains on `start()` warmup or a `result` while ready — neither ever fires again, so follow-ups strand forever (4th+ dropped).

## Fix — restart on next input
- New `_stoppedByUser` latch, set in the intentional-stop close branch (behaviour there otherwise **unchanged** — still no respawn *at stop time*).
- `sendMessage` queues as before, then calls new `_restartAfterStop()`, which — gated on the latch and guarded against `_destroying`/`_respawning`/`_respawnScheduled`/an existing `_child` — consumes the latch and calls `start()`. `start()` spawns `--resume this._sessionId`, reattaching the **same JSONL conversation**; warmup then drains the queued follow-up.
- Warmup drain extracted to `_drainPendingQueue()` so the test exercises the **production** drain (delivery assertion is not tautological).

The latch (not a bare "no child") is deliberate: crash/model-switch dead states own their own restart, and terminal give-ups (respawn cap, `resume_unknown_exhausted`) must stay dead — typing must not re-arm a session behind the cap. Consuming the latch *before* `start()` handles `DockerSession`'s async `start()` override (which keeps `_child` null across a container launch — a `_child`-only guard would double-launch). Both pinned by tests.

## Verification
- **Red-first:** the 3 restart assertions in `tests/cli-session-restart-on-input.test.js` fail on unfixed code (stranding visible in the log), pass after.
- **Mutation-tested:** all 6 guards + the latch-set proved load-bearing (drop any → red).
- `cli-session*` 273 pass / 0 fail; adjacent `docker-session`/`docker-sdk-session`/`session-manager*` 438 pass / 0 fail (DockerSession inherits the fix). All 9 server shell lints + eslint clean.
- Existing intentional-stop test (`respawnScheduled === 0` at stop time) still green; its comment updated so the two specs read as complements.

## Sibling providers
Checked and clear — no equivalent stranding: `jsonl-subprocess` (per-turn spawn), `sdk-session` (new query per send), `claude-tui` (surviving PTY). `docker-session` extends `CliSession` and inherits the fix.

## Bonus
This is the same `--resume` respawn a "fork the chat" feature (operator request) would build on — landing it is the first half of that.

Closes #7438.
