### PR TITLE
fix(store-core): stop replay-end resolving a live AskUserQuestion

### DIFF
--- a/packages/app/src/__tests__/store/message-handler.test.ts
+++ b/packages/app/src/__tests__/store/message-handler.test.ts
@@ -24,6 +24,7 @@ import {
   PERMISSION_ALREADY_ANSWERED_NOTICE,
   PERMISSION_DECISION_TOKENS,
   isLivePermissionPrompt,
+  resetReplayReconcile,
 } from '@chroxy/store-core';
 import { clearPersistedSession } from '../../store/persistence';
 import { setCallback, clearAllCallbacks } from '../../store/imperative-callbacks';
@@ -832,6 +833,161 @@ describe("history_replay_end: '(resolved)' sweep targeting (#7410)", () => {
     const st = store.getState().sessionStates;
     expect((st.s1.messages[0] as any).answered).toBeUndefined();
     expect((st.s2.messages[0] as any).answered).toBeUndefined();
+  });
+});
+
+// #7420 — the other half of #7410. `permission_request` is server-transient, so
+// a permission prompt present at replay-end always RACED the replay and
+// `!m.requestId` excludes it exactly. `user_question` is NOT transient: it is in
+// the history ring buffer and is re-sent on every replay, and the ChatMessage it
+// builds carries no `requestId` and no `expiresAt`. So a LIVE AskUserQuestion
+// that lands mid-replay is byte-identical in store state to a replayed one, and
+// the pre-fix sweep stamped both — losing the answer path for that turn.
+//
+// The discriminator is the wire frame, recorded at arrival: `replayHistory`
+// stamps every replayed history entry with `historySeq` (ws-history.js) and a
+// live broadcast never carries it. store-core's replay-reconcile module notes
+// the ids of questions that arrived WITHOUT one while the session's replay
+// window was open, and the sweep skips exactly those.
+describe("history_replay_end: '(resolved)' sweep vs a racing live AskUserQuestion (#7420)", () => {
+  beforeEach(() => {
+    // The live-arrival set is module state in store-core; a window left open by
+    // an earlier test would otherwise decide these cases.
+    resetReplayReconcile({ clearCursors: true });
+  });
+
+  afterEach(() => {
+    resetReplayFlags();
+    resetReplayReconcile({ clearCursors: true });
+  });
+
+  function seedOne(messages: any[] = []) {
+    const store = createMockStore({
+      activeSessionId: 's1',
+      sessions: [{ sessionId: 's1', name: 'S1' } as any],
+      sessionStates: { s1: { ...createEmptySessionState(), messages } },
+      sessionNotifications: [],
+    });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+    return store;
+  }
+
+  /**
+   * A `user_question` wire frame. `historySeq` present ⇒ the replay delivered
+   * it; absent ⇒ a live broadcast. That is the ONLY difference between the two
+   * on the wire, which is the whole difficulty of this bug.
+   */
+  const question = (extra: Record<string, unknown> = {}) => ({
+    type: 'user_question',
+    sessionId: 's1',
+    toolUseId: 'q-use-1',
+    questions: [{ question: 'Which approach?', options: [{ label: 'A' }, { label: 'B' }] }],
+    ...extra,
+  });
+
+  const answeredOf = (store: any, i = 0) =>
+    (store.getState().sessionStates.s1.messages[i] as any).answered;
+
+  // --- AC (a): the live racer survives -------------------------------------
+
+  it('does not stamp a live question that arrived mid-replay (delta replay)', () => {
+    const store = seedOne();
+    _testMessageHandler.handle({ type: 'history_replay_start', sessionId: 's1', fullHistory: false });
+    _testMessageHandler.handle(question());
+    // Positive control: the prompt really was appended, so an assertion of
+    // `answered === undefined` below is about the sweep and not about an
+    // absent fixture.
+    expect(store.getState().sessionStates.s1.messages).toHaveLength(1);
+    expect(store.getState().sessionStates.s1.messages[0].type).toBe('prompt');
+
+    _testMessageHandler.handle({ type: 'history_replay_end', sessionId: 's1' });
+
+    expect(answeredOf(store)).toBeUndefined();
+  });
+
+  it('does not stamp a live question that arrived mid-replay (full rebuild)', () => {
+    // A pre-replay message makes the baseline non-zero, so the atomic swap at
+    // replay-end is real (it slices the prefix off) rather than a no-op.
+    const store = seedOne([{ id: 'old-1', type: 'response', content: 'before', timestamp: 1 }]);
+    _testMessageHandler.handle({ type: 'history_replay_start', sessionId: 's1', fullHistory: true });
+    // Replayed first, then the live racer — the interleaving the server's
+    // chunked replay actually produces.
+    _testMessageHandler.handle(question({ historySeq: 3, timestamp: 1000 }));
+    _testMessageHandler.handle(question({ toolUseId: 'q-use-2' }));
+    expect(store.getState().sessionStates.s1.messages).toHaveLength(3);
+
+    _testMessageHandler.handle({ type: 'history_replay_end', sessionId: 's1' });
+
+    const msgs = store.getState().sessionStates.s1.messages;
+    // Swap dropped the pre-replay prefix; both prompts survive it.
+    expect(msgs).toHaveLength(2);
+    expect(answeredOf(store, 0)).toBe('(resolved)');
+    expect(answeredOf(store, 1)).toBeUndefined();
+  });
+
+  // --- AC (b): a genuinely replayed question is still stamped ---------------
+
+  it('still stamps a question the replay itself delivered', () => {
+    const store = seedOne();
+    _testMessageHandler.handle({ type: 'history_replay_start', sessionId: 's1', fullHistory: false });
+    _testMessageHandler.handle(question({ historySeq: 7, timestamp: 1000 }));
+    expect(store.getState().sessionStates.s1.messages).toHaveLength(1);
+
+    _testMessageHandler.handle({ type: 'history_replay_end', sessionId: 's1' });
+
+    expect(answeredOf(store)).toBe('(resolved)');
+  });
+
+  it('still stamps a question that pre-dates the replay window', () => {
+    const store = seedOne();
+    // Live, but BEFORE any replay opened — nothing about this reconnect
+    // vouches for it, so the long-standing sweep behaviour stands.
+    _testMessageHandler.handle(question());
+    _testMessageHandler.handle({ type: 'history_replay_start', sessionId: 's1', fullHistory: false });
+    _testMessageHandler.handle({ type: 'history_replay_end', sessionId: 's1' });
+
+    expect(answeredOf(store)).toBe('(resolved)');
+  });
+
+  it('forgets the previous window: a racer protected once is stamped on the NEXT replay', () => {
+    const store = seedOne();
+    _testMessageHandler.handle({ type: 'history_replay_start', sessionId: 's1', fullHistory: false });
+    _testMessageHandler.handle(question());
+    _testMessageHandler.handle({ type: 'history_replay_end', sessionId: 's1' });
+    expect(answeredOf(store)).toBeUndefined();
+
+    _testMessageHandler.handle({ type: 'history_replay_start', sessionId: 's1', fullHistory: false });
+    _testMessageHandler.handle({ type: 'history_replay_end', sessionId: 's1' });
+
+    expect(answeredOf(store)).toBe('(resolved)');
+  });
+
+  it("a racer in session s1 is not protected by session s2's replay window", () => {
+    const store = createMockStore({
+      activeSessionId: 's1',
+      sessions: [
+        { sessionId: 's1', name: 'S1' } as any,
+        { sessionId: 's2', name: 'S2' } as any,
+      ],
+      sessionStates: {
+        s1: createEmptySessionState(),
+        s2: createEmptySessionState(),
+      },
+      sessionNotifications: [],
+    });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    // Only s2 is replaying; a live question for s1 is not inside any window of
+    // its own, so s1's own replay-end still stamps it.
+    _testMessageHandler.handle({ type: 'history_replay_start', sessionId: 's2', fullHistory: false });
+    _testMessageHandler.handle(question());
+    _testMessageHandler.handle({ type: 'history_replay_end', sessionId: 's2' });
+    _testMessageHandler.handle({ type: 'history_replay_start', sessionId: 's1', fullHistory: false });
+    _testMessageHandler.handle({ type: 'history_replay_end', sessionId: 's1' });
+
+    expect((store.getState().sessionStates.s1.messages[0] as any).answered).toBe('(resolved)');
   });
 });
 

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -65,6 +65,11 @@ import {
   recordHistorySeq,
   reconcileReplayStart,
   reconcileReplayEnd,
+  // #7420 — the shared `history_replay_end` unanswered-prompt sweep. Both
+  // clients carried byte-identical copies of the predicate through #7410/#7419;
+  // it now has one implementation, which is also where the live-arrival ledger
+  // that protects a racing AskUserQuestion is read.
+  sweepUnansweredPromptsAtReplayEnd,
   replayDedupCache,
   resetReplayReconcile,
   handlePermissionRequest as sharedPermissionRequest,
@@ -2546,72 +2551,30 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         } else {
           reconcileReplayEnd(endTargetId, [], endLatestSeq);
         }
