### PR TITLE
refactor(app): remove the write-only isSessionSwitchReplay flag (#7421)

### DIFF
--- a/packages/app/src/__tests__/store/agent-event-handler.test.ts
+++ b/packages/app/src/__tests__/store/agent-event-handler.test.ts
@@ -54,7 +54,6 @@ function createMockContext() {
     connectionId: 'test-conn-1',
     reconnecting: false,
     connectedAt: Date.now(),
-    isSessionSwitchReplay: false,
     activeSessionIdAtConnect: null,
   };
 }

--- a/packages/app/src/__tests__/store/message-handler-activity.test.ts
+++ b/packages/app/src/__tests__/store/message-handler-activity.test.ts
@@ -87,7 +87,6 @@ function createMockContext() {
     connectionId: 'test-conn-1',
     reconnecting: false,
     connectedAt: Date.now(),
-    isSessionSwitchReplay: false,
     activeSessionIdAtConnect: null,
     replayingSessions: new Set<string>(),
   };

--- a/packages/app/src/__tests__/store/message-handler-permission-input.test.ts
+++ b/packages/app/src/__tests__/store/message-handler-permission-input.test.ts
@@ -71,7 +71,6 @@ function createMockContext() {
     connectionId: 'test-conn-1',
     reconnecting: false,
     connectedAt: Date.now(),
-    isSessionSwitchReplay: false,
     activeSessionIdAtConnect: null,
     replayingSessions: new Set<string>(),
   };

