### PR TITLE
fix(server): map _seq to historySeq on the request_full_history replay path (#7454)

### DIFF
--- a/packages/protocol/dist/schemas/server/stream.d.ts
+++ b/packages/protocol/dist/schemas/server/stream.d.ts
@@ -405,6 +405,7 @@ export declare const ServerUserQuestionSchema: z.ZodObject<{
     type: z.ZodLiteral<"user_question">;
     toolUseId: z.ZodString;
     questions: z.ZodArray<z.ZodAny>;
+    historySeq: z.ZodOptional<z.ZodNumber>;
 }, z.core.$strip>;
 export declare const ServerAgentBusySchema: z.ZodObject<{
     type: z.ZodLiteral<"agent_busy">;

--- a/packages/protocol/dist/schemas/server/stream.d.ts
+++ b/packages/protocol/dist/schemas/server/stream.d.ts
@@ -105,6 +105,7 @@ export declare const ServerMessageSchema: z.ZodObject<{
     attemptedResumeId: z.ZodOptional<z.ZodString>;
     stdout: z.ZodOptional<z.ZodString>;
     stderr: z.ZodOptional<z.ZodString>;
+    historySeq: z.ZodOptional<z.ZodNumber>;
 }, z.core.$strip>;
 export declare const ServerToolStartSchema: z.ZodObject<{
     type: z.ZodLiteral<"tool_start">;
@@ -113,6 +114,7 @@ export declare const ServerToolStartSchema: z.ZodObject<{
     tool: z.ZodString;
     input: z.ZodAny;
     serverName: z.ZodOptional<z.ZodString>;
+    historySeq: z.ZodOptional<z.ZodNumber>;
 }, z.core.$strip>;
 export declare const ServerToolResultSchema: z.ZodObject<{
     type: z.ZodLiteral<"tool_result">;
@@ -120,6 +122,7 @@ export declare const ServerToolResultSchema: z.ZodObject<{
     result: z.ZodAny;
     truncated: z.ZodOptional<z.ZodBoolean>;
     isError: z.ZodOptional<z.ZodBoolean>;
+    historySeq: z.ZodOptional<z.ZodNumber>;
 }, z.core.$strip>;
 export declare const ServerToolInputDeltaSchema: z.ZodObject<{
     type: z.ZodLiteral<"tool_input_delta">;
@@ -186,6 +189,7 @@ export declare const ServerResultSchema: z.ZodObject<{
             "final-round-prompt": "final-round-prompt";
         }>>;
     }, z.core.$strip>>>;
+    historySeq: z.ZodOptional<z.ZodNumber>;
 }, z.core.$strip>;
 export declare const ServerModelChangedSchema: z.ZodObject<{
     type: z.ZodLiteral<"model_changed">;

--- a/packages/protocol/dist/schemas/server/stream.js
+++ b/packages/protocol/dist/schemas/server/stream.js
@@ -185,6 +185,11 @@ export const ServerMessageSchema = z.object({
     // shape-compatible.
     stdout: z.string().max(8192).optional(),
     stderr: z.string().max(8192).optional(),
+    // #7454/#7458: present on REPLAYED frames only (both replay paths map the
+    // server-internal `_seq` onto the wire; absent on live broadcasts). The
+    // #5555.3 delta-replay cursor — and for user_question the #7420
+    // live-vs-replayed guard — key on this field's presence.
+    historySeq: z.number().optional(),
 });
 export const ServerToolStartSchema = z.object({
     type: z.literal('tool_start'),
@@ -193,6 +198,11 @@ export const ServerToolStartSchema = z.object({
     tool: z.string(),
     input: z.any(),
     serverName: z.string().optional(),
+    // #7454/#7458: present on REPLAYED frames only (both replay paths map the
+    // server-internal `_seq` onto the wire; absent on live broadcasts). The
+    // #5555.3 delta-replay cursor — and for user_question the #7420
+    // live-vs-replayed guard — key on this field's presence.
+    historySeq: z.number().optional(),
 });
 export const ServerToolResultSchema = z.object({
     type: z.literal('tool_result'),
@@ -205,6 +215,11 @@ export const ServerToolResultSchema = z.object({
     // missing value as false. Older servers and non-mcp tools omit it; codex
     // mcpToolCall emits it explicitly (`false` on success).
     isError: z.boolean().optional(),
+    // #7454/#7458: present on REPLAYED frames only (both replay paths map the
+    // server-internal `_seq` onto the wire; absent on live broadcasts). The
+    // #5555.3 delta-replay cursor — and for user_question the #7420
+    // live-vs-replayed guard — key on this field's presence.
+    historySeq: z.number().optional(),
 });
 // #4080 / #4081: incremental partial-JSON chunk for a streaming tool_use
 // `input`. Emitted between `tool_start` and `tool_result` while the
@@ -307,6 +322,11 @@ export const ServerResultSchema = z.object({
     // #6769: occupancy snapshot (see ServerContextOccupancySnapshotSchema).
     // Absent from older servers and from providers with no occupancy signal.
     contextOccupancy: ServerContextOccupancySnapshotSchema.nullable().optional(),
+    // #7454/#7458: present on REPLAYED frames only (both replay paths map the
+    // server-internal `_seq` onto the wire; absent on live broadcasts). The
+    // #5555.3 delta-replay cursor — and for user_question the #7420
+    // live-vs-replayed guard — key on this field's presence.
+    historySeq: z.number().optional(),
 });
 export const ServerModelChangedSchema = z.object({
     type: z.literal('model_changed'),

--- a/packages/protocol/dist/schemas/server/stream.js
+++ b/packages/protocol/dist/schemas/server/stream.js
@@ -608,6 +608,11 @@ export const ServerUserQuestionSchema = z.object({
     type: z.literal('user_question'),
     toolUseId: z.string(),
     questions: z.array(z.any()),
+    // #7454: present on REPLAYED frames only (both replay paths map the server's
+    // internal `_seq` onto the wire); absent on every live broadcast. The #7420
+    // live-vs-replayed discriminator keys on this field's PRESENCE — a
+    // strip-on-parse schema without it would silently disarm that guard.
+    historySeq: z.number().optional(),
 });
 export const ServerAgentBusySchema = z.object({
     type: z.literal('agent_busy'),

--- a/packages/protocol/src/schemas/server/stream.ts
+++ b/packages/protocol/src/schemas/server/stream.ts
@@ -653,6 +653,11 @@ export const ServerUserQuestionSchema = z.object({
   type: z.literal('user_question'),
   toolUseId: z.string(),
   questions: z.array(z.any()),
+  // #7454: present on REPLAYED frames only (both replay paths map the server's
+  // internal `_seq` onto the wire); absent on every live broadcast. The #7420
+  // live-vs-replayed discriminator keys on this field's PRESENCE — a
+  // strip-on-parse schema without it would silently disarm that guard.
+  historySeq: z.number().optional(),
 })
 
 export const ServerAgentBusySchema = z.object({

--- a/packages/protocol/src/schemas/server/stream.ts
+++ b/packages/protocol/src/schemas/server/stream.ts
@@ -198,6 +198,11 @@ export const ServerMessageSchema = z.object({
   // shape-compatible.
   stdout: z.string().max(8192).optional(),
   stderr: z.string().max(8192).optional(),
+  // #7454/#7458: present on REPLAYED frames only (both replay paths map the
+  // server-internal `_seq` onto the wire; absent on live broadcasts). The
+  // #5555.3 delta-replay cursor — and for user_question the #7420
+  // live-vs-replayed guard — key on this field's presence.
+  historySeq: z.number().optional(),
 })
 
 export const ServerToolStartSchema = z.object({
@@ -207,6 +212,11 @@ export const ServerToolStartSchema = z.object({
   tool: z.string(),
   input: z.any(),
   serverName: z.string().optional(),
+  // #7454/#7458: present on REPLAYED frames only (both replay paths map the
+  // server-internal `_seq` onto the wire; absent on live broadcasts). The
+  // #5555.3 delta-replay cursor — and for user_question the #7420
+  // live-vs-replayed guard — key on this field's presence.
+  historySeq: z.number().optional(),
 })
 
 export const ServerToolResultSchema = z.object({
@@ -220,6 +230,11 @@ export const ServerToolResultSchema = z.object({
   // missing value as false. Older servers and non-mcp tools omit it; codex
   // mcpToolCall emits it explicitly (`false` on success).
   isError: z.boolean().optional(),
+  // #7454/#7458: present on REPLAYED frames only (both replay paths map the
+  // server-internal `_seq` onto the wire; absent on live broadcasts). The
+  // #5555.3 delta-replay cursor — and for user_question the #7420
+  // live-vs-replayed guard — key on this field's presence.
+  historySeq: z.number().optional(),
 })
 
 // #4080 / #4081: incremental partial-JSON chunk for a streaming tool_use
@@ -325,6 +340,11 @@ export const ServerResultSchema = z.object({
   // #6769: occupancy snapshot (see ServerContextOccupancySnapshotSchema).
   // Absent from older servers and from providers with no occupancy signal.
   contextOccupancy: ServerContextOccupancySnapshotSchema.nullable().optional(),
+  // #7454/#7458: present on REPLAYED frames only (both replay paths map the
+  // server-internal `_seq` onto the wire; absent on live broadcasts). The
+  // #5555.3 delta-replay cursor — and for user_question the #7420
+  // live-vs-replayed guard — key on this field's presence.
+  historySeq: z.number().optional(),
 })
 
 export const ServerModelChangedSchema = z.object({

--- a/packages/server/src/handlers/conversation-handlers.js
+++ b/packages/server/src/handlers/conversation-handlers.js
@@ -267,7 +267,12 @@ async function handleRequestFullHistory(ws, client, msg, ctx) {
         sessionId: targetId,
       })
     } else {
-      ctx.transport.send(ws, { ...entry, sessionId: targetId })
+      // #7454: this is the SECOND replay path (replayHistory is the first), and
+      // the #7420 live-vs-replayed discriminator keys on `historySeq` PRESENCE
+      // — map the internal `_seq` onto the wire exactly as replayHistory does
+      // (ws-history.js), and never leak the raw counter.
+      const { _seq, ...wireEntry } = entry
+      ctx.transport.send(ws, { ...wireEntry, sessionId: targetId, ...(typeof _seq === 'number' ? { historySeq: _seq } : {}) })
     }
   }
   ctx.transport.send(ws, { type: 'history_replay_end', sessionId: targetId })

--- a/packages/server/tests/conversation-full-history-replay.test.js
+++ b/packages/server/tests/conversation-full-history-replay.test.js
@@ -1,0 +1,65 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { conversationHandlers } from '../src/handlers/conversation-handlers.js'
+import { createMockSessionManager, nsCtx } from './test-helpers.js'
+
+/**
+ * #7454 — `request_full_history` is the SECOND replay path (the first is
+ * ws-history.js's `replayHistory`), and the #7420 live-vs-replayed
+ * discriminator keys on `historySeq` PRESENCE. A ring-buffer `user_question`
+ * forwarded raw (no `_seq` → `historySeq` mapping) reads as a live racer on
+ * the client and is left unstamped at replay-end — and the raw `_seq` was
+ * leaking onto the wire besides.
+ */
+describe('#7454 — request_full_history maps _seq onto the wire like replayHistory does', () => {
+  const handler = conversationHandlers.request_full_history
+
+  function build(historyEntries) {
+    const sends = []
+    const { manager } = createMockSessionManager([{ id: 'sess-1', name: 'Work', cwd: '/repo' }])
+    manager.getFullHistoryAsync = async () => historyEntries
+    const ctx = nsCtx({
+      send: (ws, msg) => sends.push(msg),
+      sessionManager: manager,
+      reseedActiveAgents: () => {},
+    })
+    return { ctx, sends }
+  }
+
+  it('stamps historySeq on a ring-buffer user_question and never leaks the raw _seq', async () => {
+    const { ctx, sends } = build([
+      { type: 'user_question', toolUseId: 't1', questions: [], timestamp: 123, _seq: 7 },
+      { type: 'response', content: 'Hi', timestamp: 124 },
+    ])
+    await handler({}, { id: 'c1', activeSessionId: 'sess-1' }, { type: 'request_full_history' }, ctx)
+    const q = sends.find(m => m.type === 'user_question')
+    assert.ok(q, 'the user_question entry is forwarded')
+    assert.equal(q.historySeq, 7, 'the internal _seq must surface as historySeq — the #7420 discriminator keys on it')
+    assert.ok(!('_seq' in q), 'the internal counter must not leak onto the wire')
+  })
+
+  it('POSITIVE CONTROL: an entry with no _seq goes out with NO historySeq key', async () => {
+    // Absence is the live signal — manufacturing a historySeq here would be
+    // as wrong as omitting a real one.
+    const { ctx, sends } = build([
+      { type: 'user_question', toolUseId: 't2', questions: [], timestamp: 125 },
+    ])
+    await handler({}, { id: 'c1', activeSessionId: 'sess-1' }, { type: 'request_full_history' }, ctx)
+    const q = sends.find(m => m.type === 'user_question')
+    assert.ok(q)
+    assert.ok(!('historySeq' in q), 'no _seq means no historySeq — never null, never fabricated')
+  })
+
+  it('still brackets the forward with history_replay_start/end and rebuilds message-branch entries', async () => {
+    const { ctx, sends } = build([
+      { type: 'response', content: 'Hi', timestamp: 1, _seq: 3 },
+      { type: 'user_question', toolUseId: 't3', questions: [], timestamp: 2, _seq: 4 },
+    ])
+    await handler({}, { id: 'c1', activeSessionId: 'sess-1' }, { type: 'request_full_history' }, ctx)
+    assert.equal(sends[0].type, 'history_replay_start')
+    assert.equal(sends[sends.length - 1].type, 'history_replay_end')
+    const rebuilt = sends.find(m => m.type === 'message')
+    assert.equal(rebuilt.messageType, 'response')
+    assert.ok(!('_seq' in rebuilt), 'the message branch never carried _seq and must not start')
+  })
+})

--- a/packages/server/tests/conversation-full-history-replay.test.js
+++ b/packages/server/tests/conversation-full-history-replay.test.js
@@ -50,6 +50,22 @@ describe('#7454 — request_full_history maps _seq onto the wire like replayHist
     assert.ok(!('historySeq' in q), 'no _seq means no historySeq — never null, never fabricated')
   })
 
+  it('maps _seq for EVERY else-branch ring type, not just user_question', async () => {
+    // Review on #7458: narrowing the mapping to user_question survived every
+    // test. The clients read historySeq off `message` and `tool_start` too
+    // (the #5555.3 delta-replay cursor), so the breadth is load-bearing.
+    const { ctx, sends } = build([
+      { type: 'tool_start', tool: 'Bash', timestamp: 1, _seq: 11 },
+      { type: 'tool_result', tool: 'Bash', timestamp: 2, _seq: 12 },
+    ])
+    await handler({}, { id: 'c1', activeSessionId: 'sess-1' }, { type: 'request_full_history' }, ctx)
+    const ts = sends.find(m => m.type === 'tool_start')
+    const tr = sends.find(m => m.type === 'tool_result')
+    assert.equal(ts.historySeq, 11, 'tool_start must carry historySeq — the delta-replay cursor reads it')
+    assert.equal(tr.historySeq, 12)
+    assert.ok(!('_seq' in ts) && !('_seq' in tr), 'no raw counter on any else-branch type')
+  })
+
   it('still brackets the forward with history_replay_start/end and rebuilds message-branch entries', async () => {
     const { ctx, sends } = build([
       { type: 'response', content: 'Hi', timestamp: 1, _seq: 3 },
@@ -61,5 +77,6 @@ describe('#7454 — request_full_history maps _seq onto the wire like replayHist
     const rebuilt = sends.find(m => m.type === 'message')
     assert.equal(rebuilt.messageType, 'response')
     assert.ok(!('_seq' in rebuilt), 'the message branch never carried _seq and must not start')
+    assert.ok(!('historySeq' in rebuilt), 'nor may it grow a historySeq — the rebuild enumerates its fields')
   })
 })


### PR DESCRIPTION
Closes #7454 (found in review of PR #7453 / #7420).

`handleRequestFullHistory` brackets its own `history_replay_start`/`history_replay_end` but forwarded ring-buffer entries **raw** — no `_seq` → `historySeq` mapping. On current `main` this means the raw internal counter leaked and the #5555.3 delta-replay cursor (`recordHistorySeq`) never advanced on this path; once PR #7453 lands, it would additionally have made every replayed `user_question` read as a **live racer** to #7420's discriminator (which keys on `historySeq` presence) on every provider whose `getFullHistoryAsync` falls back to the ring buffer — this PR pre-arms that guard so the pair is safe in either merge order (review S3 corrected my original present-tense phrasing). The raw internal `_seq` counter also leaked onto the wire on that branch.

## What changed

- The else-branch now maps `_seq` → `historySeq` **exactly as `replayHistory` does** (destructure off, attach when numeric) and never sends the raw counter.
- `ServerUserQuestionSchema` gains the optional `historySeq` field with a comment naming the guard it protects — a future strip-on-parse consumer can no longer silently disarm #7420 with all tests green (the review's schema-hardening ask). Protocol dist rebuilt and committed.

## Verification

- Red-first: the new test file's main assertion failed against unmodified source (`historySeq` undefined, `_seq` leaking).
- Mutation: reverting the mapping to the raw spread fails exactly the paired test; restored, 3/3.
- Positive control: an entry with **no** `_seq` goes out with **no** `historySeq` key — absence is the live signal and must never be fabricated.
- 340/340 across the new file + `ws-history.test.js` + `ws-schemas.test.js`; all server lints pass.

## Not in scope

#7455 (replay-window refcount), #7456 (ledger lifetime), #7457 (non-racing reconnect half) — tracked separately from the same review.