-        // Mark all replayed prompts as answered — any prompt in history
-        // has already been resolved by the server.
+        // Mark replayed prompts as answered — the premise being that any prompt
+        // in history has already been resolved by the server.
         //
-        // #7410 — keyed to `endTargetId`, NOT `activeSessionId`. The predicate
-        // matches LIVE prompts as well as historical ones:
-        // `isLivePermissionPrompt` is `type === 'prompt' && requestId &&
-        // expiresAt > now && !answered`, and AskUserQuestion emits
-        // `type: 'prompt'` too. Keyed to the active session, a BACKGROUND
-        // session's replay-end stamped '(resolved)' on a permission approval
-        // the user was looking at — silently dismissing it — and
-        // `subscribe_sessions` replays every background session, so that
-        // happened on every multi-session reconnect. Fourth instance of this
+        // The predicate, its three exclusions and the reasoning behind each now
+        // live in ONE place: `sweepUnansweredPromptsAtReplayEnd` in store-core's
+        // replay-reconcile.ts. Both clients carried byte-identical copies of it
+        // through #7410 and #7419, which is the drift #7420 removed.
+        //
+        // What stays here is the KEYING. #7410 — keyed to `endTargetId`, NOT
+        // `activeSessionId`. The predicate matches LIVE prompts as well as
+        // historical ones, and `subscribe_sessions` replays every background
+        // session, so keyed to the active session a BACKGROUND session's
+        // replay-end stamped '(resolved)' on a permission approval the user was
+        // looking at — on every multi-session reconnect. Fourth instance of this
         // mis-keying in this pair of files after #4909, #7340 and #7402.
         //
         // `endTargetId` already falls back to `activeSessionId` when the frame
         // omits `sessionId`, so the single-session case is unchanged; and
         // `updateSession` no-ops on an id with no state, which is the right
         // outcome for the "session vanished mid-replay" branch above.
-        //
-        // Permission prompts are excluded by `requestId`, and that follows from
-        // the wire contract rather than from taste. Exactly two things produce
-        // a `type: 'prompt'` ChatMessage, and history splits them cleanly:
-        //
-        //   - `permission_request` is in the server's `builtinTransient` list
-        //     (`session-manager.js`), so it is NEVER written to the history
-        //     ring buffer and can never arrive as a replayed entry. It is the
-        //     only producer that sets `requestId`.
-        //   - `user_question` IS in the ring buffer and is re-sent on every
-        //     replay (`store-core/handlers/user-question.ts`), and it sets no
-        //     `requestId`.
-        //
-        // So `!m.requestId` is precisely "could this have come from history?",
-        // which is the only question this sweep is entitled to ask. A prompt
-        // with a `requestId` present at replay-end always raced the replay
-        // instead of being replayed — and that is routine, not exotic:
-        // `replayHistory` sends its first 20-entry chunk synchronously and
-        // defers the rest, while `resendPendingPermissions` runs later in the
-        // same post-auth block (`ws-history.js`), so on any session with more
-        // than one chunk of history the re-sent permission lands BEFORE
-        // `history_replay_end`. `reconcileReplayEnd`'s baseline slice keeps it
-        // deliberately. Stamping it destroys the pending approval the user
-        // reconnected to answer — the opposite of this sweep's premise that
-        // anything in history is already resolved.
-        //
-        // NOT `isLivePermissionPrompt`: that also requires `expiresAt > now`,
-        // and `expiresAt` is only set when the frame carried `remainingMs`,
-        // which is `.optional()` in `ServerPermissionRequestSchema`. An emitter
-        // that omits it yields a live prompt with `requestId` and no
-        // `expiresAt` — not "live" by that predicate, and stamped. It would
-        // also stamp a `permission_expired` prompt, whose `answered` is left
-        // empty on purpose (it is a DECISION token and no decision was made).
-        // `requestId` has neither hole.
-        //
-        // Still open: a LIVE AskUserQuestion racing a replay is byte-identical
-        // to a replayed one, so nothing here can separate them — see #7420.
         if (endTargetId) {
-          const isStampable = (m: ChatMessage): boolean =>
-            m.type === 'prompt' && !m.answered && !m.requestId;
           updateSession(endTargetId, (ss) => {
-            const hasUnansweredPrompts = ss.messages.some(isStampable);
-            if (!hasUnansweredPrompts) return {};
-            return {
-              messages: ss.messages.map((m) =>
-                isStampable(m) ? { ...m, answered: '(resolved)' } : m
-              ),
-            };
+            const swept = sweepUnansweredPromptsAtReplayEnd(endTargetId, ss.messages);
+            return swept ? { messages: swept } : {};
           });
         }
       }

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -57,7 +57,7 @@ import {
   MCP_SERVER_OP_PENDING_CAP,
 } from './message-handler'
 import { createEmptySessionState } from './utils'
-import { isLivePermissionPrompt } from '@chroxy/store-core'
+import { isLivePermissionPrompt, resetReplayReconcile } from '@chroxy/store-core'
 import type { ConnectionState } from './types'
 
 function createMockStore(initial: Partial<ConnectionState>) {
@@ -3771,6 +3771,156 @@ describe('dashboard message-handler dispatch', () => {
       expect(st.s2.messages[0].answered).toBeUndefined();
     });
   });