--- a/packages/app/src/__tests__/store/message-handler.test.ts
+++ b/packages/app/src/__tests__/store/message-handler.test.ts
@@ -74,7 +74,6 @@ function createMockContext() {
     connectionId: 'test-conn-1',
     reconnecting: false,
     connectedAt: Date.now(),
-    isSessionSwitchReplay: false,
     activeSessionIdAtConnect: null,
   };
 }

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -114,7 +114,6 @@ import {
   nextReconnectAttempt,
   pendingPairingId,
   setPendingPairingId,
-  setPendingSwitchSessionId,
   resetReplayFlags,
   clearPermissionSplits,
   clearTerminalWriteBatching,
@@ -2430,9 +2429,6 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
 
     if (sessionId === activeSessionId) return;
     if (haptic) hapticLight();
-
-    // Mark as user-initiated switch so session_switched handler uses session-switch dedup
-    if (serverNotify) setPendingSwitchSessionId(sessionId);
 
     // Optimistically switch active session + dismiss notifications for target session
     const filteredNotifications = get().sessionNotifications.filter(

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -268,7 +268,6 @@ interface MessageHandlerContext extends EncryptionContext {
   // live activity for sessions B/C/etc. Scope the flag per-session id and
   // gate per-target.
   replayingSessions: Set<string>;
-  isSessionSwitchReplay: boolean;
   pendingSwitchSessionId: string | null;
 
   // Permission boundary message splitting (#554)
@@ -323,7 +322,6 @@ function createDefaultContext(): MessageHandlerContext {
   const ctx: MessageHandlerContext = {
     ...INITIAL_ENCRYPTION_CONTEXT,
     replayingSessions: new Set<string>(),
-    isSessionSwitchReplay: false,
     pendingSwitchSessionId: null,
     postPermissionSplits: new Set<string>(),
     deltaIdRemaps: new Map<string, string>(),
@@ -769,7 +767,6 @@ export function setPendingSwitchSessionId(id: string | null): void {
 
 export function resetReplayFlags(): void {
   _ctx.replayingSessions.clear();
-  _ctx.isSessionSwitchReplay = false;
   _ctx.pendingSwitchSessionId = null;
 }
 
@@ -1856,7 +1853,6 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       // saw history_replay_end before the socket dropped). Cursors are RETAINED
       // so this reconnect's replay can be incremental.
       resetReplayReconcile();
-      _ctx.isSessionSwitchReplay = false;
       _ctx.pendingSwitchSessionId = null;
       // #5555.5 — a successful auth is the ONLY proof the link is healthy, so
       // reset the close/error-path backoff ladder here (not on socket-open). A
@@ -2322,13 +2318,6 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       // switch and the real follow-up could otherwise leave a stale
       // `pendingSwitchSessionId` and falsely flip the replay-dedup flag on
       // the next valid switch. Run the replay-dedup check before clearing.
-      if (
-        switched &&
-        _ctx.pendingSwitchSessionId &&
-        _ctx.pendingSwitchSessionId === switched.newSessionId
-      ) {
-        _ctx.isSessionSwitchReplay = true;
-      }
       _ctx.pendingSwitchSessionId = null;
       if (!switched) break;
       const { newSessionId: sessionId, conversationId: switchConvId } = switched;
@@ -2445,10 +2434,6 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       // messages visible and records a baseline; the authoritative replayed set
       // is appended and swapped in atomically at history_replay_end (no blank
       // flash). Delta replay (cursor honoured) is purely append-only.
-      // `isSessionSwitchReplay` still gates the same UX paths as before.
-      if (fullHistory) {
-        _ctx.isSessionSwitchReplay = true;
-      }
       {
         const curLen =
           (replayTargetId && get().sessionStates[replayTargetId]?.messages.length) || 0;
@@ -2615,7 +2600,6 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
           });
         }
       }
-      _ctx.isSessionSwitchReplay = false;
       break;
 
     // --- User input echoed from other clients ---

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -268,7 +268,6 @@ interface MessageHandlerContext extends EncryptionContext {
   // live activity for sessions B/C/etc. Scope the flag per-session id and
   // gate per-target.
   replayingSessions: Set<string>;
-  pendingSwitchSessionId: string | null;
 
   // Permission boundary message splitting (#554)
   postPermissionSplits: Set<string>;
@@ -322,7 +321,6 @@ function createDefaultContext(): MessageHandlerContext {
   const ctx: MessageHandlerContext = {
     ...INITIAL_ENCRYPTION_CONTEXT,
     replayingSessions: new Set<string>(),
-    pendingSwitchSessionId: null,
     postPermissionSplits: new Set<string>(),
     deltaIdRemaps: new Map<string, string>(),
     pendingTerminalWrites: '',
@@ -761,13 +759,8 @@ export function setPendingPairingIdentityKey(key: string | null): void {
 // ---------------------------------------------------------------------------
 // History replay flags
 // ---------------------------------------------------------------------------
-export function setPendingSwitchSessionId(id: string | null): void {
-  _ctx.pendingSwitchSessionId = id;
-}
-
 export function resetReplayFlags(): void {
   _ctx.replayingSessions.clear();
-  _ctx.pendingSwitchSessionId = null;
 }
 
 // ---------------------------------------------------------------------------
@@ -1853,7 +1846,6 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       // saw history_replay_end before the socket dropped). Cursors are RETAINED
       // so this reconnect's replay can be incremental.
       resetReplayReconcile();
-      _ctx.pendingSwitchSessionId = null;
       // #5555.5 — a successful auth is the ONLY proof the link is healthy, so
       // reset the close/error-path backoff ladder here (not on socket-open). A
       // socket that opens but never authenticates keeps climbing the ladder.
@@ -2313,12 +2305,6 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
 
     case 'session_switched': {
       const switched = sharedSessionSwitched(msg);
-      // Defensive: clear the pending hint regardless of validity (#3121).
-      // A malformed `session_switched` arriving between a user-initiated
-      // switch and the real follow-up could otherwise leave a stale
-      // `pendingSwitchSessionId` and falsely flip the replay-dedup flag on
-      // the next valid switch. Run the replay-dedup check before clearing.
-      _ctx.pendingSwitchSessionId = null;
       if (!switched) break;
       const { newSessionId: sessionId, conversationId: switchConvId } = switched;
       set((state: ConnectionState) => {

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -4048,9 +4048,9 @@ describe('dashboard message-handler dispatch', () => {
     }
 
     // Regression: on plain reconnect replay (not a session switch), the
-    // dashboard's `tool_start` handler had a blanket
-    // `_receivingHistoryReplay && !_isSessionSwitchReplay && get().messages.length > 0`
-    // early return that fired against the legacy flat `messages` array — but
+    // dashboard's `tool_start` handler had a blanket early return (receiving a
+    // history replay that is not a session-switch one, with `messages`
+    // non-empty) that fired against the legacy flat `messages` array — but
     // multi-session state keeps that array empty, so the guard never tripped
     // and replayed tool_use entries appended on top of the live copies. The
     // per-id dedup at the same handler now runs on every replay path.

--- a/packages/store-core/src/handlers/session-status.ts
+++ b/packages/store-core/src/handlers/session-status.ts
@@ -277,10 +277,9 @@ export interface SessionSwitchedPayload {
  * `set({activeSessionId: ...})` which the rest of the store can't recover
  * from) and tightens validation against malformed payloads.
  *
- * Both clients consume this handler today. Side effects (replay-dedup gating
- * via `_ctx.pendingSwitchSessionId` on the app, flat-field sync on the
- * dashboard, slash-command/agent refresh, sessionStates initialisation) stay
- * at the call site — they touch the WS socket and several side stores.
+ * Both clients consume this handler today. Side effects (flat-field sync on
+ * the dashboard, slash-command/agent refresh, sessionStates initialisation)
+ * stay at the call site — they touch the WS socket and several side stores.
  */
 export function handleSessionSwitched(
   msg: Record<string, unknown>,


### PR DESCRIPTION
Closes #7421.

`_ctx.isSessionSwitchReplay` had eight references and zero reads — five writes, an initialiser, a type declaration, and a comment claiming it *"still gates the same UX paths as before"*. It gated nothing (the issue's analysis, re-verified here), which is the comment-stronger-than-code shape in `docs/false-safety-guards.md`: someone reasoning about replay ordering would believe the flag load-bearing and preserve write ordering that costs nothing to change (exactly how it surfaced in #7419).

## What changed

- Deleted the field, initialiser, and all five writes. One write was the sole body of a `pendingSwitchSessionId` comparison block in the `conversation_id` path — the whole block goes with it (the `pendingSwitchSessionId = null` reset after it is kept).
- Deleted the false comment; the four app store-test fixtures drop their `isSessionSwitchReplay: false` initialiser (they would no longer typecheck).
- Reworded the dashboard regression-test comment that quoted a `_isSessionSwitchReplay` identifier that no longer exists in that package — the dashboard had its own flag and deleted it in #2901/#3044 (April 2026), a history correction the review caught (the first commit message says "never existed", which is wrong; the reworded prose is accurate for current code either way).

## Acceptance criteria

- [x] `grep -rn isSessionSwitchReplay packages/app packages/dashboard` (both jest roots checked) → empty
- [x] The comment no longer claims a gate that does not exist
- [x] App suite: `tsc --noEmit` clean; store suites 725/725 (34 suites, clean exit); dashboard `message-handler.test.ts` 306/306

Per the issue's alternative ("restore a reader"): no reader was lost in a refactor — the dashboard never had one, and the app writes were self-consistent bookkeeping with no consumer, so deletion is the honest fix.
