### PR TITLE
test(ci): floor the node --test suites so a zero-test run cannot pass (#7447)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1215,6 +1215,14 @@ jobs:
         # (scripts/lib, packages/server/src/utils, sidecar/agent.js) — #7222.
         run: node scripts/__tests__/is-entry-point.test.mjs
 
+      - name: Run assert-test-count.mjs tests
+        # #7447 — `node --test` exits 0 on zero discovered tests, so a suite
+        # that stops being discovered and a passing suite are the same
+        # observable outcome. This pins the shared floor wrapper (hoisted from
+        # packages/server) that server, design-tokens and claude-hooks all
+        # front their test commands with — including its fail-closed --min.
+        run: node scripts/__tests__/assert-test-count.test.mjs
+
       - name: Run no-test-force-exit.mjs tests
         # #7400 — `--test-force-exit` made the runner report 154-192 of
         # base-session.test.js's 192 tests, exit 0, and print `# fail 0`. Both

--- a/packages/claude-hooks/package.json
+++ b/packages/claude-hooks/package.json
@@ -7,7 +7,7 @@
     "chroxy-hooks": "bin/chroxy-hooks.js"
   },
   "scripts": {
-    "test": "node --import ./tests/_setup.mjs --test './tests/**/*.test.js'"
+    "test": "node ../../scripts/lib/assert-test-count.mjs --min 150 node --import ./tests/_setup.mjs --test './tests/**/*.test.js'"
   },
   "engines": {
     "node": ">=22"

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -16,7 +16,7 @@
     "index.d.ts"
   ],
   "scripts": {
-    "test": "node --import ../../scripts/lib/no-test-force-exit-hook.mjs --test"
+    "test": "node ../../scripts/lib/assert-test-count.mjs --min 5 node --import ../../scripts/lib/no-test-force-exit-hook.mjs --test"
   },
   "license": "MIT"
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "start": "node src/cli.js start",
     "dev": "node --watch src/cli.js start",
-    "test": "node ./scripts/assert-test-count.mjs c8 node --import ./tests/_setup.mjs --experimental-test-module-mocks --test './tests/**/*.test.js'",
+    "test": "node ../../scripts/lib/assert-test-count.mjs c8 node --import ./tests/_setup.mjs --experimental-test-module-mocks --test './tests/**/*.test.js'",
     "test:raw": "c8 node --import ./tests/_setup.mjs --experimental-test-module-mocks --test './tests/**/*.test.js'",
     "test:coverage": "c8 --reporter=text --reporter=html node --import ./tests/_setup.mjs --experimental-test-module-mocks --test './tests/**/*.test.js'",
     "test:integration": "node --import ./tests/_setup.mjs --test ./tests/*.integration.test.js",

--- a/scripts/__tests__/assert-test-count.test.mjs
+++ b/scripts/__tests__/assert-test-count.test.mjs
@@ -25,9 +25,13 @@ let pass = 0
 let fail = 0
 const failures = []
 
+// Ambient-env insulation: OMIT the key rather than passing undefined. Node
+// does drop undefined env values on every supported version, but an explicit
+// omission cannot be re-litigated (review thread on #7461) and cannot regress.
+const { CHROXY_MIN_TEST_COUNT: _ambient, ...insulatedEnv } = process.env
 const run = (args, env = {}) => new Promise((done) => {
   execFile(process.execPath, [script, ...args], {
-    env: { ...process.env, CHROXY_MIN_TEST_COUNT: undefined, ...env },
+    env: { ...insulatedEnv, ...env },
   }, (err) => done(err ? err.code ?? 1 : 0))
 })
 