+
+  // #7420 — the other half of #7410. `permission_request` is server-transient, so
+  // a permission prompt present at replay-end always RACED the replay and
+  // `!m.requestId` excludes it exactly. `user_question` is NOT transient: it is
+  // in the history ring buffer and is re-sent on every replay, and the
+  // ChatMessage it builds carries no `requestId` and no `expiresAt`. So a LIVE
+  // AskUserQuestion that lands mid-replay is byte-identical in store state to a
+  // replayed one, and the pre-fix sweep stamped both — losing the answer path
+  // for that turn.
+  //
+  // The discriminator is the wire frame, recorded at arrival: `replayHistory`
+  // stamps every replayed history entry with `historySeq` (ws-history.js) and a
+  // live broadcast never carries it. store-core's replay-reconcile module notes
+  // the ids of questions that arrived WITHOUT one while the session's replay
+  // window was open, and the sweep skips exactly those.
+  describe("history_replay_end: '(resolved)' sweep vs a racing live AskUserQuestion (#7420)", () => {
+    beforeEach(() => {
+      // The live-arrival set is module state in store-core; a window left open
+      // by an earlier test would otherwise decide these cases.
+      resetReplayReconcile({ clearCursors: true })
+    })
+
+    afterEach(() => {
+      resetReplayReconcile({ clearCursors: true })
+    })
+
+    function seedOne(messages: any[] = []) {
+      store = createMockStore(
+        baseState({
+          activeSessionId: 's1',
+          sessions: [{ sessionId: 's1', name: 'S1' } as any],
+          sessionStates: { s1: { ...createEmptySessionState(), messages } },
+        }),
+      )
+      setStore(store)
+    }
+
+    /**
+     * A `user_question` wire frame. `historySeq` present ⇒ the replay delivered
+     * it; absent ⇒ a live broadcast. That is the ONLY difference between the
+     * two on the wire, which is the whole difficulty of this bug.
+     */
+    const question = (extra: Record<string, unknown> = {}) => ({
+      type: 'user_question',
+      sessionId: 's1',
+      toolUseId: 'q-use-1',
+      questions: [{ question: 'Which approach?', options: [{ label: 'A' }, { label: 'B' }] }],
+      ...extra,
+    })
+
+    const answeredOf = (i = 0) =>
+      (store.getState() as any).sessionStates.s1.messages[i].answered
+
+    // --- AC (a): the live racer survives -----------------------------------
+
+    it('does not stamp a live question that arrived mid-replay (delta replay)', () => {
+      seedOne()
+      handleMessage({ type: 'history_replay_start', sessionId: 's1', fullHistory: false }, ctx() as any)
+      handleMessage(question() as any, ctx() as any)
+      // Positive control: the prompt really was appended, so the
+      // `answered === undefined` assertion below is about the sweep and not
+      // about an absent fixture.
+      expect((store.getState() as any).sessionStates.s1.messages).toHaveLength(1)
+      expect((store.getState() as any).sessionStates.s1.messages[0].type).toBe('prompt')
+
+      handleMessage({ type: 'history_replay_end', sessionId: 's1' }, ctx() as any)
+
+      expect(answeredOf()).toBeUndefined()
+    })
+
+    it('does not stamp a live question that arrived mid-replay (full rebuild)', () => {
+      // A pre-replay message makes the baseline non-zero, so the atomic swap at
+      // replay-end is real (it slices the prefix off) rather than a no-op.
+      seedOne([{ id: 'old-1', type: 'response', content: 'before', timestamp: 1 }])
+      handleMessage({ type: 'history_replay_start', sessionId: 's1', fullHistory: true }, ctx() as any)
+      // Replayed first, then the live racer — the interleaving the server's
+      // chunked replay actually produces.
+      handleMessage(question({ historySeq: 3, timestamp: 1000 }) as any, ctx() as any)
+      handleMessage(question({ toolUseId: 'q-use-2' }) as any, ctx() as any)
+      expect((store.getState() as any).sessionStates.s1.messages).toHaveLength(3)
+
+      handleMessage({ type: 'history_replay_end', sessionId: 's1' }, ctx() as any)
+
+      // Swap dropped the pre-replay prefix; both prompts survive it.
+      expect((store.getState() as any).sessionStates.s1.messages).toHaveLength(2)
+      expect(answeredOf(0)).toBe('(resolved)')
+      expect(answeredOf(1)).toBeUndefined()
+    })
+
+    // --- AC (b): a genuinely replayed question is still stamped -------------
+
+    it('still stamps a question the replay itself delivered', () => {
+      seedOne()
+      handleMessage({ type: 'history_replay_start', sessionId: 's1', fullHistory: false }, ctx() as any)
+      handleMessage(question({ historySeq: 7, timestamp: 1000 }) as any, ctx() as any)
+      expect((store.getState() as any).sessionStates.s1.messages).toHaveLength(1)
+
+      handleMessage({ type: 'history_replay_end', sessionId: 's1' }, ctx() as any)
+
+      expect(answeredOf()).toBe('(resolved)')
+    })
+
+    it('still stamps a question that pre-dates the replay window', () => {
+      seedOne()
+      // Live, but BEFORE any replay opened — nothing about this reconnect
+      // vouches for it, so the long-standing sweep behaviour stands.
+      handleMessage(question() as any, ctx() as any)
+      handleMessage({ type: 'history_replay_start', sessionId: 's1', fullHistory: false }, ctx() as any)
+      handleMessage({ type: 'history_replay_end', sessionId: 's1' }, ctx() as any)
+
+      expect(answeredOf()).toBe('(resolved)')
+    })
+
+    it('forgets the previous window: a racer protected once is stamped on the NEXT replay', () => {
+      seedOne()
+      handleMessage({ type: 'history_replay_start', sessionId: 's1', fullHistory: false }, ctx() as any)
+      handleMessage(question() as any, ctx() as any)
+      handleMessage({ type: 'history_replay_end', sessionId: 's1' }, ctx() as any)
+      expect(answeredOf()).toBeUndefined()
+
+      handleMessage({ type: 'history_replay_start', sessionId: 's1', fullHistory: false }, ctx() as any)
+      handleMessage({ type: 'history_replay_end', sessionId: 's1' }, ctx() as any)
+
+      expect(answeredOf()).toBe('(resolved)')
+    })
+
+    it("a racer in session s1 is not protected by session s2's replay window", () => {
+      store = createMockStore(
+        baseState({
+          activeSessionId: 's1',
+          sessions: [{ sessionId: 's1', name: 'S1' } as any, { sessionId: 's2', name: 'S2' } as any],
+          sessionStates: {
+            s1: createEmptySessionState(),
+            s2: createEmptySessionState(),
+          },
+        }),
+      )
+      setStore(store)
+
+      // Only s2 is replaying; a live question for s1 is not inside any window
+      // of its own, so s1's own replay-end still stamps it.
+      handleMessage({ type: 'history_replay_start', sessionId: 's2', fullHistory: false }, ctx() as any)
+      handleMessage(question() as any, ctx() as any)
+      handleMessage({ type: 'history_replay_end', sessionId: 's2' }, ctx() as any)
+      handleMessage({ type: 'history_replay_start', sessionId: 's1', fullHistory: false }, ctx() as any)
+      handleMessage({ type: 'history_replay_end', sessionId: 's1' }, ctx() as any)
+
+      expect(answeredOf()).toBe('(resolved)')
+    })
+  })
 
   describe('history replay: user_input rehydration', () => {
     function seed() {

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -59,6 +59,11 @@ import {
   recordHistorySeq,
   reconcileReplayStart,
   reconcileReplayEnd,
+  // #7420 — the shared `history_replay_end` unanswered-prompt sweep. Both
+  // clients carried byte-identical copies of the predicate through #7410/#7419;
+  // it now has one implementation, which is also where the live-arrival ledger
+  // that protects a racing AskUserQuestion is read.
+  sweepUnansweredPromptsAtReplayEnd,
   replayDedupCache,
   resetReplayReconcile,
   handlePermissionExpired as sharedPermissionExpired,
@@ -5241,72 +5246,30 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
           // Session vanished mid-replay — still settle the cursor.
           reconcileReplayEnd(endTargetId, [], endLatestSeq);
         }
-        // Mark all replayed prompts as answered — any prompt in history
-        // has already been resolved by the server.
+        // Mark replayed prompts as answered — the premise being that any prompt
+        // in history has already been resolved by the server.
         //
-        // #7410 — keyed to `endTargetId`, NOT `activeSessionId`. The predicate
-        // matches LIVE prompts as well as historical ones:
-        // `isLivePermissionPrompt` is `type === 'prompt' && requestId &&
-        // expiresAt > now && !answered`, and AskUserQuestion emits
-        // `type: 'prompt'` too. Keyed to the active session, a BACKGROUND
-        // session's replay-end stamped '(resolved)' on a permission approval
-        // the user was looking at — silently dismissing it — and
-        // `subscribe_sessions` replays every background session, so that
-        // happened on every multi-session reconnect. Fourth instance of this
+        // The predicate, its three exclusions and the reasoning behind each now
+        // live in ONE place: `sweepUnansweredPromptsAtReplayEnd` in store-core's
+        // replay-reconcile.ts. Both clients carried byte-identical copies of it
+        // through #7410 and #7419, which is the drift #7420 removed.
+        //
+        // What stays here is the KEYING. #7410 — keyed to `endTargetId`, NOT
+        // `activeSessionId`. The predicate matches LIVE prompts as well as
+        // historical ones, and `subscribe_sessions` replays every background
+        // session, so keyed to the active session a BACKGROUND session's
+        // replay-end stamped '(resolved)' on a permission approval the user was
+        // looking at — on every multi-session reconnect. Fourth instance of this
         // mis-keying in this pair of files after #4909, #7340 and #7402.
         //
         // `endTargetId` already falls back to `activeSessionId` when the frame
         // omits `sessionId`, so the single-session case is unchanged; and
         // `updateSession` no-ops on an id with no state, which is the right
         // outcome for the "session vanished mid-replay" branch above.
-        //
-        // Permission prompts are excluded by `requestId`, and that follows from
-        // the wire contract rather than from taste. Exactly two things produce
-        // a `type: 'prompt'` ChatMessage, and history splits them cleanly:
-        //
-        //   - `permission_request` is in the server's `builtinTransient` list
-        //     (`session-manager.js`), so it is NEVER written to the history
-        //     ring buffer and can never arrive as a replayed entry. It is the
-        //     only producer that sets `requestId`.
-        //   - `user_question` IS in the ring buffer and is re-sent on every
-        //     replay (`store-core/handlers/user-question.ts`), and it sets no
-        //     `requestId`.
-        //
-        // So `!m.requestId` is precisely "could this have come from history?",
-        // which is the only question this sweep is entitled to ask. A prompt
-        // with a `requestId` present at replay-end always raced the replay
-        // instead of being replayed — and that is routine, not exotic:
-        // `replayHistory` sends its first 20-entry chunk synchronously and
-        // defers the rest, while `resendPendingPermissions` runs later in the
-        // same post-auth block (`ws-history.js`), so on any session with more
-        // than one chunk of history the re-sent permission lands BEFORE
-        // `history_replay_end`. `reconcileReplayEnd`'s baseline slice keeps it
-        // deliberately. Stamping it destroys the pending approval the user
-        // reconnected to answer — the opposite of this sweep's premise that
-        // anything in history is already resolved.
-        //
-        // NOT `isLivePermissionPrompt`: that also requires `expiresAt > now`,
-        // and `expiresAt` is only set when the frame carried `remainingMs`,
-        // which is `.optional()` in `ServerPermissionRequestSchema`. An emitter
-        // that omits it yields a live prompt with `requestId` and no
-        // `expiresAt` — not "live" by that predicate, and stamped. It would
-        // also stamp a `permission_expired` prompt, whose `answered` is left
-        // empty on purpose (it is a DECISION token and no decision was made).
-        // `requestId` has neither hole.
-        //
-        // Still open: a LIVE AskUserQuestion racing a replay is byte-identical
-        // to a replayed one, so nothing here can separate them — see #7420.
         if (endTargetId) {
-          const isStampable = (m: ChatMessage): boolean =>
-            m.type === 'prompt' && !m.answered && !m.requestId;
           updateSession(endTargetId, (ss) => {
-            const hasUnansweredPrompts = ss.messages.some(isStampable);
-            if (!hasUnansweredPrompts) return {};
-            return {
-              messages: ss.messages.map((m) =>
-                isStampable(m) ? { ...m, answered: '(resolved)' } : m
-              ),
-            };
+            const swept = sweepUnansweredPromptsAtReplayEnd(endTargetId, ss.messages);
+            return swept ? { messages: swept } : {};
           });
         }
       }

--- a/packages/store-core/src/dispatch-table.test.ts
+++ b/packages/store-core/src/dispatch-table.test.ts
@@ -15,6 +15,14 @@ import type {
   Checkpoint,
 } from './types'
 import type { PermissionRule } from './handlers'
+// #7420 — the replay window / live-arrival ledger the `user_question` case writes.
+import {
+  resetReplayReconcile,
+  reconcileReplayStart,
+  reconcileReplayEnd,
+  wasPromptLiveDuringReplay,
+  sweepUnansweredPromptsAtReplayEnd,
+} from './replay-reconcile'
 
 // ---------------------------------------------------------------------------
 // Fake adapter — a minimal in-memory store that records every mutation a
@@ -391,6 +399,57 @@ describe('shared dispatch table', () => {
       expect(env.notifications).toEqual([
         { sessionId: 's1', eventType: 'question', message: 'Proceed with the deploy?' },
       ])
+    })
+
+    // #7420 — the dispatcher is the last point at which the wire frame is in
+    // hand, so it is where "did the replay deliver this, or did it race the
+    // replay?" is decided. `historySeq` is stamped on every replayed history
+    // entry by `replayHistory` (ws-history.js) and never appears on a live
+    // broadcast; the resulting ChatMessages are byte-identical, which is why
+    // the verdict has to be recorded here rather than re-derived at replay-end.
+    it('records a live question (no historySeq) as a live arrival during the replay window', () => {
+      resetReplayReconcile({ clearCursors: true })
+      reconcileReplayStart('s1', false, 0)
+      const env = makeAdapter({
+        activeSessionId: 's1',
+        sessions: { s1: { sessionId: 's1', messages: [] } },
+      })
+      dispatch(env, {
+        type: 'user_question',
+        sessionId: 's1',
+        questions: [{ question: 'Which approach?' }],
+      })
+      const appended = env.sessions.s1.messages[0]
+      expect(appended).toBeDefined()
+      expect(wasPromptLiveDuringReplay('s1', appended.id)).toBe(true)
+      // ...and the replay-end sweep therefore leaves it alone.
+      reconcileReplayEnd('s1', [])
+      expect(sweepUnansweredPromptsAtReplayEnd('s1', env.sessions.s1.messages)).toBeNull()
+      resetReplayReconcile({ clearCursors: true })
+    })
+
+    it('does NOT record a question the replay delivered (historySeq present)', () => {
+      resetReplayReconcile({ clearCursors: true })
+      reconcileReplayStart('s1', false, 0)
+      const env = makeAdapter({
+        activeSessionId: 's1',
+        sessions: { s1: { sessionId: 's1', messages: [] } },
+      })
+      dispatch(env, {
+        type: 'user_question',
+        sessionId: 's1',
+        questions: [{ question: 'Which approach?' }],
+        historySeq: 12,
+        timestamp: 1_700_000_000_000,
+      } as never)
+      const appended = env.sessions.s1.messages[0]
+      expect(appended).toBeDefined()
+      expect(wasPromptLiveDuringReplay('s1', appended.id)).toBe(false)
+      // ...so the replay-end sweep stamps it, as it always has.
+      reconcileReplayEnd('s1', [])
+      const swept = sweepUnansweredPromptsAtReplayEnd('s1', env.sessions.s1.messages)
+      expect(swept?.[0]).toMatchObject({ answered: '(resolved)' })
+      resetReplayReconcile({ clearCursors: true })
     })
 
     it('honours a finite wire timestamp on the appended prompt (#4613)', () => {

--- a/packages/store-core/src/dispatch-table.ts
+++ b/packages/store-core/src/dispatch-table.ts
@@ -160,6 +160,9 @@ import {
 // #6449 slice 1 — shared raw-output parse for the terminal-mirror cases. The
 // './handlers' barrel doesn't re-export stream.ts, so import it directly.
 import { handleRawOutput } from './handlers/stream'
+// #7420 — the replay window / live-arrival ledger the `user_question` case
+// writes into and `history_replay_end`'s sweep reads.
+import { noteLivePromptDuringReplay } from './replay-reconcile'
 
 // ---------------------------------------------------------------------------
 // Client adapter
@@ -927,6 +930,12 @@ export interface DispatchMessageMap {
     // number) for history-replay ordering, falling back to append-time
     // Date.now(). Documented here so the message shape matches the parser.
     timestamp?: number
+    // #7420 — `replayHistory` stamps every entry it replays with the session's
+    // monotonic history seq (ws-history.js); a LIVE broadcast never carries
+    // one. It is the only thing that separates a replayed AskUserQuestion from
+    // a live one, so the dispatcher reads it to decide liveness. Not a new wire
+    // field: the same value already drives `recordHistorySeq`.
+    historySeq?: number
   }
   // --- multi_question_intervention (#5618) — the deny-event the builder reads ---
   multi_question_intervention: {
@@ -1973,6 +1982,17 @@ function dispatchUserQuestion<S extends DispatchSessionBase>(
   const parsed = handleUserQuestion(msg as Record<string, unknown>, adapter.getActiveSessionId())
   if (!parsed) return
   const { sessionId, chatMessage, questionText } = parsed
+  // #7420 — a `user_question` that arrives while its session's replay window is
+  // open is either an entry the replay itself delivered or a LIVE question that
+  // raced it, and the two build byte-identical ChatMessages (no `requestId`, no
+  // `expiresAt`). The wire frame is the only place they differ — `historySeq`
+  // is stamped by `replayHistory` and absent from every live broadcast — and
+  // this is the last point at which it is still in hand, so record the verdict
+  // now. `history_replay_end`'s sweep then skips the live ones instead of
+  // stamping them '(resolved)' and destroying the answer path for that turn.
+  const seq = (msg as { historySeq?: unknown }).historySeq
+  const deliveredByReplay = typeof seq === 'number' && Number.isFinite(seq)
+  if (!deliveredByReplay) noteLivePromptDuringReplay(sessionId, chatMessage.id)
   if (sessionId && adapter.hasSession(sessionId)) {
     adapter.updateSession(
       sessionId,

--- a/packages/store-core/src/dispatch-table.ts
+++ b/packages/store-core/src/dispatch-table.ts
@@ -1988,7 +1988,10 @@ function dispatchUserQuestion<S extends DispatchSessionBase>(
   // `expiresAt`). The wire frame is the only place they differ — `historySeq`
   // is stamped by `replayHistory` and absent from every live broadcast — and
   // this is the last point at which it is still in hand, so record the verdict
-  // now. `history_replay_end`'s sweep then skips the live ones instead of
+  // now. KNOWN GAP (#7454): the `request_full_history` replay path forwards
+  // ring-buffer entries without mapping `_seq` to `historySeq`, so questions
+  // it replays read as live here — they are left unstamped (the benign
+  // direction) until the server closes that gap. `history_replay_end`'s sweep then skips the live ones instead of
   // stamping them '(resolved)' and destroying the answer path for that turn.
   const seq = (msg as { historySeq?: unknown }).historySeq
   const deliveredByReplay = typeof seq === 'number' && Number.isFinite(seq)

--- a/packages/store-core/src/dispatch-table.ts
+++ b/packages/store-core/src/dispatch-table.ts
@@ -1988,10 +1988,10 @@ function dispatchUserQuestion<S extends DispatchSessionBase>(
   // `expiresAt`). The wire frame is the only place they differ — `historySeq`
   // is stamped by `replayHistory` and absent from every live broadcast — and
   // this is the last point at which it is still in hand, so record the verdict
-  // now. KNOWN GAP (#7454): the `request_full_history` replay path forwards
-  // ring-buffer entries without mapping `_seq` to `historySeq`, so questions
-  // it replays read as live here — they are left unstamped (the benign
-  // direction) until the server closes that gap. `history_replay_end`'s sweep then skips the live ones instead of
+  // now. Both server replay paths map `_seq` onto the wire — `replayHistory`
+  // always did, and #7454 (PR #7458) closed the `request_full_history` gap
+  // where its replayed questions read as live here (the benign direction:
+  // left unstamped, never falsely resolved). `history_replay_end`'s sweep then skips the live ones instead of
   // stamping them '(resolved)' and destroying the answer path for that turn.
   const seq = (msg as { historySeq?: unknown }).historySeq
   const deliveredByReplay = typeof seq === 'number' && Number.isFinite(seq)

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -70,6 +70,14 @@ export {
   reconcileReplayEnd,
   isRebuildInProgress,
   replayDedupCache,
+  // #7420 — the `history_replay_end` unanswered-prompt sweep, and the
+  // live-arrival ledger that keeps it off an AskUserQuestion which raced the
+  // replay. One implementation for both clients (they carried byte-identical
+  // copies of the sweep until now).
+  noteLivePromptDuringReplay,
+  wasPromptLiveDuringReplay,
+  sweepUnansweredPromptsAtReplayEnd,
+  REPLAY_RESOLVED_PLACEHOLDER,
 } from './replay-reconcile'
 
 export type {

--- a/packages/store-core/src/replay-reconcile.test.ts
+++ b/packages/store-core/src/replay-reconcile.test.ts
@@ -8,6 +8,10 @@ import {
   reconcileReplayEnd,
   isRebuildInProgress,
   replayDedupCache,
+  noteLivePromptDuringReplay,
+  wasPromptLiveDuringReplay,
+  sweepUnansweredPromptsAtReplayEnd,
+  REPLAY_RESOLVED_PLACEHOLDER,
 } from './replay-reconcile'
 
 type Msg = { id: string }
@@ -187,5 +191,167 @@ describe('replay × delta-flusher race ordering (#5588)', () => {
     // Post-end, no rebuild is active, so a later flush just appends normally;
     // reconcileReplayEnd for a non-rebuild session returns null (no second swap).
     expect(reconcileReplayEnd('s1', [{ id: 'r-1' }, { id: 'f-1' }]).swappedMessages).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// #7420 — the history_replay_end unanswered-prompt sweep
+// ---------------------------------------------------------------------------
+//
+// The sweep's premise is "anything in history is already resolved". Two things
+// build a `type: 'prompt'` ChatMessage and history splits them:
+//
+//   - `permission_request` is server-transient (never in the ring buffer) and
+//     is the only producer that sets `requestId` — #7410/#7419 excluded it.
+//   - `user_question` IS in the ring buffer AND is broadcast live, and its
+//     ChatMessage sets neither `requestId` nor `expiresAt` — so the two are
+//     byte-identical here and only the ARRIVING FRAME could tell them apart
+//     (`historySeq` is stamped by replayHistory, never by a live broadcast).
+//
+// `noteLivePromptDuringReplay` is where that observation is kept.
+type Prompt = { id: string; type: string; answered?: string; requestId?: string }
+
+const prompt = (id: string, extra: Partial<Prompt> = {}): Prompt => ({
+  id,
+  type: 'prompt',
+  ...extra,
+})
+
+describe('replay-end unanswered-prompt sweep (#7380 / #7410 / #7420)', () => {
+  it('stamps an unanswered, requestId-less prompt', () => {
+    const out = sweepUnansweredPromptsAtReplayEnd('s1', [prompt('q1')])
+    expect(out).toEqual([{ id: 'q1', type: 'prompt', answered: REPLAY_RESOLVED_PLACEHOLDER }])
+    expect(REPLAY_RESOLVED_PLACEHOLDER).toBe('(resolved)')
+  })
+
+  it('returns null when nothing is stampable (caller emits a no-op patch)', () => {
+    expect(sweepUnansweredPromptsAtReplayEnd('s1', [])).toBeNull()
+    expect(sweepUnansweredPromptsAtReplayEnd('s1', [{ id: 'm1', type: 'response' }])).toBeNull()
+    expect(sweepUnansweredPromptsAtReplayEnd('s1', [prompt('q1', { answered: 'yes' })])).toBeNull()
+  })
+
+  it('never touches a permission prompt — #7410/#7419 unchanged', () => {
+    // Both shapes #7419 protects: with and without a TTL. Only `requestId` is
+    // required, because `expiresAt` is absent whenever the frame omitted
+    // `remainingMs`.
+    expect(
+      sweepUnansweredPromptsAtReplayEnd('s1', [
+        prompt('p1', { requestId: 'req-1' }),
+        prompt('p2', { requestId: 'req-2' }),
+      ]),
+    ).toBeNull()
+  })
+
+  it('leaves other messages untouched and stamps only the stampable prompts', () => {
+    const out = sweepUnansweredPromptsAtReplayEnd('s1', [
+      { id: 'm1', type: 'response' },
+      prompt('q1'),
+      prompt('p1', { requestId: 'req-1' }),
+      prompt('q2', { answered: 'a' }),
+    ])
+    expect(out).toEqual([
+      { id: 'm1', type: 'response' },
+      { id: 'q1', type: 'prompt', answered: REPLAY_RESOLVED_PLACEHOLDER },
+      { id: 'p1', type: 'prompt', requestId: 'req-1' },
+      { id: 'q2', type: 'prompt', answered: 'a' },
+    ])
+  })
+
+  it('returns null for a null/empty sessionId (the sweep is per-session)', () => {
+    expect(sweepUnansweredPromptsAtReplayEnd(null, [prompt('q1')])).toBeNull()
+    expect(sweepUnansweredPromptsAtReplayEnd(undefined, [prompt('q1')])).toBeNull()
+  })
+
+  describe('live-arrival ledger', () => {
+    it('skips a prompt that arrived live inside the window, stamps one the replay delivered', () => {
+      reconcileReplayStart('s1', false, 0)
+      // Only the live one is recorded; the replayed one carried a historySeq at
+      // the call site and so is never noted.
+      noteLivePromptDuringReplay('s1', 'live-q')
+      // Positive control — the fixture actually took effect. Without it, a
+      // green "not stamped" could just as well mean the note never landed.
+      expect(wasPromptLiveDuringReplay('s1', 'live-q')).toBe(true)
+      expect(wasPromptLiveDuringReplay('s1', 'replayed-q')).toBe(false)
+      reconcileReplayEnd('s1', [])
+
+      const out = sweepUnansweredPromptsAtReplayEnd('s1', [
+        prompt('replayed-q'),
+        prompt('live-q'),
+      ])
+      expect(out).toEqual([
+        { id: 'replayed-q', type: 'prompt', answered: REPLAY_RESOLVED_PLACEHOLDER },
+        { id: 'live-q', type: 'prompt' },
+      ])
+    })
+
+    it('is a no-op outside a replay window — a prompt that pre-dates it stays stampable', () => {
+      noteLivePromptDuringReplay('s1', 'q1')
+      expect(wasPromptLiveDuringReplay('s1', 'q1')).toBe(false)
+      reconcileReplayStart('s1', false, 0)
+      reconcileReplayEnd('s1', [])
+      expect(sweepUnansweredPromptsAtReplayEnd('s1', [prompt('q1')])).toEqual([
+        { id: 'q1', type: 'prompt', answered: REPLAY_RESOLVED_PLACEHOLDER },
+      ])
+    })
+
+    it('opens the window for a DELTA replay too, not just a full rebuild', () => {
+      // `_rebuildBaseline` only tracks full rebuilds, so the window has to be
+      // its own thing — a live question races a delta replay just as easily.
+      reconcileReplayStart('s1', false, 0)
+      expect(isRebuildInProgress('s1')).toBe(false)
+      noteLivePromptDuringReplay('s1', 'q1')
+      expect(wasPromptLiveDuringReplay('s1', 'q1')).toBe(true)
+    })
+
+    it('closes the window at replay end — a later arrival is not protected', () => {
+      reconcileReplayStart('s1', true, 0)
+      reconcileReplayEnd('s1', [])
+      noteLivePromptDuringReplay('s1', 'after-q')
+      expect(wasPromptLiveDuringReplay('s1', 'after-q')).toBe(false)
+    })
+
+    it('forgets the previous window at the next start', () => {
+      reconcileReplayStart('s1', false, 0)
+      noteLivePromptDuringReplay('s1', 'q1')
+      reconcileReplayEnd('s1', [])
+      expect(wasPromptLiveDuringReplay('s1', 'q1')).toBe(true)
+      // Second replay: q1 is now just an old on-screen prompt with nothing
+      // vouching for it, so the sweep is entitled to stamp it again.
+      reconcileReplayStart('s1', false, 1)
+      expect(wasPromptLiveDuringReplay('s1', 'q1')).toBe(false)
+      reconcileReplayEnd('s1', [])
+      expect(sweepUnansweredPromptsAtReplayEnd('s1', [prompt('q1')])).toEqual([
+        { id: 'q1', type: 'prompt', answered: REPLAY_RESOLVED_PLACEHOLDER },
+      ])
+    })
+
+    it("is per-session — s2's window does not protect a prompt in s1", () => {
+      reconcileReplayStart('s2', false, 0)
+      noteLivePromptDuringReplay('s1', 'q1')
+      expect(wasPromptLiveDuringReplay('s1', 'q1')).toBe(false)
+      expect(sweepUnansweredPromptsAtReplayEnd('s1', [prompt('q1')])).toEqual([
+        { id: 'q1', type: 'prompt', answered: REPLAY_RESOLVED_PLACEHOLDER },
+      ])
+    })
+
+    it('ignores a null session id or message id', () => {
+      reconcileReplayStart('s1', false, 0)
+      noteLivePromptDuringReplay(null, 'q1')
+      noteLivePromptDuringReplay('s1', null)
+      noteLivePromptDuringReplay('s1', '')
+      expect(wasPromptLiveDuringReplay('s1', 'q1')).toBe(false)
+      expect(wasPromptLiveDuringReplay(null, 'q1')).toBe(false)
+      expect(wasPromptLiveDuringReplay('s1', null)).toBe(false)
+    })
+
+    it('resetReplayReconcile drops the window and the ledger (fresh auth)', () => {
+      reconcileReplayStart('s1', false, 0)
+      noteLivePromptDuringReplay('s1', 'q1')
+      resetReplayReconcile()
+      expect(wasPromptLiveDuringReplay('s1', 'q1')).toBe(false)
+      // Window gone too: a note after the reset is not retroactively honoured.
+      noteLivePromptDuringReplay('s1', 'q2')
+      expect(wasPromptLiveDuringReplay('s1', 'q2')).toBe(false)
+    })
   })
 })

--- a/packages/store-core/src/replay-reconcile.ts
+++ b/packages/store-core/src/replay-reconcile.ts
@@ -73,6 +73,45 @@ const _rebuildBaseline = new Map<string, number>()
 const _historyCursors = new Map<string, number>()
 
 /**
+ * Per-session "a replay window is open right now" marker (#7420).
+ *
+ * Deliberately NOT `_rebuildBaseline`: that map only holds FULL rebuilds, and a
+ * live prompt can race a DELTA replay just as easily (the server chunks both
+ * over `setImmediate`, with back-pressure pauses of up to 30s — ws-history.js).
+ * Added at `reconcileReplayStart` for either kind, removed at
+ * `reconcileReplayEnd`.
+ */
+const _replayWindowOpen = new Set<string>()
+
+/**
+ * Per-session ids of `prompt` ChatMessages that arrived LIVE — i.e. were NOT
+ * delivered by the replay — while that session's replay window was open (#7420).
+ *
+ * This is the whole fix for #7420. `history_replay_end` sweeps unanswered
+ * prompts with `answered: '(resolved)'` on the premise that anything in history
+ * is already resolved. `permission_request` is in the server's `builtinTransient`
+ * list so it is never replayed, and #7410/#7419 excluded it by `requestId`. But
+ * `user_question` IS in the history ring buffer, and the ChatMessage it builds
+ * carries no `requestId` and no `expiresAt` — so a live AskUserQuestion that
+ * lands mid-replay is byte-identical in store state to a replayed one, and the
+ * sweep stamped both, silently destroying the answer path for that turn.
+ *
+ * The one signal that separates them is the wire frame, which only exists at
+ * arrival: `replayHistory` stamps every replayed entry with `historySeq`
+ * (ws-history.js) and a live broadcast never carries one. So the call site
+ * records the id here as the message is appended, and the sweep skips it.
+ *
+ * Lifetime is exactly one replay window: the set is dropped at the NEXT
+ * `reconcileReplayStart` for that session (anything already on screen when a
+ * window opens pre-dates it and stays stampable) and by `resetReplayReconcile`.
+ * That also bounds it — the entries are a subset of the ChatMessages the store
+ * is already holding for the same window — so it needs no cap of its own, and
+ * it leaves {@link sweepUnansweredPromptsAtReplayEnd} a pure read, with no
+ * ordering hazard against the caller that consumes it.
+ */
+const _liveDuringReplay = new Map<string, Set<string>>()
+
+/**
  * Client-side cap on the per-session cursor map. Mirrors the server's
  * `MAX_HISTORY_CURSORS` (ws-auth.js): the server only honours that many keys
  * from a single `auth`, so retaining/sending more is pure bloat. Holding the
@@ -90,6 +129,10 @@ const MAX_CLIENT_HISTORY_CURSORS = 64
  */
 export function resetReplayReconcile(opts: { clearCursors?: boolean } = {}): void {
   _rebuildBaseline.clear()
+  // #7420 — an open window and its live-arrival ids are per-connection state
+  // like the baseline, never a cursor: a fresh auth must not inherit either.
+  _replayWindowOpen.clear()
+  _liveDuringReplay.clear()
   if (opts.clearCursors) _historyCursors.clear()
 }
 
@@ -158,6 +201,11 @@ export function reconcileReplayStart(
   _latestSeq?: unknown,
 ): { rebuildInProgress: boolean } {
   if (!sessionId) return { rebuildInProgress: false }
+  // #7420 — open the window for BOTH replay kinds, and drop the previous
+  // window's live-arrival ids: every prompt already on screen pre-dates this
+  // replay, so nothing about it is vouched for by this window.
+  _replayWindowOpen.add(sessionId)
+  _liveDuringReplay.delete(sessionId)
   if (fullHistory) {
     _rebuildBaseline.set(sessionId, Math.max(0, currentLen | 0))
     return { rebuildInProgress: true }
@@ -207,6 +255,11 @@ export function reconcileReplayEnd(
   if (sessionId && typeof latestSeq === 'number' && Number.isFinite(latestSeq)) {
     recordHistorySeq(sessionId, latestSeq)
   }
+  // #7420 — close the window BEFORE the delta-replay early return below, so a
+  // delta replay's window closes too. The live-arrival ids themselves are left
+  // in place for `sweepUnansweredPromptsAtReplayEnd`, which the caller runs
+  // after this; they are dropped at the next start / on reset.
+  if (sessionId) _replayWindowOpen.delete(sessionId)
   if (!sessionId || !_rebuildBaseline.has(sessionId)) {
     return { swappedMessages: null }
   }
@@ -216,4 +269,104 @@ export function reconcileReplayEnd(
   // tail, in array order. A baseline at or past the end yields [] (a session
   // that genuinely had no replayed entries, e.g. server-side trim to empty).
   return { swappedMessages: messages.slice(base) }
+}
+
+// ---------------------------------------------------------------------------
+// #7420 — the `history_replay_end` unanswered-prompt sweep
+// ---------------------------------------------------------------------------
+
+/**
+ * The `answered` value `history_replay_end` stamps on a prompt nobody answered.
+ *
+ * `answered` is a decision TOKEN, not a label (#6222/#6223), and this is the
+ * one non-decision it may hold — which is why `isPermissionRequestAnswered`
+ * (pending-permissions.ts) explicitly rejects it. One writer, here, so the two
+ * clients cannot drift on the string.
+ */
+export const REPLAY_RESOLVED_PLACEHOLDER = '(resolved)'
+
+/** The subset of `ChatMessage` the replay-end sweep reads. */
+interface SweepablePrompt {
+  id: string
+  type: string
+  answered?: unknown
+  requestId?: unknown
+}
+
+/**
+ * Record that a `prompt` message arrived LIVE during `sessionId`'s replay
+ * window, so {@link sweepUnansweredPromptsAtReplayEnd} leaves it alone (#7420).
+ *
+ * A no-op when no window is open for that session — a prompt that arrives
+ * outside a replay is not racing one, and the next replay's sweep is entitled
+ * to stamp it (that is the pre-#7420 behaviour, deliberately kept).
+ *
+ * The CALLER decides liveness, because only the caller still has the wire
+ * frame: a replayed entry carries `historySeq`, a live broadcast does not.
+ */
+export function noteLivePromptDuringReplay(
+  sessionId: string | null | undefined,
+  messageId: string | null | undefined,
+): void {
+  if (!sessionId || !messageId) return
+  if (!_replayWindowOpen.has(sessionId)) return
+  let ids = _liveDuringReplay.get(sessionId)
+  if (!ids) {
+    ids = new Set<string>()
+    _liveDuringReplay.set(sessionId, ids)
+  }
+  ids.add(messageId)
+}
+
+/** Was this prompt recorded as a live arrival during the current window? */
+export function wasPromptLiveDuringReplay(
+  sessionId: string | null | undefined,
+  messageId: string | null | undefined,
+): boolean {
+  if (!sessionId || !messageId) return false
+  return _liveDuringReplay.get(sessionId)?.has(messageId) === true
+}
+
+/**
+ * The `history_replay_end` sweep, shared so the app and the dashboard cannot
+ * drift on it (they carried byte-identical copies until #7420).
+ *
+ * Stamps `answered: '(resolved)'` on every unanswered `prompt` in `messages`
+ * that the sweep is entitled to touch, and returns the new array — or `null`
+ * when there is nothing to stamp, so the caller can return a no-op patch and
+ * avoid a re-render.
+ *
+ * Three exclusions, each for its own reason:
+ *
+ *   - `m.answered` already set — a real decision, or an earlier sweep.
+ *   - `m.requestId` present (#7410/#7419) — only `permission_request` sets it,
+ *     and `permission_request` is in the server's `builtinTransient` list
+ *     (session-manager.js) so it is NEVER written to the history ring buffer.
+ *     A permission prompt at replay-end therefore always RACED the replay; that
+ *     is routine, not exotic, because `resendPendingPermissions` runs after
+ *     `replayHistory` has already sent its first chunk. Keyed on `requestId`
+ *     rather than `isLivePermissionPrompt` because `expiresAt` is only set when
+ *     the frame carried `remainingMs` (`.optional()` in the schema), and a
+ *     `permission_expired` prompt deliberately keeps `answered` empty.
+ *   - recorded by {@link noteLivePromptDuringReplay} (#7420) — a `user_question`
+ *     that arrived live inside this window. `user_question` IS in the ring
+ *     buffer and its ChatMessage sets neither `requestId` nor `expiresAt`, so
+ *     shape alone cannot tell a live one from a replayed one; only the arriving
+ *     frame could, and this is where that observation is kept.
+ *
+ * Everything else — replayed prompts, and prompts that pre-date the window — is
+ * stamped, which is the sweep's original premise.
+ */
+export function sweepUnansweredPromptsAtReplayEnd<T extends SweepablePrompt>(
+  sessionId: string | null | undefined,
+  messages: readonly T[],
+): T[] | null {
+  if (!sessionId) return null
+  const live = _liveDuringReplay.get(sessionId)
+  const isStampable = (m: T): boolean =>
+    m.type === 'prompt' && !m.answered && !m.requestId && !(live?.has(m.id) === true)
+  if (!messages.some(isStampable)) return null
+  return messages.map((m) =>
+    isStampable(m) ? ({ ...m, answered: REPLAY_RESOLVED_PLACEHOLDER } as T) : m,
+  )
 }


### PR DESCRIPTION
## The bug

`history_replay_end` sweeps the replayed session's messages and stamps
`answered: '(resolved)'` on every unanswered `type: 'prompt'`, on the premise
that anything in history is already resolved.

#7410 / PR #7419 excluded **permission** prompts by `requestId`, and that
exclusion is exact because the wire contract decides it: `permission_request` is
in the server's `builtinTransient` list (`session-manager.js`), so it is never
written to the history ring buffer — a permission prompt present at replay-end
therefore always *raced* the replay.

`user_question` is **not** transient. It IS in the ring buffer and is re-sent on
every replay (`store-core/handlers/user-question.ts`), *and* it is broadcast
live. The ChatMessage it builds carries **no `requestId` and no `expiresAt`**
(`user-question.ts:172-183`), so:

- a **replayed** AskUserQuestion prompt, and
- a **live** AskUserQuestion that arrived mid-replay

are byte-identical in client state, and the sweep stamped both. The prompt
collapses into a resolved pill and the answer path for that turn is lost.

The race window is wide, not exotic: `replayHistory` emits 20-entry chunks
separated by `setImmediate` yields with back-pressure pauses of up to 30s
(`ws-history.js:17-47`), and `reconcileReplayEnd`'s baseline slice deliberately
preserves any racing live entry (`replay-reconcile.ts`).

## Why option (3)

Options (1) and (2) from the issue both need a wire change (a `replayed: true`
flag, or a server-supplied liveness token on the prompt). (3) is client-only and
needs no protocol version bump, so it is what this PR implements.

The issue's parenthetical suggested sweeping "only entries at or before the
baseline". That does not work, and the code says why: in a full rebuild the
pre-baseline prefix is **discarded** by the atomic swap, and the surviving tail
(`messages.slice(base)`) contains replayed entries *and* racing live ones
interleaved in arrival order. Index position cannot separate them. So the
discriminator has to be recorded at arrival instead — which is still option (3),
using the same module that already tracks the replay window.

## The discriminator, and why it cannot re-break #7419

**`historySeq` presence on the arriving frame.** `replayHistory` surfaces the
server-internal `_seq` as `historySeq` on every entry it replays
(`ws-history.js:1265-1268`), and a live broadcast never carries one. It is not a
new wire field — the same value already drives `recordHistorySeq` — and it is
reliably present: `_pushHistory` stamps `_seq` on append and `setHistory`
re-stamps 1..N on restore, so every ring-buffer entry has one.

`dispatchUserQuestion` (shared by both clients) is the last point at which the
frame is in hand, so it records the ids of questions that arrived **without**
`historySeq` while that session's replay window was open. The sweep skips
exactly those.

Three properties keep #7419 intact:

1. **The `requestId` exclusion is untouched.** It is still the first thing the
   sweep checks, and the new clause only ever *removes* messages from the
   stamped set. A permission prompt cannot become stampable because of this
   change — mutation M2 below confirms the two directions are pinned separately.
2. **The ledger is per-session and per-window.** It is dropped at the next
   `reconcileReplayStart` for that session, so a prompt that pre-dates a replay
   window stays stampable — the long-standing behaviour, unchanged.
3. **The window is tracked for delta replays too.** `_rebuildBaseline` only
   holds full rebuilds; a live question races a delta replay just as easily, so
   `_replayWindowOpen` is its own set.

Also folded in: the sweep predicate itself now has **one implementation**
(`sweepUnansweredPromptsAtReplayEnd` in store-core). Both clients carried
byte-identical copies of it through #7410 and #7419 — the exact drift surface
this repo keeps getting bitten by — and now both just call it.

## Acceptance criteria → tests

| AC | Test |
|----|------|
| A live `user_question` arriving during its own session's `history_replay_end` is not stamped | app + dashboard `does not stamp a live question that arrived mid-replay (delta replay)` and `(full rebuild)`; store-core `skips a prompt that arrived live inside the window…` |
| A genuinely replayed `user_question` still is | app + dashboard `still stamps a question the replay itself delivered`; the full-rebuild test also asserts the replayed prompt IS stamped in the same array; store-core `does NOT record a question the replay delivered (historySeq present)` |
| Both clients | the app and dashboard describes are mirrored case-for-case |
| Each test proven red against the pre-fix source | below |

Extra guards: `still stamps a question that pre-dates the replay window`,
`forgets the previous window: a racer protected once is stamped on the NEXT
replay`, `a racer in session s1 is not protected by session s2's replay window`,
plus store-core unit tests for the ledger (no-op outside a window, closes at
end, per-session, cleared by `resetReplayReconcile`, null-id handling) and for
the sweep's #7410/#7419 exclusions (`never touches a permission prompt`, both
the with-TTL and no-`expiresAt` shapes).

## Red-first evidence

Both client describes were written and run **against the completely unmodified
source** (no store-core change, no client change) before any implementation:

```
app      Tests: 3 failed, 3 passed
dashboard  Tests: 3 failed | 3 passed
```

The three failures per client, identical on both:

- `does not stamp a live question that arrived mid-replay (delta replay)` — `expected '(resolved)' to be undefined`
- `does not stamp a live question that arrived mid-replay (full rebuild)` — same
- `forgets the previous window: a racer protected once is stamped on the NEXT replay` — same (its first half is an AC-(a) assertion)

The three that passed pre-fix are the AC-(b) / unchanged-behaviour pins
(`still stamps a question the replay itself delivered`, `still stamps a question
that pre-dates the replay window`, the cross-session one). They are stated
honestly as such — they are green on both sides of the fix and exist to catch an
*over-broad* fix, and mutation M2 shows they do.

The store-core unit tests cover functions that did not exist pre-fix, so they
carry their red proof by mutation instead.

## Mutation evidence

Each mutation was applied by script with an occurrence-count assert, `grep`-verified
to have landed, and restored from a byte backup with `cp` (absolute paths, sha
verified equal afterwards).

| # | Mutation | Result |
|---|----------|--------|
| M1 | drop the `!live?.has(m.id)` clause from the sweep (revert the fix) | store-core 2 failed / 161 passed · app 3 failed (exactly the pre-fix three) · dashboard 3 failed (same three) |
| M2 | drop the `historySeq` check in the dispatcher — record *every* question as live (an over-broad "never stamp a question" fix) | store-core 1 failed (`does NOT record a question the replay delivered`) · app 2 failed (`still stamps a question the replay itself delivered`, and the full-rebuild test's replayed-prompt assertion) · dashboard the same 2 |
| M3 | stop clearing the ledger at `reconcileReplayStart` | store-core 1 failed (`forgets the previous window at the next start`) · app 1 · dashboard 1 — exactly the paired tests |
| M4 | remove the `_replayWindowOpen` gate in `noteLivePromptDuringReplay` | store-core 4 failed (`no-op outside a replay window`, `closes the window at replay end`, `is per-session`, `resetReplayReconcile drops the window and the ledger`) · app and dashboard **green** |

M4 is worth stating plainly rather than hiding: the client-level "pre-dates the
window" and "s2's window doesn't protect s1" cases survive it, because the
start-time ledger clear independently produces the right answer for both. The
gate is pinned directly at the store-core level, which is where the four
failures land. Two mechanisms, tested separately.

M1 and M2 together are the load-bearing pair: they kill disjoint test sets, so
neither direction of the discriminator is free.

## Test results

| Package | Command | Result |
|---------|---------|--------|
| store-core | `npx vitest run` | **60 files / 2189 tests passed** |
| store-core | `npm run typecheck` | clean |
| app | `npx tsc --noEmit` | clean |
| app | `npx jest src/__tests__/store --coverage=false` | **34 suites / 731 tests passed** |
| app | `npx jest --coverage=false` (full suite, both jest roots) | **181 suites / 2372 tests passed** |
| dashboard | `npx vitest run src/store/` | 79 files / 1158 tests passed, 1 file failed to load |
| dashboard | `npx tsc --noEmit` | 249 errors, **identical count on the pristine tree** (`git stash` comparison) |

The dashboard's load failure and its 249 type errors are one pre-existing
environment gap, not a regression: `@testing-library/react` is declared in
`packages/dashboard/package.json` but absent from the installed
`node_modules`, so 170 test files cannot resolve it and every test callback in
them types as implicit `any`. All 170 failures share that single cause, every
file that *did* load passed (1968 tests, zero test failures), and none of the
type errors are in a file this PR touches. CI installs the dependency.

Related: #7410 / PR #7419 (the permission-prompt half), #7402, #7340, #4909
(the `updateActiveSession` mis-keying family).

Closes #7420
