### PR TITLE
ci: run packages/design-tokens' test suite on every PR (#7408)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -814,6 +814,36 @@ jobs:
       - name: Run tests
         run: npm test
 
+  design-tokens-tests:
+    name: Design Tokens Tests
+    # #7408: the one JS workspace package whose `npm test` no CI job invoked —
+    # the plain form of docs/false-safety-guards.md (a suite that never runs and
+    # a green PR are the same observable outcome; the tokens feed the
+    # dashboard's generated theme.css/tokens.ts, so a regression surfaced as a
+    # visual defect instead of a red check). Six sub-second tests; runs
+    # unconditionally like the sibling per-package jobs.
+    needs: runner-target
+    runs-on: ${{ fromJSON(needs.runner-target.outputs.runner) }}  # SELF_HOSTED_OR_HOSTED (see header)
+    timeout-minutes: 5
+    defaults:
+      run:
+        working-directory: packages/design-tokens
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+          cache: ${{ needs.runner-target.outputs.npmcache }}
+          cache-dependency-path: '**/package-lock.json'
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: .
+
+      - name: Run tests
+        run: npm test
+
   store-core-typecheck:
     name: Store Core Type Check
     needs: runner-target

--- a/packages/design-tokens/test/index.test.js
+++ b/packages/design-tokens/test/index.test.js
@@ -28,7 +28,7 @@ test('navy palette + structural tokens are present with expected values', () => 
   assert.equal(vars['bg-primary'], '#0f0f1a') // navy preserved
   assert.equal(vars['accent-blue'], '#4a9eff')
   assert.equal(vars['text-chat'], '15px') // new chat reading size
-  assert.equal(vars['radius-md'], '999px') // RED-PROOF (#7408): temporary — reverted in the next commit
+  assert.equal(vars['radius-md'], '10px')
   assert.equal(vars['dur-base'], '200ms')
   assert.match(vars['ease-out'], /^cubic-bezier/)
 })

--- a/packages/design-tokens/test/index.test.js
+++ b/packages/design-tokens/test/index.test.js
@@ -28,7 +28,7 @@ test('navy palette + structural tokens are present with expected values', () => 
   assert.equal(vars['bg-primary'], '#0f0f1a') // navy preserved
   assert.equal(vars['accent-blue'], '#4a9eff')
   assert.equal(vars['text-chat'], '15px') // new chat reading size
-  assert.equal(vars['radius-md'], '10px')
+  assert.equal(vars['radius-md'], '999px') // RED-PROOF (#7408): temporary — reverted in the next commit
   assert.equal(vars['dur-base'], '200ms')
   assert.match(vars['ease-out'], /^cubic-bezier/)
 })


### PR DESCRIPTION
Closes #7408.

`packages/design-tokens` has a real six-test suite that no CI job ever invoked — `ci.yml` mentioned the package only in the dashboard staleness check. This is the plain form of `docs/false-safety-guards.md`: a suite that never runs and a green PR are the same observable outcome, and these tokens feed the dashboard's generated `theme.css`/`tokens.ts`, so a regression would surface as a visual defect rather than a red check.

## What changed

One new **Design Tokens Tests** job, modeled line-for-line on the sibling per-package jobs (`runner-target` resolution, Node 22 + npm cache, `npm ci` at the root, `npm test` in the package). It runs unconditionally on every PR, like its siblings — the suite is six sub-second tests, so path-gating would buy nothing and cost a filter to maintain.

## Acceptance criteria

- [x] `npm test` for the package runs in CI on every PR — the new job.
- [x] **Red-proof completed in this PR's own CI history** (the guard lives in CI config, where no local test can prove the wiring — #7270's lesson): RED on `0df81c5fd` — [failing Design Tokens Tests run](https://github.com/blamechris/chroxy/actions/runs/33200183741/job/98947490111) · GREEN on the exact revert `db9e5b138` — [passing run](https://github.com/blamechris/chroxy/actions/runs/33200558894/job/98948732808).
- [x] Survey of other unreferenced test scripts: server / claude-hooks / protocol / store-core / dashboard / app all have jobs; desktop is Rust (Desktop Rust Tests ×2); the repo `scripts/` suite runs under Scripts Tests. **design-tokens was the only `packages/*` gap.** (The `scripts/` suite runs under Scripts Tests, but that job names test files by hand and is missing one — pre-existing, tracked as #7252.)

## Note for the merger

The new check is not in the branch-protection required-contexts list; making it required is a repo-settings change only the owner can do.