--- a/scripts/__tests__/assert-test-count.test.mjs
+++ b/scripts/__tests__/assert-test-count.test.mjs
@@ -66,6 +66,13 @@ await test('an invalid --min is fail-closed: exit 2, never a disabled floor', as
 await test('a VALID env override outranks --min (the targeted-run escape hatch)', async () => {
   eq(await run(['--min', '100', ...tap(5, 0)], { CHROXY_MIN_TEST_COUNT: '3' }), 0, 'exit')
 })
+await test('a valid env override EQUAL to the server default still outranks --min', async () => {
+  // The distinguishing input for validity-tracking (#7461 review, C1): the
+  // naive value-comparison (EXPECTED === DEFAULT) reads env=13500 as "no
+  // override" and lets --min 1 win, exiting 0 here. Validity tracking keeps
+  // the env floor, so 5 < 13500 exits 1.
+  eq(await run(['--min', '1', ...tap(5, 0)], { CHROXY_MIN_TEST_COUNT: '13500' }), 1, 'exit')
+})
 await test('an INVALID env override falls back to --min, not to the server default', async () => {
   // 5 >= 3 passes ONLY if the fallback floor is --min's 3; the server default
   // (13500) would fail it — so exit 0 pins the fallback target.

--- a/scripts/__tests__/assert-test-count.test.mjs
+++ b/scripts/__tests__/assert-test-count.test.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+/**
+ * assert-test-count.test.mjs — harness for scripts/lib/assert-test-count.mjs
+ * (#7447: hoisted from packages/server and shared by server, design-tokens and
+ * claude-hooks).
+ *
+ * No external test framework, matching its siblings. Each case spawns the real
+ * script around a `node -e` child that emits a synthetic TAP summary, and
+ * asserts on the EXIT CODE — the one observable the guard exists to produce.
+ * A guard proven only by its output string would pass with the exit wiring
+ * broken, which is the false-safety shape docs/false-safety-guards.md tracks.
+ *
+ * Run from repo root:
+ *   node scripts/__tests__/assert-test-count.test.mjs
+ */
+
+import { execFile } from 'node:child_process'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const script = resolve(__dirname, '..', 'lib', 'assert-test-count.mjs')
+
+let pass = 0
+let fail = 0
+const failures = []
+
+const run = (args, env = {}) => new Promise((done) => {
+  execFile(process.execPath, [script, ...args], {
+    env: { ...process.env, CHROXY_MIN_TEST_COUNT: undefined, ...env },
+  }, (err) => done(err ? err.code ?? 1 : 0))
+})
+
+/** A child that prints the given TAP summary lines and exits 0. */
+const tap = (tests, failed) =>
+  [process.execPath, '-e', `console.log('# tests ${tests}'); console.log('# fail ${failed}')`]
+
+const test = async (name, fn) => {
+  try {
+    await fn()
+    pass += 1
+    console.log(`ok - ${name}`)
+  } catch (e) {
+    fail += 1
+    failures.push(`${name}: ${e.message}`)
+    console.log(`not ok - ${name}`)
+  }
+}
+const eq = (a, b, msg) => { if (a !== b) throw new Error(`${msg}: got ${a}, want ${b}`) }
+
+await test('zero discovered tests fails the floor (#7447: the zero-test green)', async () => {
+  eq(await run(['--min', '5', ...tap(0, 0)]), 1, 'exit')
+})
+await test('an at-floor run passes', async () => {
+  eq(await run(['--min', '5', ...tap(5, 0)]), 0, 'exit')
+})
+await test('real test failures fail even above the floor', async () => {
+  eq(await run(['--min', '2', ...tap(10, 2)]), 1, 'exit')
+})
+await test('a missing TAP summary fails (runner died before reporting)', async () => {
+  eq(await run(['--min', '2', process.execPath, '-e', "console.log('no summary here')"]), 1, 'exit')
+})
+await test('an invalid --min is fail-closed: exit 2, never a disabled floor', async () => {
+  eq(await run(['--min', 'abc', ...tap(9999, 0)]), 2, 'exit')
+})
+await test('a VALID env override outranks --min (the targeted-run escape hatch)', async () => {
+  eq(await run(['--min', '100', ...tap(5, 0)], { CHROXY_MIN_TEST_COUNT: '3' }), 0, 'exit')
+})
+await test('an INVALID env override falls back to --min, not to the server default', async () => {
+  // 5 >= 3 passes ONLY if the fallback floor is --min's 3; the server default
+  // (13500) would fail it — so exit 0 pins the fallback target.
+  eq(await run(['--min', '3', ...tap(5, 0)], { CHROXY_MIN_TEST_COUNT: 'abc' }), 0, 'exit')
+})
+await test('no command at all is a usage error', async () => {
+  eq(await run(['--min', '5']), 2, 'exit')
+})
+
+console.log(`\n${pass} passed, ${fail} failed`)
+if (fail > 0) {
+  for (const f of failures) console.error(`  FAIL ${f}`)
+  process.exit(1)
+}

--- a/scripts/lib/assert-test-count.mjs
+++ b/scripts/lib/assert-test-count.mjs
@@ -36,7 +36,8 @@
  *          below the documented floor — a glob that stopped matching, a file
  *          that failed to load, a bad merge that deleted a directory).
  *
- * EXPECTED_MIN_TESTS is a *lower bound*, not the exact count. The floor sits
+ * The floor (--min for the non-server consumers, EXPECTED_MIN_TESTS below for
+ * the server) is a *lower bound*, not the exact count. The floor sits
  * below the live count with headroom so it does not break every time a test is
  * added, but high enough that a meaningful loss trips it. When the suite grows
  * well past the floor, bump the floor (the script prints the live count + a
@@ -74,7 +75,9 @@ if (process.env.CHROXY_MIN_TEST_COUNT !== undefined) {
 }
 
 // How far above the floor the live count must climb before we suggest bumping
-// the floor. Purely advisory — never fails the run.
+// the floor. Purely advisory — never fails the run. Calibrated to the server
+// default; for small --min floors it effectively never fires, which is fine —
+// a 6-test package does not need drift nudges (#7461 review, N1).
 const HEADROOM_NUDGE = 600
 
 // #7447: consumers other than the server pass their own (much smaller) floor
@@ -169,7 +172,8 @@ child.on('close', (code, signal) => {
       '  running or reporting: a glob that no longer matches, a file that threw while\n' +
       '  loading, a deleted directory. Look for a file the TAP output never mentions —\n' +
       '  the count is the only symptom, because the run still exited 0. If you\n' +
-      '  intentionally removed tests below the floor, lower EXPECTED_MIN_TESTS in this script.',
+      '  intentionally removed tests below the floor, lower it: the --min N in your\n' +
+      '  package.json test script, or (server) EXPECTED_MIN_TESTS in this script.',
     )
     return fail()
   }
@@ -178,7 +182,8 @@ child.on('close', (code, signal) => {
   if (total - EXPECTED_MIN_TESTS > HEADROOM_NUDGE) {
     console.error(
       `\n[assert-test-count] OK: ${total} tests ran (floor ${EXPECTED_MIN_TESTS}). ` +
-      `Consider raising EXPECTED_MIN_TESTS — the suite is now ${total - EXPECTED_MIN_TESTS} above the floor.`,
+      `Consider raising the floor (--min in the caller's package.json, or the server's ` +
+      `EXPECTED_MIN_TESTS here) — the suite is now ${total - EXPECTED_MIN_TESTS} above it.`,
     )
   } else {
     console.error(`\n[assert-test-count] OK: ${total} tests ran (floor ${EXPECTED_MIN_TESTS}).`)

--- a/scripts/lib/assert-test-count.mjs
+++ b/scripts/lib/assert-test-count.mjs
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 /**
- * Truncation guard for the server suite (#5480, corrected in #7400).
+ * Truncation guard for the `node --test` suites (#5480, corrected in #7400;
+ * hoisted from packages/server/scripts and shared in #7447 — server,
+ * design-tokens and claude-hooks all front their test commands with it).
  *
  * A test run that dies, aborts, or silently drops whole files still prints a
  * clean-looking TAP summary and exits 0. "Ran and passed" and "never ran" are
@@ -57,10 +59,12 @@ const DEFAULT_MIN_TESTS = 13500
 // false, which would quietly turn the guard off — so fall back to the default and
 // warn loudly instead.
 let EXPECTED_MIN_TESTS = DEFAULT_MIN_TESTS
+let envOverrideValid = false
 if (process.env.CHROXY_MIN_TEST_COUNT !== undefined) {
   const parsed = Number(process.env.CHROXY_MIN_TEST_COUNT)
   if (Number.isInteger(parsed) && parsed > 0) {
     EXPECTED_MIN_TESTS = parsed
+    envOverrideValid = true
   } else {
     console.error(
       `[assert-test-count] ignoring invalid CHROXY_MIN_TEST_COUNT='${process.env.CHROXY_MIN_TEST_COUNT}' ` +
@@ -73,11 +77,32 @@ if (process.env.CHROXY_MIN_TEST_COUNT !== undefined) {
 // the floor. Purely advisory — never fails the run.
 const HEADROOM_NUDGE = 600
 
-const cmd = process.argv[2]
-const args = process.argv.slice(3)
+// #7447: consumers other than the server pass their own (much smaller) floor
+// as `--min N`. Precedence: a valid CHROXY_MIN_TEST_COUNT env override (the
+// documented targeted-run escape hatch) > --min (the package's floor) > the
+// server default above. An INVALID --min is fail-closed (exit 2, never a
+// silently-disabled floor) — unlike the env var, it is committed configuration,
+// not a one-off override, so a typo must break the build loudly.
+let argIdx = 2
+if (process.argv[argIdx] === '--min') {
+  const parsed = Number(process.argv[argIdx + 1])
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    console.error(`[assert-test-count] invalid --min '${process.argv[argIdx + 1]}' (must be a positive integer).`)
+    process.exit(2)
+  }
+  // Only a VALID env override outranks --min (validity tracked explicitly —
+  // comparing values would let --min beat a valid override that happens to
+  // equal the default). An invalid override already warned, and must fall
+  // back to the package's floor, not to 13500.
+  if (!envOverrideValid) EXPECTED_MIN_TESTS = parsed
+  argIdx += 2
+}
+
+const cmd = process.argv[argIdx]
+const args = process.argv.slice(argIdx + 1)
 
 if (!cmd) {
-  console.error('[assert-test-count] usage: assert-test-count.mjs <cmd> [...args]')
+  console.error('[assert-test-count] usage: assert-test-count.mjs [--min N] <cmd> [...args]')
   process.exit(2)
 }
 


### PR DESCRIPTION
Closes #7447 (found in review of #7444).

`node --test` exits 0 when it discovers zero test files, so `packages/design-tokens` (bare `--test`, cwd discovery) and `packages/claude-hooks` (quoted glob, non-matching = empty = green) could both pass CI with nothing run — the defect class `docs/false-safety-guards.md` exists for, one level below the job-existence gap #7444 closed.

## What changed

- **`assert-test-count.mjs` hoisted** from `packages/server/scripts/` to `scripts/lib/` — the established shared-guard home (`no-test-force-exit-hook.mjs`, `test-fs-sandbox.mjs` already live there). One implementation, three consumers; `git mv`, 83% similarity.
- **New `--min N` flag** for per-package floors: design-tokens `--min 5` (6 live tests), claude-hooks `--min 150` (188 live). The server keeps its built-in 13500 default — its invocation changes only in path. Precedence: a **valid** `CHROXY_MIN_TEST_COUNT` (the documented targeted-run escape hatch) > `--min` > default, tracked by **validity, not value** (a valid override equal to the default cannot be beaten by `--min`). An invalid `--min` exits 2: committed configuration fails loudly, never a silently disabled floor.
- **`scripts/__tests__/assert-test-count.test.mjs`** pins the exit codes — 8 cases: zero-test red, at-floor green, failures red, missing-summary red, fail-closed `--min`, both precedence directions, usage error. Wired into the Scripts Tests job (its step list is hand-named — added properly; the roster gap itself is #7252).

## Acceptance criteria → evidence

- [x] design-tokens exits non-zero on zero discovered tests — scratch copy, `test/` deleted → **exit 1**; file moved out of discovery (`src/tokens.spec.js`) → **exit 1**, `only 0 tests ran, below the floor of 5`.
- [x] claude-hooks exits non-zero on an empty glob — scratch copy, tests deleted → **exit 1**, floor 150.
- [x] Proven red before claimed: both scratch red-proofs ran through the real `npm test` scripts, with positive controls (6/floor-5 OK, 188/floor-150 OK) and a server-shape check from `packages/server` (c8 + env override; a 36-test file fails floor 40, passes floor 30).
- [x] No second implementation — the module moved, nothing copied. (`run-windows-tests.mjs`'s deliberate TAP-parse mirror predates this and is documented in its header; unchanged.)

## Interactions

- Composes with unmerged #7444: its Design Tokens Tests CI job will run the now-wrapped `npm test`. Different `ci.yml` hunks — no conflict with the queued merge train.
- `Server Windows Tests` spawns node directly (never through this wrapper) — unaffected.