### PR TITLE
test(app): extract a typed shared createMockMessageHandlerContext factory

### DIFF
--- a/packages/app/__tests__/PushTokenError.test.ts
+++ b/packages/app/__tests__/PushTokenError.test.ts
@@ -1,5 +1,5 @@
 import { _testMessageHandler, setStore } from '../src/store/message-handler';
-import { createMockMessageHandlerContext } from '../src/test-utils/mock-message-handler-context';
+import { createMockConnectionContext } from '../src/test-utils/mock-connection-context';
 import { createEmptySessionState } from '../src/store/utils';
 import type { ConnectionState } from '../src/store/types';
 
@@ -53,7 +53,7 @@ describe('push_token_error handler (#1987)', () => {
       sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'push_token_error',
@@ -73,7 +73,7 @@ describe('push_token_error handler (#1987)', () => {
       sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'push_token_error',

--- a/packages/app/__tests__/PushTokenError.test.ts
+++ b/packages/app/__tests__/PushTokenError.test.ts
@@ -1,4 +1,5 @@
 import { _testMessageHandler, setStore } from '../src/store/message-handler';
+import { createMockMessageHandlerContext } from '../src/test-utils/mock-message-handler-context';
 import { createEmptySessionState } from '../src/store/utils';
 import type { ConnectionState } from '../src/store/types';
 
@@ -30,16 +31,6 @@ function createMockStore(initialState: Partial<ConnectionState>) {
   };
 }
 
-function createMockContext() {
-  return {
-    url: 'wss://test',
-    token: 'test-token',
-    isReconnect: false,
-    silent: false,
-    socket: { send: jest.fn(), close: jest.fn() } as unknown as WebSocket,
-  };
-}
-
 describe('push_token_error handler (#1987)', () => {
   let warnSpy: jest.SpyInstance;
 
@@ -62,7 +53,7 @@ describe('push_token_error handler (#1987)', () => {
       sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'push_token_error',
@@ -82,7 +73,7 @@ describe('push_token_error handler (#1987)', () => {
       sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'push_token_error',

--- a/packages/app/src/__tests__/store/agent-event-handler.test.ts
+++ b/packages/app/src/__tests__/store/agent-event-handler.test.ts
@@ -12,6 +12,7 @@ import {
   _testMessageHandler,
   setStore,
 } from '../../store/message-handler';
+import { createMockMessageHandlerContext } from '../../test-utils/mock-message-handler-context';
 import { createEmptySessionState } from '../../store/utils';
 import type { ConnectionState } from '../../store/types';
 import type { ChatMessage } from '../../store/connection';
@@ -46,18 +47,6 @@ function createMockStore(initialState: Partial<ConnectionState>) {
   };
 }
 
-function createMockContext() {
-  return {
-    socket: { readyState: 1, send: jest.fn() } as any,
-    serverUrl: 'wss://test.example.com',
-    apiToken: 'test-token',
-    connectionId: 'test-conn-1',
-    reconnecting: false,
-    connectedAt: Date.now(),
-    activeSessionIdAtConnect: null,
-  };
-}
-
 function taskBubble(toolUseId: string): ChatMessage {
   return {
     id: `m-${toolUseId}`,
@@ -84,7 +73,7 @@ describe('agent_event handler (#5060)', () => {
   it('appends a child wire event to the parent Task bubble childAgentEvents[]', () => {
     const store = storeWithTask('parent-1');
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'agent_event',
@@ -104,7 +93,7 @@ describe('agent_event handler (#5060)', () => {
   it('accumulates multiple events in arrival order', () => {
     const store = storeWithTask('parent-2');
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'agent_event',
@@ -134,7 +123,7 @@ describe('agent_event handler (#5060)', () => {
   it('same-reference no-op when parentToolUseId matches no bubble', () => {
     const store = storeWithTask('parent-3');
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
     const before = store.getState().sessionStates.s1.messages;
 
     _testMessageHandler.handle({

--- a/packages/app/src/__tests__/store/agent-event-handler.test.ts
+++ b/packages/app/src/__tests__/store/agent-event-handler.test.ts
@@ -12,7 +12,7 @@ import {
   _testMessageHandler,
   setStore,
 } from '../../store/message-handler';
-import { createMockMessageHandlerContext } from '../../test-utils/mock-message-handler-context';
+import { createMockConnectionContext } from '../../test-utils/mock-connection-context';
 import { createEmptySessionState } from '../../store/utils';
 import type { ConnectionState } from '../../store/types';
 import type { ChatMessage } from '../../store/connection';
@@ -73,7 +73,7 @@ describe('agent_event handler (#5060)', () => {
   it('appends a child wire event to the parent Task bubble childAgentEvents[]', () => {
     const store = storeWithTask('parent-1');
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'agent_event',
@@ -93,7 +93,7 @@ describe('agent_event handler (#5060)', () => {
   it('accumulates multiple events in arrival order', () => {
     const store = storeWithTask('parent-2');
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'agent_event',
@@ -123,7 +123,7 @@ describe('agent_event handler (#5060)', () => {
   it('same-reference no-op when parentToolUseId matches no bubble', () => {
     const store = storeWithTask('parent-3');
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
     const before = store.getState().sessionStates.s1.messages;
 
     _testMessageHandler.handle({

--- a/packages/app/src/__tests__/store/connection.test.ts
+++ b/packages/app/src/__tests__/store/connection.test.ts
@@ -20,6 +20,7 @@ import {
   getEncryptionState,
   setEncryptionState,
 } from '../../store/message-handler';
+import { createMockMessageHandlerContext } from '../../test-utils/mock-message-handler-context';
 import { createKeyPair } from '@chroxy/store-core';
 
 // Reset store between tests
@@ -821,10 +822,7 @@ describe('connectionError and connectionRetryCount state', () => {
 
   it('auth_ok clears both fields', () => {
     const mockSocket = { readyState: 1, send: jest.fn(), close: jest.fn() } as unknown as WebSocket;
-    _testMessageHandler.setContext({
-      url: 'wss://test', token: 'tok', isReconnect: false,
-      silent: false, socket: mockSocket,
-    });
+    _testMessageHandler.setContext(createMockMessageHandlerContext({ socket: mockSocket }));
     useConnectionLifecycleStore.setState({ connectionError: 'Network error', connectionRetryCount: 2 });
     _testMessageHandler.handle({ type: 'auth_ok', serverMode: 'cli' });
     const state = useConnectionLifecycleStore.getState();
@@ -859,10 +857,7 @@ describe('multi-client message handling', () => {
   const mockSocket = { readyState: 1, send: jest.fn(), close: jest.fn() } as unknown as WebSocket;
 
   beforeEach(() => {
-    _testMessageHandler.setContext({
-      url: 'wss://test', token: 'tok', isReconnect: false,
-      silent: false, socket: mockSocket,
-    });
+    _testMessageHandler.setContext(createMockMessageHandlerContext({ socket: mockSocket }));
   });
   afterEach(() => _testMessageHandler.clearContext());
 
@@ -997,10 +992,7 @@ describe('WS message handler (direct)', () => {
   beforeEach(() => {
     (mockSocket.send as jest.Mock).mockClear();
     (mockSocket.close as jest.Mock).mockClear();
-    _testMessageHandler.setContext({
-      url: 'wss://test', token: 'tok', isReconnect: false,
-      silent: false, socket: mockSocket,
-    });
+    _testMessageHandler.setContext(createMockMessageHandlerContext({ socket: mockSocket }));
   });
   afterEach(() => _testMessageHandler.clearContext());
 
@@ -1323,10 +1315,7 @@ describe('WS message handler (direct)', () => {
 
       useConnectionStore.getState().disconnect();
 
-      _testMessageHandler.setContext({
-        url: 'wss://test', token: 'tok', isReconnect: false,
-        silent: false, socket: mockSocket,
-      });
+      _testMessageHandler.setContext(createMockMessageHandlerContext({ socket: mockSocket }));
 
       _testMessageHandler.handle({
         type: 'directory_listing',
@@ -1610,10 +1599,7 @@ describe('permission boundary splitting', () => {
     useConnectionLifecycleStore.setState({ connectionPhase: 'disconnected' });
     (mockSocket.send as jest.Mock).mockClear();
     (mockSocket.close as jest.Mock).mockClear();
-    _testMessageHandler.setContext({
-      url: 'wss://test', token: 'tok', isReconnect: false,
-      silent: false, socket: mockSocket,
-    });
+    _testMessageHandler.setContext(createMockMessageHandlerContext({ socket: mockSocket }));
   });
 
   afterEach(() => {
@@ -1794,10 +1780,7 @@ describe('permission_request dedup on reconnect', () => {
     useConnectionLifecycleStore.setState({ connectionPhase: 'disconnected' });
     (mockSocket.send as jest.Mock).mockClear();
     (mockSocket.close as jest.Mock).mockClear();
-    _testMessageHandler.setContext({
-      url: 'wss://test', token: 'tok', isReconnect: false,
-      silent: false, socket: mockSocket,
-    });
+    _testMessageHandler.setContext(createMockMessageHandlerContext({ socket: mockSocket }));
   });
 
   afterEach(() => {

--- a/packages/app/src/__tests__/store/connection.test.ts
+++ b/packages/app/src/__tests__/store/connection.test.ts
@@ -20,7 +20,7 @@ import {
   getEncryptionState,
   setEncryptionState,
 } from '../../store/message-handler';
-import { createMockMessageHandlerContext } from '../../test-utils/mock-message-handler-context';
+import { createMockConnectionContext } from '../../test-utils/mock-connection-context';
 import { createKeyPair } from '@chroxy/store-core';
 
 // Reset store between tests
@@ -822,7 +822,7 @@ describe('connectionError and connectionRetryCount state', () => {
 
   it('auth_ok clears both fields', () => {
     const mockSocket = { readyState: 1, send: jest.fn(), close: jest.fn() } as unknown as WebSocket;
-    _testMessageHandler.setContext(createMockMessageHandlerContext({ socket: mockSocket }));
+    _testMessageHandler.setContext(createMockConnectionContext({ socket: mockSocket }));
     useConnectionLifecycleStore.setState({ connectionError: 'Network error', connectionRetryCount: 2 });
     _testMessageHandler.handle({ type: 'auth_ok', serverMode: 'cli' });
     const state = useConnectionLifecycleStore.getState();
@@ -857,7 +857,7 @@ describe('multi-client message handling', () => {
   const mockSocket = { readyState: 1, send: jest.fn(), close: jest.fn() } as unknown as WebSocket;
 
   beforeEach(() => {
-    _testMessageHandler.setContext(createMockMessageHandlerContext({ socket: mockSocket }));
+    _testMessageHandler.setContext(createMockConnectionContext({ socket: mockSocket }));
   });
   afterEach(() => _testMessageHandler.clearContext());
 
@@ -992,7 +992,7 @@ describe('WS message handler (direct)', () => {
   beforeEach(() => {
     (mockSocket.send as jest.Mock).mockClear();
     (mockSocket.close as jest.Mock).mockClear();
-    _testMessageHandler.setContext(createMockMessageHandlerContext({ socket: mockSocket }));
+    _testMessageHandler.setContext(createMockConnectionContext({ socket: mockSocket }));
   });
   afterEach(() => _testMessageHandler.clearContext());
 
@@ -1315,7 +1315,7 @@ describe('WS message handler (direct)', () => {
 
       useConnectionStore.getState().disconnect();
 
-      _testMessageHandler.setContext(createMockMessageHandlerContext({ socket: mockSocket }));
+      _testMessageHandler.setContext(createMockConnectionContext({ socket: mockSocket }));
 
       _testMessageHandler.handle({
         type: 'directory_listing',
@@ -1599,7 +1599,7 @@ describe('permission boundary splitting', () => {
     useConnectionLifecycleStore.setState({ connectionPhase: 'disconnected' });
     (mockSocket.send as jest.Mock).mockClear();
     (mockSocket.close as jest.Mock).mockClear();
-    _testMessageHandler.setContext(createMockMessageHandlerContext({ socket: mockSocket }));
+    _testMessageHandler.setContext(createMockConnectionContext({ socket: mockSocket }));
   });
 
   afterEach(() => {
@@ -1780,7 +1780,7 @@ describe('permission_request dedup on reconnect', () => {
     useConnectionLifecycleStore.setState({ connectionPhase: 'disconnected' });
     (mockSocket.send as jest.Mock).mockClear();
     (mockSocket.close as jest.Mock).mockClear();
-    _testMessageHandler.setContext(createMockMessageHandlerContext({ socket: mockSocket }));
+    _testMessageHandler.setContext(createMockConnectionContext({ socket: mockSocket }));
   });
 
   afterEach(() => {

--- a/packages/app/src/__tests__/store/message-handler-activity.test.ts
+++ b/packages/app/src/__tests__/store/message-handler-activity.test.ts
@@ -19,7 +19,7 @@ import {
   _testResetStore,
   setStore,
 } from '../../store/message-handler';
-import { createMockMessageHandlerContext } from '../../test-utils/mock-message-handler-context';
+import { createMockConnectionContext } from '../../test-utils/mock-connection-context';
 import { createEmptyActivityState } from '@chroxy/store-core';
 import type { ActivityEntry, ActivityState } from '@chroxy/store-core';
 import type { ConnectionState } from '../../store/types';
@@ -98,7 +98,7 @@ describe('activity feeder (#6246)', () => {
   it('activity_snapshot populates state.activity for a session', () => {
     const { store, current } = createMockStore(createEmptyActivityState());
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'activity_snapshot',
@@ -116,7 +116,7 @@ describe('activity feeder (#6246)', () => {
   it('activity_snapshot REPLACES the prior tree for that session', () => {
     const { store, current } = createMockStore(createEmptyActivityState());
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'activity_snapshot',
@@ -139,7 +139,7 @@ describe('activity feeder (#6246)', () => {
   it('activity_delta upserts an entry into its session', () => {
     const { store, current } = createMockStore(createEmptyActivityState());
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'activity_delta',
@@ -170,7 +170,7 @@ describe('activity feeder (#6246)', () => {
     const seeded = createEmptyActivityState();
     const { store, current } = createMockStore(seeded);
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     expect(() =>
       _testMessageHandler.handle({
@@ -190,7 +190,7 @@ describe('activity feeder (#6246)', () => {
     const seeded = createEmptyActivityState();
     const { store, current } = createMockStore(seeded);
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     expect(() =>
       _testMessageHandler.handle({
@@ -214,7 +214,7 @@ describe('activity feeder (#6246)', () => {
       s2: { lastClientActivityAt: 1000, inactivityWarning: { remainingMs: 5000 } },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'activity_delta',
@@ -232,7 +232,7 @@ describe('activity feeder (#6246)', () => {
   it('activity_delta does NOT bump a session absent from sessionStates (no throw)', () => {
     const { store, current } = createMockStore(createEmptyActivityState()); // empty sessionStates
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     expect(() =>
       _testMessageHandler.handle({
@@ -257,7 +257,7 @@ describe('activity feeder (#6246)', () => {
       s2: { messages: [], lastClientActivityAt: 1000, inactivityWarning: { remainingMs: 5000 } },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     // Put s2 into _ctx.replayingSessions via the real replay-start path.
     _testMessageHandler.handle({ type: 'history_replay_start', sessionId: 's2' });
@@ -284,7 +284,7 @@ describe('activity feeder (#6246)', () => {
       s2: { lastClientActivityAt: 1000, inactivityWarning: { remainingMs: 5000 } },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'activity_snapshot',

--- a/packages/app/src/__tests__/store/message-handler-activity.test.ts
+++ b/packages/app/src/__tests__/store/message-handler-activity.test.ts
@@ -19,6 +19,7 @@ import {
   _testResetStore,
   setStore,
 } from '../../store/message-handler';
+import { createMockMessageHandlerContext } from '../../test-utils/mock-message-handler-context';
 import { createEmptyActivityState } from '@chroxy/store-core';
 import type { ActivityEntry, ActivityState } from '@chroxy/store-core';
 import type { ConnectionState } from '../../store/types';
@@ -79,19 +80,6 @@ function createMockStore(
   };
 }
 
-function createMockContext() {
-  return {
-    socket: { readyState: 1, send: jest.fn() } as any,
-    serverUrl: 'wss://test.example.com',
-    apiToken: 'test-token',
-    connectionId: 'test-conn-1',
-    reconnecting: false,
-    connectedAt: Date.now(),
-    activeSessionIdAtConnect: null,
-    replayingSessions: new Set<string>(),
-  };
-}
-
 beforeEach(() => {
   jest.clearAllMocks();
 });
@@ -110,7 +98,7 @@ describe('activity feeder (#6246)', () => {
   it('activity_snapshot populates state.activity for a session', () => {
     const { store, current } = createMockStore(createEmptyActivityState());
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'activity_snapshot',
@@ -128,7 +116,7 @@ describe('activity feeder (#6246)', () => {
   it('activity_snapshot REPLACES the prior tree for that session', () => {
     const { store, current } = createMockStore(createEmptyActivityState());
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'activity_snapshot',
@@ -151,7 +139,7 @@ describe('activity feeder (#6246)', () => {
   it('activity_delta upserts an entry into its session', () => {
     const { store, current } = createMockStore(createEmptyActivityState());
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'activity_delta',
@@ -182,7 +170,7 @@ describe('activity feeder (#6246)', () => {
     const seeded = createEmptyActivityState();
     const { store, current } = createMockStore(seeded);
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     expect(() =>
       _testMessageHandler.handle({
@@ -202,7 +190,7 @@ describe('activity feeder (#6246)', () => {
     const seeded = createEmptyActivityState();
     const { store, current } = createMockStore(seeded);
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     expect(() =>
       _testMessageHandler.handle({
@@ -226,7 +214,7 @@ describe('activity feeder (#6246)', () => {
       s2: { lastClientActivityAt: 1000, inactivityWarning: { remainingMs: 5000 } },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'activity_delta',
@@ -244,7 +232,7 @@ describe('activity feeder (#6246)', () => {
   it('activity_delta does NOT bump a session absent from sessionStates (no throw)', () => {
     const { store, current } = createMockStore(createEmptyActivityState()); // empty sessionStates
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     expect(() =>
       _testMessageHandler.handle({
@@ -269,7 +257,7 @@ describe('activity feeder (#6246)', () => {
       s2: { messages: [], lastClientActivityAt: 1000, inactivityWarning: { remainingMs: 5000 } },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     // Put s2 into _ctx.replayingSessions via the real replay-start path.
     _testMessageHandler.handle({ type: 'history_replay_start', sessionId: 's2' });
@@ -296,7 +284,7 @@ describe('activity feeder (#6246)', () => {
       s2: { lastClientActivityAt: 1000, inactivityWarning: { remainingMs: 5000 } },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'activity_snapshot',

--- a/packages/app/src/__tests__/store/message-handler-permission-input.test.ts
+++ b/packages/app/src/__tests__/store/message-handler-permission-input.test.ts
@@ -19,6 +19,7 @@ import {
   _testResetStore,
   setStore,
 } from '../../store/message-handler';
+import { createMockMessageHandlerContext } from '../../test-utils/mock-message-handler-context';
 import type { ConnectionState } from '../../store/types';
 
 // Mock persistence so the handler's imports resolve without touching disk.
@@ -63,19 +64,6 @@ function createMockStore(initialInputs: Record<string, unknown> = {}) {
   };
 }
 
-function createMockContext() {
-  return {
-    socket: { readyState: 1, send: jest.fn() } as any,
-    serverUrl: 'wss://test.example.com',
-    apiToken: 'test-token',
-    connectionId: 'test-conn-1',
-    reconnecting: false,
-    connectedAt: Date.now(),
-    activeSessionIdAtConnect: null,
-    replayingSessions: new Set<string>(),
-  };
-}
-
 beforeEach(() => {
   jest.clearAllMocks();
 });
@@ -92,7 +80,7 @@ describe('permission_input feeder (#6543 PR-4)', () => {
   it('stores a found:true permission_input keyed by requestId', () => {
     const { store, current } = createMockStore();
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'permission_input',
@@ -112,7 +100,7 @@ describe('permission_input feeder (#6543 PR-4)', () => {
   it('stores a found:false permission_input (unavailable, carries error)', () => {
     const { store, current } = createMockStore();
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'permission_input',
@@ -130,7 +118,7 @@ describe('permission_input feeder (#6543 PR-4)', () => {
   it('does not clobber a prior entry for a different requestId', () => {
     const { store, current } = createMockStore();
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'permission_input',
@@ -157,7 +145,7 @@ describe('permission_input feeder (#6543 PR-4)', () => {
     const seeded = {};
     const { store, current } = createMockStore(seeded);
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     expect(() =>
       _testMessageHandler.handle({ type: 'permission_input', requestId: 'r3' }),
@@ -174,7 +162,7 @@ describe('permission_input feeder (#6543 PR-4)', () => {
       keep: { type: 'permission_input', requestId: 'keep', found: true, tool: 'Edit', input: { file_path: '/y' } },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({ type: 'permission_resolved', requestId: 'r1', decision: 'allow' });
 
@@ -188,7 +176,7 @@ describe('permission_input feeder (#6543 PR-4)', () => {
       rt: { type: 'permission_input', requestId: 'rt', found: true, tool: 'Write', input: {} },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({ type: 'permission_expired', requestId: 're', message: 'expired' });
     _testMessageHandler.handle({ type: 'permission_timeout', requestId: 'rt', message: 'timed out' });
@@ -202,7 +190,7 @@ describe('permission_input feeder (#6543 PR-4)', () => {
       live: { type: 'permission_input', requestId: 'live', found: true, tool: 'Write', input: {} },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     // Resolving a DIFFERENT request must not touch the still-live prompt's input.
     _testMessageHandler.handle({ type: 'permission_resolved', requestId: 'other', decision: 'allow' });

--- a/packages/app/src/__tests__/store/message-handler-permission-input.test.ts
+++ b/packages/app/src/__tests__/store/message-handler-permission-input.test.ts
@@ -19,7 +19,7 @@ import {
   _testResetStore,
   setStore,
 } from '../../store/message-handler';
-import { createMockMessageHandlerContext } from '../../test-utils/mock-message-handler-context';
+import { createMockConnectionContext } from '../../test-utils/mock-connection-context';
 import type { ConnectionState } from '../../store/types';
 
 // Mock persistence so the handler's imports resolve without touching disk.
@@ -80,7 +80,7 @@ describe('permission_input feeder (#6543 PR-4)', () => {
   it('stores a found:true permission_input keyed by requestId', () => {
     const { store, current } = createMockStore();
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'permission_input',
@@ -100,7 +100,7 @@ describe('permission_input feeder (#6543 PR-4)', () => {
   it('stores a found:false permission_input (unavailable, carries error)', () => {
     const { store, current } = createMockStore();
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'permission_input',
@@ -118,7 +118,7 @@ describe('permission_input feeder (#6543 PR-4)', () => {
   it('does not clobber a prior entry for a different requestId', () => {
     const { store, current } = createMockStore();
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'permission_input',
@@ -145,7 +145,7 @@ describe('permission_input feeder (#6543 PR-4)', () => {
     const seeded = {};
     const { store, current } = createMockStore(seeded);
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     expect(() =>
       _testMessageHandler.handle({ type: 'permission_input', requestId: 'r3' }),
@@ -162,7 +162,7 @@ describe('permission_input feeder (#6543 PR-4)', () => {
       keep: { type: 'permission_input', requestId: 'keep', found: true, tool: 'Edit', input: { file_path: '/y' } },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({ type: 'permission_resolved', requestId: 'r1', decision: 'allow' });
 
@@ -176,7 +176,7 @@ describe('permission_input feeder (#6543 PR-4)', () => {
       rt: { type: 'permission_input', requestId: 'rt', found: true, tool: 'Write', input: {} },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({ type: 'permission_expired', requestId: 're', message: 'expired' });
     _testMessageHandler.handle({ type: 'permission_timeout', requestId: 'rt', message: 'timed out' });
@@ -190,7 +190,7 @@ describe('permission_input feeder (#6543 PR-4)', () => {
       live: { type: 'permission_input', requestId: 'live', found: true, tool: 'Write', input: {} },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     // Resolving a DIFFERENT request must not touch the still-live prompt's input.
     _testMessageHandler.handle({ type: 'permission_resolved', requestId: 'other', decision: 'allow' });

--- a/packages/app/src/__tests__/store/message-handler.test.ts
+++ b/packages/app/src/__tests__/store/message-handler.test.ts
@@ -19,7 +19,7 @@ import {
   _testClearPendingPermissionModeRequests,
   setDeltaFlushIntervalOverride,
 } from '../../store/message-handler';
-import { createMockMessageHandlerContext } from '../../test-utils/mock-message-handler-context';
+import { createMockConnectionContext } from '../../test-utils/mock-connection-context';
 import { createEmptySessionState } from '../../store/utils';
 import {
   PERMISSION_ALREADY_ANSWERED_NOTICE,
@@ -84,7 +84,7 @@ describe('session_error SESSION_TOKEN_MISMATCH UX', () => {
       sessionStates: { s1: createEmptySessionState() },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'session_error',
@@ -118,7 +118,7 @@ describe('session_error SESSION_TOKEN_MISMATCH UX', () => {
       clearSavedConnection,
     } as any);
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'session_error',
@@ -146,7 +146,7 @@ describe('session_error SESSION_TOKEN_MISMATCH UX', () => {
       sessionStates: { s1: createEmptySessionState() },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'session_error',
@@ -175,7 +175,7 @@ describe('session_role handler (#5589 / #5281)', () => {
       sessionStates: { s1: createEmptySessionState() },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({ type: 'session_role', sessionId: 's1', primaryClientId: 'other' });
 
@@ -192,7 +192,7 @@ describe('session_role handler (#5589 / #5281)', () => {
       sessionStates: { s1: createEmptySessionState() },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({ type: 'session_role', sessionId: 's1', primaryClientId: 'me' });
 
@@ -209,7 +209,7 @@ describe('session_role handler (#5589 / #5281)', () => {
       sessionStates: { s1: { ...createEmptySessionState(), sessionRole: 'observer', primaryClientId: 'other' } },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({ type: 'session_role', sessionId: 's1', primaryClientId: null });
 
@@ -222,7 +222,7 @@ describe('session_role handler (#5589 / #5281)', () => {
     useMultiClientStore.getState().setMyClientId('me');
     const store = createMockStore({ activeSessionId: null, sessionStates: {} });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({ type: 'session_role', sessionId: 'ghost', primaryClientId: 'other' });
 
@@ -254,7 +254,7 @@ describe('session_error input_conflict handler (#5589 / #5281)', () => {
       },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     const reason = 'Session is already processing input from another device. Wait for it to finish or interrupt first.';
     _testMessageHandler.handle({
@@ -287,7 +287,7 @@ describe('session_error input_conflict handler (#5589 / #5281)', () => {
       sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     const reason = 'Another device is the primary for this session. Request a hand-off or wait for it to release.';
     _testMessageHandler.handle({
@@ -323,7 +323,7 @@ describe('session_stopped handler (#4879)', () => {
       },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     const before = Date.now();
     _testMessageHandler.handle({ type: 'session_stopped', sessionId: 's2', code: 143 });
@@ -351,7 +351,7 @@ describe('session_stopped handler (#4879)', () => {
       sessionStates: { s1: createEmptySessionState() },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({ type: 'session_stopped', code: 0 });
 
@@ -367,7 +367,7 @@ describe('session_stopped handler (#4879)', () => {
       sessionStates: { s1: createEmptySessionState() },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({ type: 'session_stopped' });
 
@@ -385,7 +385,7 @@ describe('session_stopped handler (#4879)', () => {
       sessionStates: { s1: createEmptySessionState() },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({ type: 'session_stopped', sessionId: 's1', code: 0 });
 
@@ -399,7 +399,7 @@ describe('session_stopped handler (#4879)', () => {
       sessionStates: { s1: createEmptySessionState() },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({ type: 'session_stopped', sessionId: 'unknown-session', code: 0 });
 
@@ -420,7 +420,7 @@ describe('session_stopped handler (#4879)', () => {
       sessionStates: { s1: { ...createEmptySessionState(), stoppedAt: 123, stoppedCode: 0 } },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({ type: 'claude_ready' });
 
@@ -452,7 +452,7 @@ describe('history_replay_start clears stale session_stopped marker (#4909)', () 
       },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({ type: 'history_replay_start', sessionId: 's1' });
 
@@ -477,7 +477,7 @@ describe('history_replay_start clears stale session_stopped marker (#4909)', () 
       },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({ type: 'history_replay_start', sessionId: 's2' });
 
@@ -495,7 +495,7 @@ describe('history_replay_start clears stale session_stopped marker (#4909)', () 
       sessionStates: { s1: createEmptySessionState() },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     const sessionStatesBefore = store.getState().sessionStates;
     _testMessageHandler.handle({ type: 'history_replay_start', sessionId: 's1' });
@@ -515,7 +515,7 @@ describe('history_replay_start clears stale session_stopped marker (#4909)', () 
       sessionStates: { s1: createEmptySessionState() },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     expect(() =>
       _testMessageHandler.handle({ type: 'history_replay_start', sessionId: 'unknown-id' }),
@@ -554,7 +554,7 @@ describe('history_replay_start: isPlanPending wipe targeting (#7402)', () => {
       },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
     return store;
   }
 
@@ -591,7 +591,7 @@ describe('history_replay_start: isPlanPending wipe targeting (#7402)', () => {
       },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({ type: 'history_replay_start', sessionId: 's2' });
 
@@ -711,7 +711,7 @@ describe("history_replay_end: '(resolved)' sweep targeting (#7410)", () => {
       },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
     return store;
   }
 
@@ -856,7 +856,7 @@ describe("history_replay_end: '(resolved)' sweep vs a racing live AskUserQuestio
       sessionNotifications: [],
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
     return store;
   }
 
@@ -964,7 +964,7 @@ describe("history_replay_end: '(resolved)' sweep vs a racing live AskUserQuestio
       sessionNotifications: [],
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     // Only s2 is replaying; a live question for s1 is not inside any window of
     // its own, so s1's own replay-end still stamps it.
@@ -994,7 +994,7 @@ describe('session_timeout handler', () => {
     });
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({ type: 'session_timeout', sessionId: 's1', name: 'Session 1', idleMs: 600000 });
 
@@ -1019,7 +1019,7 @@ describe('session_timeout handler', () => {
     });
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({ type: 'session_timeout', sessionId: 's1', name: 'Session 1', idleMs: 600000 });
 
@@ -1039,7 +1039,7 @@ describe('session_timeout handler', () => {
     });
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({ type: 'session_timeout', sessionId: 's1', name: 'Session 1', idleMs: 600000 });
 
@@ -1057,7 +1057,7 @@ describe('session_timeout handler', () => {
     });
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({ type: 'session_timeout', sessionId: 's1', name: 'Test', idleMs: 300000 });
 
@@ -1073,7 +1073,7 @@ describe('session_timeout handler', () => {
     });
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({ type: 'session_timeout', sessionId: 's1', name: 'My Project', idleMs: 600000 });
 
@@ -1098,7 +1098,7 @@ describe('session_timeout handler', () => {
     });
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({ type: 'session_timeout', sessionId: 's2', name: 'Background', idleMs: 600000 });
 
@@ -1127,7 +1127,7 @@ describe('session_list GC handler', () => {
     });
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     // Send session_list that only includes s1 (s2 removed)
     _testMessageHandler.handle({
@@ -1148,7 +1148,7 @@ describe('session_list GC handler', () => {
     });
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'session_list',
@@ -1175,7 +1175,7 @@ describe('session_list GC handler', () => {
     });
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     // Only s1 remains
     _testMessageHandler.handle({
@@ -1208,7 +1208,7 @@ describe('session_list GC handler', () => {
     });
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     // Remove active session s1, only s2 remains
     _testMessageHandler.handle({
@@ -1235,7 +1235,7 @@ describe('session_list GC handler', () => {
     });
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'session_list',
@@ -1264,7 +1264,7 @@ describe('checkpoint_restored handler', () => {
     } as any);
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({ type: 'checkpoint_restored', newSessionId: 's2' });
 
@@ -1282,7 +1282,7 @@ describe('checkpoint_restored handler', () => {
     } as any);
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({ type: 'checkpoint_restored' });
 
@@ -1300,7 +1300,7 @@ describe('checkpoint_restored handler', () => {
     } as any);
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({ type: 'checkpoint_restored', newSessionId: '' });
 
@@ -1318,7 +1318,7 @@ describe('checkpoint_restored handler', () => {
     } as any);
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({ type: 'checkpoint_restored', newSessionId: '   ' });
 
@@ -1336,7 +1336,7 @@ describe('checkpoint_restored handler', () => {
     } as any);
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({ type: 'checkpoint_restored', newSessionId: 42 });
 
@@ -1357,7 +1357,7 @@ describe('checkpoint_restored handler', () => {
     } as any);
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'checkpoint_restored',
@@ -1387,7 +1387,7 @@ describe('session_updated handler (#1381)', () => {
     });
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'session_updated',
@@ -1406,7 +1406,7 @@ describe('session_updated handler (#1381)', () => {
     });
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'session_updated',
@@ -1426,7 +1426,7 @@ describe('conversations_list handler', () => {
     });
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     const mockConversations = [
       { conversationId: 'conv-1', projectName: 'project-a', lastModified: Date.now(), preview: 'hello', sizeBytes: 1024 },
@@ -1450,7 +1450,7 @@ describe('conversations_list handler', () => {
     });
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'conversations_list',
@@ -1485,7 +1485,7 @@ describe('unknown message type (default case)', () => {
     });
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({ type: 'some_future_feature' });
 
@@ -1504,7 +1504,7 @@ describe('unknown message type (default case)', () => {
     });
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({ type: 'some_future_feature' });
 
@@ -1520,7 +1520,7 @@ describe('unknown message type (default case)', () => {
     });
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({ type: 'some_future_feature' });
 
@@ -1553,7 +1553,7 @@ describe('client_focus_changed follow mode', () => {
     });
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'client_focus_changed',
@@ -1583,7 +1583,7 @@ describe('client_focus_changed follow mode', () => {
     });
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'client_focus_changed',
@@ -1615,7 +1615,7 @@ describe('client_focus_changed follow mode', () => {
     });
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'client_focus_changed',
@@ -1647,7 +1647,7 @@ describe('client_focus_changed follow mode', () => {
     });
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'client_focus_changed',
@@ -1666,7 +1666,7 @@ describe('server_mode handler (PTY removal)', () => {
       viewMode: 'chat',
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({ type: 'server_mode', mode: 'cli' });
     // serverMode now lives in the lifecycle store (canonical source)
@@ -1678,7 +1678,7 @@ describe('server_mode handler (PTY removal)', () => {
       viewMode: 'chat',
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({ type: 'server_mode', mode: 'terminal' });
     // serverMode now lives in the lifecycle store (canonical source)
@@ -1697,7 +1697,7 @@ describe('git result handlers', () => {
 
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'git_status_result',
@@ -1725,7 +1725,7 @@ describe('git result handlers', () => {
 
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     expect(() => {
       _testMessageHandler.handle({
@@ -1748,7 +1748,7 @@ describe('git result handlers', () => {
 
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'git_branches_result',
@@ -1773,7 +1773,7 @@ describe('git result handlers', () => {
 
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({ type: 'git_stage_result' });
 
@@ -1790,7 +1790,7 @@ describe('git result handlers', () => {
 
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({ type: 'git_unstage_result' });
 
@@ -1807,7 +1807,7 @@ describe('git result handlers', () => {
 
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({ type: 'git_stage_result', error: 'failed to stage' });
 
@@ -1824,7 +1824,7 @@ describe('git result handlers', () => {
 
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'git_commit_result',
@@ -1849,7 +1849,7 @@ describe('git result handlers', () => {
 
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'git_commit_result',
@@ -1881,7 +1881,7 @@ describe('permission_request rich notification details', () => {
     });
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'permission_request',
@@ -1917,7 +1917,7 @@ describe('permission_request rich notification details', () => {
     });
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     const longCommand = 'a'.repeat(200);
     _testMessageHandler.handle({
@@ -1950,7 +1950,7 @@ describe('permission_request rich notification details', () => {
     });
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'permission_request',
@@ -1984,7 +1984,7 @@ describe('plan_ready notification', () => {
     });
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'plan_ready',
@@ -2014,7 +2014,7 @@ describe('plan_ready notification', () => {
     });
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'plan_ready',
@@ -2038,7 +2038,7 @@ describe('session subscription (#1692)', () => {
     });
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'session_list',
@@ -2067,7 +2067,7 @@ describe('session subscription (#1692)', () => {
     });
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'session_list',
@@ -2090,7 +2090,7 @@ describe('session subscription (#1692)', () => {
     });
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     // Create enough sessions to require chunking: 1 active + (CHUNK_SIZE + 4) non-active
     const nonActiveCount = SUBSCRIBE_SESSIONS_CHUNK_SIZE + 4;
@@ -2121,7 +2121,7 @@ describe('session subscription (#1692)', () => {
     });
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'subscriptions_updated',
@@ -2141,7 +2141,7 @@ describe('user_input cross-client echo', () => {
       },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'user_input',
@@ -2167,7 +2167,7 @@ describe('user_input cross-client echo', () => {
       },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'user_input',
@@ -2204,7 +2204,7 @@ describe('stream_start handler', () => {
 
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({ type: 'stream_start', messageId: 'msg-1', sessionId: 's1' });
 
@@ -2223,7 +2223,7 @@ describe('stream_start handler', () => {
 
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({ type: 'stream_start', messageId: 'msg-1', sessionId: 's1' });
 
@@ -2243,7 +2243,7 @@ describe('stream_start handler', () => {
 
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({ type: 'stream_start', messageId: 'msg-1', sessionId: 's1' });
 
@@ -2268,7 +2268,7 @@ describe('reconnect replay dedup', () => {
       sessionStates: { s1: { ...createEmptySessionState(), messages, streamingMessageId: null } },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
     // Enter reconnect replay mode (no fullHistory = not a session switch)
     _testMessageHandler.handle({ type: 'history_replay_start', sessionId: 's1' });
     return store;
@@ -2466,7 +2466,7 @@ describe('reconnect replay dedup', () => {
       sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'message', messageType: 'user_input', content: 'live echo',
@@ -2497,7 +2497,7 @@ describe('stream_delta handler', () => {
 
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({ type: 'stream_start', messageId: 'msg-1', sessionId: 's1' });
     _testMessageHandler.handle({ type: 'stream_delta', messageId: 'msg-1', sessionId: 's1', delta: 'Hello' });
@@ -2522,7 +2522,7 @@ describe('stream_delta handler', () => {
       sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
     try {
@@ -2554,7 +2554,7 @@ describe('stream_delta handler', () => {
       sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({ type: 'stream_start', messageId: 'msg-1', sessionId: 's1', serverTs: 1_700_000_000_000 });
     _testMessageHandler.handle({ type: 'stream_delta', messageId: 'msg-1', sessionId: 's1', delta: 'Hello', serverTs: 1_700_000_000_010 });
@@ -2576,7 +2576,7 @@ describe('stream_delta handler', () => {
 
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({ type: 'stream_start', messageId: 'msg-1', sessionId: 's1' });
     _testMessageHandler.handle({ type: 'stream_delta', messageId: 'msg-1', sessionId: 's1', delta: 'Content' });
@@ -2602,7 +2602,7 @@ describe('stream_delta handler', () => {
       sessionStates: { s1: { ...createEmptySessionState(), messages: [toolMsg] } },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     // Skip stream_start — simulate the dropped/raced case
     _testMessageHandler.handle({ type: 'stream_delta', messageId: 'msg-1', sessionId: 's1', delta: 'After tool ' });
@@ -2630,7 +2630,7 @@ describe('stream_delta handler', () => {
       sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     // Step 1: dispatch delta when no message exists at this id — defensive
     // remap can't catch the collision since the tool_use isn't there yet.
@@ -2677,7 +2677,7 @@ describe('stream_delta handler', () => {
       sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     // Skip stream_start — simulate the dropped/raced case
     _testMessageHandler.handle({ type: 'stream_delta', messageId: 'msg-orphan', sessionId: 's1', delta: 'After tool ' });
@@ -2731,7 +2731,7 @@ describe('post-tool text chunks split into continuation slots (#4922 / #4889)', 
       sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     // text-A -> tool -> text-B -> tool -> text-C, all sharing messageId 'resp-1'
     _testMessageHandler.handle({ type: 'stream_start', messageId: 'resp-1', sessionId: 's1' });
@@ -2806,7 +2806,7 @@ describe('post-tool text chunks split into continuation slots (#4922 / #4889)', 
       sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({ type: 'stream_start', messageId: 'resp-1', sessionId: 's1' });
     // Sentence-terminated fixtures so #4975 mid-word peel doesn't kick in --
@@ -2853,7 +2853,7 @@ describe('post-tool text chunks split into continuation slots (#4922 / #4889)', 
       sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({ type: 'stream_start', messageId: 'resp-1', sessionId: 's1' });
     _testMessageHandler.handle({
@@ -2888,7 +2888,7 @@ describe('post-tool text chunks split into continuation slots (#4922 / #4889)', 
       sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({ type: 'stream_start', messageId: 'resp-1', sessionId: 's1' });
     // Sentence-terminated fixtures so #4975 mid-word peel doesn't fire --
@@ -2937,7 +2937,7 @@ describe('post-tool text chunks split into continuation slots (#4922 / #4889)', 
       sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     // Enter replay mode for s1 -- mirrors the live wire sequence: server emits
     // `history_replay_start` before streaming the cached transcript.
@@ -3001,7 +3001,7 @@ describe('post-tool text chunks split into continuation slots (#4922 / #4889)', 
         sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
       });
       setStore(store as any);
-      _testMessageHandler.setContext(createMockMessageHandlerContext());
+      _testMessageHandler.setContext(createMockConnectionContext());
 
       // text "Starting Phase 1 — agent-review on PR #3.Del" -> tool ->
       // "egating...". The pre-tool content ends with `l` (mid-sentence),
@@ -3047,7 +3047,7 @@ describe('post-tool text chunks split into continuation slots (#4922 / #4889)', 
         sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
       });
       setStore(store as any);
-      _testMessageHandler.setContext(createMockMessageHandlerContext());
+      _testMessageHandler.setContext(createMockConnectionContext());
 
       _testMessageHandler.handle({ type: 'stream_start', messageId: 'resp-1', sessionId: 's1' });
       // Skip jest.runAllTimers() so "PR #3.Del" stays in pendingDeltas
@@ -3088,7 +3088,7 @@ describe('post-tool text chunks split into continuation slots (#4922 / #4889)', 
         sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
       });
       setStore(store as any);
-      _testMessageHandler.setContext(createMockMessageHandlerContext());
+      _testMessageHandler.setContext(createMockConnectionContext());
 
       _testMessageHandler.handle({ type: 'stream_start', messageId: 'resp-1', sessionId: 's1' });
       _testMessageHandler.handle({
@@ -3134,7 +3134,7 @@ describe('post-tool text chunks split into continuation slots (#4922 / #4889)', 
         sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
       });
       setStore(store as any);
-      _testMessageHandler.setContext(createMockMessageHandlerContext());
+      _testMessageHandler.setContext(createMockConnectionContext());
 
       _testMessageHandler.handle({ type: 'stream_start', messageId: 'resp-1', sessionId: 's1' });
       // Prior delta ends with `Running` (word char `g`).
@@ -3183,7 +3183,7 @@ describe('post-tool text chunks split into continuation slots (#4922 / #4889)', 
         sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
       });
       setStore(store as any);
-      _testMessageHandler.setContext(createMockMessageHandlerContext());
+      _testMessageHandler.setContext(createMockConnectionContext());
 
       _testMessageHandler.handle({ type: 'stream_start', messageId: 'resp-1', sessionId: 's1' });
       _testMessageHandler.handle({
@@ -3231,7 +3231,7 @@ describe('post-tool text chunks split into continuation slots (#4922 / #4889)', 
         sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
       });
       setStore(store as any);
-      _testMessageHandler.setContext(createMockMessageHandlerContext());
+      _testMessageHandler.setContext(createMockConnectionContext());
 
       // Repro from #4999.
       _testMessageHandler.handle({ type: 'stream_start', messageId: 'resp-1', sessionId: 's1' });
@@ -3275,7 +3275,7 @@ describe('post-tool text chunks split into continuation slots (#4922 / #4889)', 
         sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
       });
       setStore(store as any);
-      _testMessageHandler.setContext(createMockMessageHandlerContext());
+      _testMessageHandler.setContext(createMockConnectionContext());
 
       _testMessageHandler.handle({ type: 'stream_start', messageId: 'resp-1', sessionId: 's1' });
       _testMessageHandler.handle({
@@ -3317,7 +3317,7 @@ describe('post-tool text chunks split into continuation slots (#4922 / #4889)', 
         sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
       });
       setStore(store as any);
-      _testMessageHandler.setContext(createMockMessageHandlerContext());
+      _testMessageHandler.setContext(createMockConnectionContext());
 
       _testMessageHandler.handle({ type: 'stream_start', messageId: 'resp-1', sessionId: 's1' });
       _testMessageHandler.handle({
@@ -3356,7 +3356,7 @@ describe('post-tool text chunks split into continuation slots (#4922 / #4889)', 
         sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
       });
       setStore(store as any);
-      _testMessageHandler.setContext(createMockMessageHandlerContext());
+      _testMessageHandler.setContext(createMockConnectionContext());
 
       _testMessageHandler.handle({ type: 'stream_start', messageId: 'resp-1', sessionId: 's1' });
       _testMessageHandler.handle({
@@ -3401,7 +3401,7 @@ describe('post-tool text chunks split into continuation slots (#4922 / #4889)', 
         sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
       });
       setStore(store as any);
-      _testMessageHandler.setContext(createMockMessageHandlerContext());
+      _testMessageHandler.setContext(createMockConnectionContext());
 
       _testMessageHandler.handle({ type: 'stream_start', messageId: 'resp-1', sessionId: 's1' });
       _testMessageHandler.handle({
@@ -3441,7 +3441,7 @@ describe('post-tool text chunks split into continuation slots (#4922 / #4889)', 
         sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
       });
       setStore(store as any);
-      _testMessageHandler.setContext(createMockMessageHandlerContext());
+      _testMessageHandler.setContext(createMockConnectionContext());
 
       _testMessageHandler.handle({ type: 'stream_start', messageId: 'resp-1', sessionId: 's1' });
       _testMessageHandler.handle({
@@ -3484,7 +3484,7 @@ describe('post-tool text chunks split into continuation slots (#4922 / #4889)', 
         sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
       });
       setStore(store as any);
-      _testMessageHandler.setContext(createMockMessageHandlerContext());
+      _testMessageHandler.setContext(createMockConnectionContext());
 
       _testMessageHandler.handle({ type: 'stream_start', messageId: 'resp-1', sessionId: 's1' });
       _testMessageHandler.handle({
@@ -3524,7 +3524,7 @@ describe('post-tool text chunks split into continuation slots (#4922 / #4889)', 
         sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
       });
       setStore(store as any);
-      _testMessageHandler.setContext(createMockMessageHandlerContext());
+      _testMessageHandler.setContext(createMockConnectionContext());
 
       _testMessageHandler.handle({ type: 'stream_start', messageId: 'resp-1', sessionId: 's1' });
       _testMessageHandler.handle({
@@ -3564,7 +3564,7 @@ describe('post-tool text chunks split into continuation slots (#4922 / #4889)', 
         sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
       });
       setStore(store as any);
-      _testMessageHandler.setContext(createMockMessageHandlerContext());
+      _testMessageHandler.setContext(createMockConnectionContext());
 
       _testMessageHandler.handle({ type: 'stream_start', messageId: 'resp-1', sessionId: 's1' });
       _testMessageHandler.handle({
@@ -3604,7 +3604,7 @@ describe('post-tool text chunks split into continuation slots (#4922 / #4889)', 
         sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
       });
       setStore(store as any);
-      _testMessageHandler.setContext(createMockMessageHandlerContext());
+      _testMessageHandler.setContext(createMockConnectionContext());
 
       _testMessageHandler.handle({ type: 'stream_start', messageId: 'resp-1', sessionId: 's1' });
       _testMessageHandler.handle({
@@ -3647,7 +3647,7 @@ describe('post-tool text chunks split into continuation slots (#4922 / #4889)', 
         sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
       });
       setStore(store as any);
-      _testMessageHandler.setContext(createMockMessageHandlerContext());
+      _testMessageHandler.setContext(createMockConnectionContext());
 
       _testMessageHandler.handle({ type: 'stream_start', messageId: 'resp-1', sessionId: 's1' });
       _testMessageHandler.handle({
@@ -3696,7 +3696,7 @@ describe('stream_end handler', () => {
 
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({ type: 'stream_start', messageId: 'msg-1', sessionId: 's1' });
     _testMessageHandler.handle({ type: 'stream_delta', messageId: 'msg-1', sessionId: 's1', delta: 'Final text' });
@@ -3719,7 +3719,7 @@ describe('tool_start handler', () => {
 
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'tool_start',
@@ -3755,7 +3755,7 @@ describe('tool_start handler', () => {
       },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'tool_start',
@@ -3783,7 +3783,7 @@ describe('tool_start handler', () => {
       },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'tool_start',
@@ -3807,7 +3807,7 @@ describe('tool_start handler', () => {
       },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'tool_start',
@@ -3847,7 +3847,7 @@ describe('agent_idle handler (#3171)', () => {
       },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({ type: 'agent_idle', sessionId: 's1' });
 
@@ -3865,7 +3865,7 @@ describe('agent_idle handler (#3171)', () => {
       },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({ type: 'agent_idle', sessionId: 's1' });
 
@@ -3890,7 +3890,7 @@ describe('tool_result handler', () => {
 
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'tool_result',
@@ -3911,7 +3911,7 @@ describe('tool_result handler', () => {
 
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     expect(() => {
       _testMessageHandler.handle({ type: 'tool_result', sessionId: 's1' });
@@ -3939,7 +3939,7 @@ describe('result handler', () => {
       sessionNotifications: [],
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'result',
@@ -3975,7 +3975,7 @@ describe('result handler', () => {
       sessionNotifications: [],
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'result',
@@ -4044,7 +4044,7 @@ describe('permission_resolved handler', () => {
 
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'permission_resolved',
@@ -4079,7 +4079,7 @@ describe('permission_resolved handler', () => {
 
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'permission_resolved',
@@ -4098,7 +4098,7 @@ describe('permission_resolved handler', () => {
       sessionStates: {},
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     // Should not throw when no session has the requestId
     _testMessageHandler.handle({
@@ -4123,7 +4123,7 @@ describe('permission_resolved handler', () => {
       ],
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'permission_resolved',
@@ -4163,7 +4163,7 @@ describe('permission_expired handler', () => {
       ],
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'permission_expired',
@@ -4217,7 +4217,7 @@ describe('permission_expired handler', () => {
 
   function expire(store: ReturnType<typeof createMockStore>) {
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
     _testMessageHandler.handle({
       type: 'permission_expired',
       requestId: 'req-race',
@@ -4359,7 +4359,7 @@ describe('permission_expired handler', () => {
       sessionNotifications: [],
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
     for (const k of ['a', 'b', 'c']) {
       _testMessageHandler.handle({
         type: 'permission_expired',
@@ -4402,7 +4402,7 @@ describe('permission_expired handler', () => {
       sessionNotifications: [],
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
     _testMessageHandler.handle({
       type: 'permission_expired',
       requestId: 'req-race',
@@ -4426,7 +4426,7 @@ describe('permission_request message handler', () => {
       sessionNotifications: [],
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
     clearPermissionSplits();
 
     _testMessageHandler.handle({
@@ -4461,7 +4461,7 @@ describe('permission_request message handler', () => {
       sessionNotifications: [],
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
     clearPermissionSplits();
 
     _testMessageHandler.handle({
@@ -4489,7 +4489,7 @@ describe('permission_request message handler', () => {
       sessionNotifications: [],
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
     clearPermissionSplits();
 
     _testMessageHandler.handle({
@@ -4521,7 +4521,7 @@ describe('permission_request message handler', () => {
       sessionNotifications: [],
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
     clearPermissionSplits();
 
     _testMessageHandler.handle({
@@ -4555,7 +4555,7 @@ describe('permission_request message handler', () => {
       sessionNotifications: [],
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
     clearPermissionSplits();
 
     _testMessageHandler.handle({
@@ -4582,7 +4582,7 @@ describe('permission_request message handler', () => {
       sessionNotifications: [],
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
     clearPermissionSplits();
 
     _testMessageHandler.handle({
@@ -4607,7 +4607,7 @@ describe('permission_request message handler', () => {
       sessionNotifications: [],
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
     clearPermissionSplits();
 
     _testMessageHandler.handle({
@@ -4630,7 +4630,7 @@ describe('session_context handler', () => {
 
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'session_context',
@@ -4657,7 +4657,7 @@ describe('session_context handler', () => {
 
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     expect(() => {
       _testMessageHandler.handle({
@@ -4685,7 +4685,7 @@ describe('user_question handler', () => {
       sessionNotifications: [],
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'user_question',
@@ -4715,7 +4715,7 @@ describe('user_question handler', () => {
       sessionNotifications: [],
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({ type: 'user_question', sessionId: 's1', questions: [] });
 
@@ -4731,7 +4731,7 @@ describe('permission_rules_updated handler', () => {
       sessionStates: { s1: createEmptySessionState() },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'permission_rules_updated',
@@ -4753,7 +4753,7 @@ describe('permission_rules_updated handler', () => {
       },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'permission_rules_updated',
@@ -4777,7 +4777,7 @@ describe('permission_rules_updated handler', () => {
       },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'permission_rules_updated',
@@ -4795,7 +4795,7 @@ describe('permission_rules_updated handler', () => {
       sessionStates: { s1: createEmptySessionState() },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'permission_rules_updated',
@@ -4814,7 +4814,7 @@ describe('permission_rules_updated handler', () => {
       sessionStates: { s1: createEmptySessionState() },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     expect(() => {
       _testMessageHandler.handle({
@@ -4849,7 +4849,7 @@ describe('permission_timeout handler', () => {
       serverErrors: [],
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'permission_timeout',
@@ -4888,7 +4888,7 @@ describe('permission_timeout handler', () => {
       serverErrors: [],
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'permission_timeout',
@@ -4923,7 +4923,7 @@ describe('permission_timeout handler', () => {
       ],
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'permission_timeout',
@@ -4959,7 +4959,7 @@ describe('permission_timeout handler', () => {
       serverErrors: [],
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'permission_timeout',
@@ -4983,7 +4983,7 @@ describe('permission_timeout handler', () => {
       serverErrors: [],
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'permission_timeout',
@@ -5004,7 +5004,7 @@ describe('permission_timeout handler', () => {
       serverErrors: [],
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     expect(() => {
       _testMessageHandler.handle({
@@ -5026,7 +5026,7 @@ describe('error handler', () => {
       sessionStates: { s1: createEmptySessionState() },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     expect(() => {
       _testMessageHandler.handle({
@@ -5045,7 +5045,7 @@ describe('error handler', () => {
       sessionStates: { s1: createEmptySessionState() },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'error',
@@ -5064,7 +5064,7 @@ describe('error handler', () => {
       sessionStates: { s1: createEmptySessionState() },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     expect(() => {
       _testMessageHandler.handle({ type: 'error' });
@@ -5088,7 +5088,7 @@ describe('error handler', () => {
         sessionStates: { s1: createEmptySessionState() },
       });
       setStore(store as any);
-      _testMessageHandler.setContext(createMockMessageHandlerContext());
+      _testMessageHandler.setContext(createMockConnectionContext());
 
       _testMessageHandler.handle({
         type: 'error',
@@ -5123,7 +5123,7 @@ describe('error handler', () => {
         sessionStates: { s1: createEmptySessionState() },
       });
       setStore(store as any);
-      _testMessageHandler.setContext(createMockMessageHandlerContext());
+      _testMessageHandler.setContext(createMockConnectionContext());
 
       _testMessageHandler.handle({
         type: 'error',
@@ -5150,7 +5150,7 @@ describe('error handler', () => {
         sessionStates: { s1: createEmptySessionState() },
       });
       setStore(store as any);
-      _testMessageHandler.setContext(createMockMessageHandlerContext());
+      _testMessageHandler.setContext(createMockConnectionContext());
 
       _testMessageHandler.handle({
         type: 'error',
@@ -5176,7 +5176,7 @@ describe('web_task_error SESSION_TOKEN_MISMATCH UX', () => {
       webTasks: [],
     } as any);
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'web_task_error',
@@ -5213,7 +5213,7 @@ describe('web_task_error SESSION_TOKEN_MISMATCH UX', () => {
       clearSavedConnection,
     } as any);
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'web_task_error',
@@ -5243,7 +5243,7 @@ describe('web_task_error SESSION_TOKEN_MISMATCH UX', () => {
       webTasks: [],
     } as any);
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'web_task_error',
@@ -5270,7 +5270,7 @@ describe('web_task_error SESSION_TOKEN_MISMATCH UX', () => {
       webTasks: [],
     } as any);
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'web_task_error',
@@ -5306,7 +5306,7 @@ describe('set_permission_mode CAPABILITY_NOT_SUPPORTED rejection', () => {
       pendingPermissionConfirm: { mode: 'auto', warning: 'Are you sure?' } as any,
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     // Simulate the connection-store action: optimistically apply 'auto' and
     // register the pending request with the previous mode 'plan'.
@@ -5345,7 +5345,7 @@ describe('set_permission_mode CAPABILITY_NOT_SUPPORTED rejection', () => {
       sessionStates: { s1: createEmptySessionState() },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'error',
@@ -5365,7 +5365,7 @@ describe('set_permission_mode CAPABILITY_NOT_SUPPORTED rejection', () => {
       sessionStates: { s1: createEmptySessionState() },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     registerPendingPermissionModeRequest('perm-mode-req-2', {
       sessionId: 's1',
@@ -5414,7 +5414,7 @@ describe('set_permission_mode CAPABILITY_NOT_SUPPORTED rejection', () => {
       sessionStates: { s1: session },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     // Tap #1: plan → auto (request A in flight)
     registerPendingPermissionModeRequest('perm-mode-req-A', {
@@ -5477,7 +5477,7 @@ describe('set_permission_mode CAPABILITY_NOT_SUPPORTED rejection', () => {
       sessionStates: { s1: session },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     // Pending request is for 'auto' but the current mode has already moved
     // on to 'acceptEdits' (e.g. a later request landed first).
@@ -5521,7 +5521,7 @@ describe('history replay must not reset activity timers (#4492)', () => {
       sessionStates: { s1: { ...createEmptySessionState(), ...extra } },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
     return store;
   }
 
@@ -5604,7 +5604,7 @@ describe('replay flag is per-session (#4512)', () => {
       },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
     return store;
   }
 
@@ -5655,7 +5655,7 @@ describe('replay flag is per-session (#4512)', () => {
     // wrongly gated against a session that no longer thinks it's replaying.
     const store = seedTwoSessions({ lastClientActivityAt: 100 }, { lastClientActivityAt: 100 });
     // Reconnect context preserves session state through auth_ok.
-    _testMessageHandler.setContext(createMockMessageHandlerContext({ isReconnect: true }));
+    _testMessageHandler.setContext(createMockConnectionContext({ isReconnect: true }));
     _testMessageHandler.handle({ type: 'history_replay_start', sessionId: 'sA' });
     _testMessageHandler.handle({ type: 'history_replay_start', sessionId: 'sB' });
     // Reconnect: auth_ok must drop both entries.
@@ -5716,7 +5716,7 @@ describe('replay flag is per-session (#4512)', () => {
       },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     // Session A starts replay. Session B is NOT replaying.
     _testMessageHandler.handle({ type: 'history_replay_start', sessionId: 'sA' });
@@ -5772,7 +5772,7 @@ describe('server_error session-scoped routing (#3141)', () => {
       serverErrors: [],
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'server_error',
@@ -5797,7 +5797,7 @@ describe('server_error session-scoped routing (#3141)', () => {
       serverErrors: [],
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'server_error',
@@ -5821,7 +5821,7 @@ describe('server_error session-scoped routing (#3141)', () => {
       serverErrors: [],
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'server_error',
@@ -5847,7 +5847,7 @@ describe('multi_question_intervention handler (#4764)', () => {
       sessionStates: { s1: createEmptySessionState() },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'multi_question_intervention',
@@ -5875,7 +5875,7 @@ describe('multi_question_intervention handler (#4764)', () => {
       sessionStates: { s1: createEmptySessionState() },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'multi_question_intervention',
@@ -5908,7 +5908,7 @@ describe('multi_question_intervention handler (#4764)', () => {
       sessionStates: { s1: createEmptySessionState() },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     const payload = {
       type: 'multi_question_intervention' as const,
@@ -5934,7 +5934,7 @@ describe('multi_question_intervention handler (#4764)', () => {
       sessionStates: { s1: createEmptySessionState() },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'multi_question_intervention',
@@ -5969,7 +5969,7 @@ describe('multi_question_intervention handler (#4764)', () => {
       },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'multi_question_intervention',
@@ -6001,7 +6001,7 @@ describe('auth_bootstrap (#5555)', () => {
   it('skips the 3 connect-time list requests when capabilities.authBootstrap is set', () => {
     const store = createMockStore({ sessionStates: {} });
     setStore(store as any);
-    const ctx = createMockMessageHandlerContext();
+    const ctx = createMockConnectionContext();
     _testMessageHandler.setContext(ctx);
 
     _testMessageHandler.handle({
@@ -6020,7 +6020,7 @@ describe('auth_bootstrap (#5555)', () => {
   it('requests the 3 lists when authBootstrap is absent (old server)', () => {
     const store = createMockStore({ sessionStates: {} });
     setStore(store as any);
-    const ctx = createMockMessageHandlerContext();
+    const ctx = createMockConnectionContext();
     _testMessageHandler.setContext(ctx);
 
     _testMessageHandler.handle({
@@ -6038,7 +6038,7 @@ describe('auth_bootstrap (#5555)', () => {
   it('folds availablePermissionModes from auth_ok into the store', () => {
     const store = createMockStore({ sessionStates: {} });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
 
     _testMessageHandler.handle({
       type: 'auth_ok',
@@ -6053,7 +6053,7 @@ describe('auth_bootstrap (#5555)', () => {
   it('applies a subsequent auth_bootstrap burst to the provider/slash/agent stores', () => {
     const store = createMockStore({ sessionStates: {}, activeSessionId: null });
     setStore(store as any);
-    const ctx = createMockMessageHandlerContext();
+    const ctx = createMockConnectionContext();
     _testMessageHandler.setContext(ctx);
 
     _testMessageHandler.handle({
@@ -6077,7 +6077,7 @@ describe('auth_bootstrap (#5555)', () => {
   it('#5555 (sub-item 7): an auth_bootstrap burst with tunnelUrl re-learns the rotated URL', () => {
     const store = createMockStore({ sessionStates: {}, activeSessionId: null });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
     useConnectionLifecycleStore.getState().setSavedConnection({
       url: 'wss://old.trycloudflare.com',
       token: 'tok',
@@ -6108,7 +6108,7 @@ describe('tunnel_url_changed (#5555 sub-item 7)', () => {
   it('repoints the persisted tunnelUrl when the push arrives', () => {
     const store = createMockStore({ sessionStates: {} });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
     useConnectionLifecycleStore.getState().setSavedConnection({
       url: 'wss://old.trycloudflare.com',
       token: 'tok',
@@ -6129,7 +6129,7 @@ describe('tunnel_url_changed (#5555 sub-item 7)', () => {
   it('ignores a malformed push (no url) without throwing', () => {
     const store = createMockStore({ sessionStates: {} });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockMessageHandlerContext());
+    _testMessageHandler.setContext(createMockConnectionContext());
     useConnectionLifecycleStore.getState().setSavedConnection({
       url: 'wss://old.trycloudflare.com',
       token: 'tok',

--- a/packages/app/src/__tests__/store/message-handler.test.ts
+++ b/packages/app/src/__tests__/store/message-handler.test.ts
@@ -19,6 +19,7 @@ import {
   _testClearPendingPermissionModeRequests,
   setDeltaFlushIntervalOverride,
 } from '../../store/message-handler';
+import { createMockMessageHandlerContext } from '../../test-utils/mock-message-handler-context';
 import { createEmptySessionState } from '../../store/utils';
 import {
   PERMISSION_ALREADY_ANSWERED_NOTICE,
@@ -31,7 +32,7 @@ import { setCallback, clearAllCallbacks } from '../../store/imperative-callbacks
 import { useMultiClientStore } from '../../store/multi-client';
 import { useConnectionLifecycleStore } from '../../store/connection-lifecycle';
 import { useNotificationStore } from '../../store/notifications';
-import type { ConnectionState } from '../../store/types';
+import type { ConnectionContext, ConnectionState } from '../../store/types';
 
 // Mock persistence to track calls
 jest.mock('../../store/persistence', () => ({
@@ -66,19 +67,6 @@ function createMockStore(initialState: Partial<ConnectionState>) {
   };
 }
 
-/** Create a minimal ConnectionContext */
-function createMockContext() {
-  return {
-    socket: { readyState: 1, send: jest.fn() } as any,
-    serverUrl: 'wss://test.example.com',
-    apiToken: 'test-token',
-    connectionId: 'test-conn-1',
-    reconnecting: false,
-    connectedAt: Date.now(),
-    activeSessionIdAtConnect: null,
-  };
-}
-
 beforeEach(() => {
   jest.clearAllMocks();
   clearAllCallbacks();
@@ -96,7 +84,7 @@ describe('session_error SESSION_TOKEN_MISMATCH UX', () => {
       sessionStates: { s1: createEmptySessionState() },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'session_error',
@@ -130,7 +118,7 @@ describe('session_error SESSION_TOKEN_MISMATCH UX', () => {
       clearSavedConnection,
     } as any);
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'session_error',
@@ -158,7 +146,7 @@ describe('session_error SESSION_TOKEN_MISMATCH UX', () => {
       sessionStates: { s1: createEmptySessionState() },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'session_error',
@@ -187,7 +175,7 @@ describe('session_role handler (#5589 / #5281)', () => {
       sessionStates: { s1: createEmptySessionState() },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({ type: 'session_role', sessionId: 's1', primaryClientId: 'other' });
 
@@ -204,7 +192,7 @@ describe('session_role handler (#5589 / #5281)', () => {
       sessionStates: { s1: createEmptySessionState() },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({ type: 'session_role', sessionId: 's1', primaryClientId: 'me' });
 
@@ -221,7 +209,7 @@ describe('session_role handler (#5589 / #5281)', () => {
       sessionStates: { s1: { ...createEmptySessionState(), sessionRole: 'observer', primaryClientId: 'other' } },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({ type: 'session_role', sessionId: 's1', primaryClientId: null });
 
@@ -234,7 +222,7 @@ describe('session_role handler (#5589 / #5281)', () => {
     useMultiClientStore.getState().setMyClientId('me');
     const store = createMockStore({ activeSessionId: null, sessionStates: {} });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({ type: 'session_role', sessionId: 'ghost', primaryClientId: 'other' });
 
@@ -266,7 +254,7 @@ describe('session_error input_conflict handler (#5589 / #5281)', () => {
       },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     const reason = 'Session is already processing input from another device. Wait for it to finish or interrupt first.';
     _testMessageHandler.handle({
@@ -299,7 +287,7 @@ describe('session_error input_conflict handler (#5589 / #5281)', () => {
       sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     const reason = 'Another device is the primary for this session. Request a hand-off or wait for it to release.';
     _testMessageHandler.handle({
@@ -335,7 +323,7 @@ describe('session_stopped handler (#4879)', () => {
       },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     const before = Date.now();
     _testMessageHandler.handle({ type: 'session_stopped', sessionId: 's2', code: 143 });
@@ -363,7 +351,7 @@ describe('session_stopped handler (#4879)', () => {
       sessionStates: { s1: createEmptySessionState() },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({ type: 'session_stopped', code: 0 });
 
@@ -379,7 +367,7 @@ describe('session_stopped handler (#4879)', () => {
       sessionStates: { s1: createEmptySessionState() },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({ type: 'session_stopped' });
 
@@ -397,7 +385,7 @@ describe('session_stopped handler (#4879)', () => {
       sessionStates: { s1: createEmptySessionState() },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({ type: 'session_stopped', sessionId: 's1', code: 0 });
 
@@ -411,7 +399,7 @@ describe('session_stopped handler (#4879)', () => {
       sessionStates: { s1: createEmptySessionState() },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({ type: 'session_stopped', sessionId: 'unknown-session', code: 0 });
 
@@ -432,7 +420,7 @@ describe('session_stopped handler (#4879)', () => {
       sessionStates: { s1: { ...createEmptySessionState(), stoppedAt: 123, stoppedCode: 0 } },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({ type: 'claude_ready' });
 
@@ -464,7 +452,7 @@ describe('history_replay_start clears stale session_stopped marker (#4909)', () 
       },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({ type: 'history_replay_start', sessionId: 's1' });
 
@@ -489,7 +477,7 @@ describe('history_replay_start clears stale session_stopped marker (#4909)', () 
       },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({ type: 'history_replay_start', sessionId: 's2' });
 
@@ -507,7 +495,7 @@ describe('history_replay_start clears stale session_stopped marker (#4909)', () 
       sessionStates: { s1: createEmptySessionState() },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     const sessionStatesBefore = store.getState().sessionStates;
     _testMessageHandler.handle({ type: 'history_replay_start', sessionId: 's1' });
@@ -527,7 +515,7 @@ describe('history_replay_start clears stale session_stopped marker (#4909)', () 
       sessionStates: { s1: createEmptySessionState() },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     expect(() =>
       _testMessageHandler.handle({ type: 'history_replay_start', sessionId: 'unknown-id' }),
@@ -566,7 +554,7 @@ describe('history_replay_start: isPlanPending wipe targeting (#7402)', () => {
       },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
     return store;
   }
 
@@ -603,7 +591,7 @@ describe('history_replay_start: isPlanPending wipe targeting (#7402)', () => {
       },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({ type: 'history_replay_start', sessionId: 's2' });
 
@@ -723,7 +711,7 @@ describe("history_replay_end: '(resolved)' sweep targeting (#7410)", () => {
       },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
     return store;
   }
 
@@ -868,7 +856,7 @@ describe("history_replay_end: '(resolved)' sweep vs a racing live AskUserQuestio
       sessionNotifications: [],
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
     return store;
   }
 
@@ -976,7 +964,7 @@ describe("history_replay_end: '(resolved)' sweep vs a racing live AskUserQuestio
       sessionNotifications: [],
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     // Only s2 is replaying; a live question for s1 is not inside any window of
     // its own, so s1's own replay-end still stamps it.
@@ -1006,7 +994,7 @@ describe('session_timeout handler', () => {
     });
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({ type: 'session_timeout', sessionId: 's1', name: 'Session 1', idleMs: 600000 });
 
@@ -1031,7 +1019,7 @@ describe('session_timeout handler', () => {
     });
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({ type: 'session_timeout', sessionId: 's1', name: 'Session 1', idleMs: 600000 });
 
@@ -1051,7 +1039,7 @@ describe('session_timeout handler', () => {
     });
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({ type: 'session_timeout', sessionId: 's1', name: 'Session 1', idleMs: 600000 });
 
@@ -1069,7 +1057,7 @@ describe('session_timeout handler', () => {
     });
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({ type: 'session_timeout', sessionId: 's1', name: 'Test', idleMs: 300000 });
 
@@ -1085,7 +1073,7 @@ describe('session_timeout handler', () => {
     });
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({ type: 'session_timeout', sessionId: 's1', name: 'My Project', idleMs: 600000 });
 
@@ -1110,7 +1098,7 @@ describe('session_timeout handler', () => {
     });
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({ type: 'session_timeout', sessionId: 's2', name: 'Background', idleMs: 600000 });
 
@@ -1139,7 +1127,7 @@ describe('session_list GC handler', () => {
     });
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     // Send session_list that only includes s1 (s2 removed)
     _testMessageHandler.handle({
@@ -1160,7 +1148,7 @@ describe('session_list GC handler', () => {
     });
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'session_list',
@@ -1187,7 +1175,7 @@ describe('session_list GC handler', () => {
     });
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     // Only s1 remains
     _testMessageHandler.handle({
@@ -1220,7 +1208,7 @@ describe('session_list GC handler', () => {
     });
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     // Remove active session s1, only s2 remains
     _testMessageHandler.handle({
@@ -1247,7 +1235,7 @@ describe('session_list GC handler', () => {
     });
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'session_list',
@@ -1276,7 +1264,7 @@ describe('checkpoint_restored handler', () => {
     } as any);
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({ type: 'checkpoint_restored', newSessionId: 's2' });
 
@@ -1294,7 +1282,7 @@ describe('checkpoint_restored handler', () => {
     } as any);
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({ type: 'checkpoint_restored' });
 
@@ -1312,7 +1300,7 @@ describe('checkpoint_restored handler', () => {
     } as any);
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({ type: 'checkpoint_restored', newSessionId: '' });
 
@@ -1330,7 +1318,7 @@ describe('checkpoint_restored handler', () => {
     } as any);
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({ type: 'checkpoint_restored', newSessionId: '   ' });
 
@@ -1348,7 +1336,7 @@ describe('checkpoint_restored handler', () => {
     } as any);
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({ type: 'checkpoint_restored', newSessionId: 42 });
 
@@ -1369,7 +1357,7 @@ describe('checkpoint_restored handler', () => {
     } as any);
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'checkpoint_restored',
@@ -1399,7 +1387,7 @@ describe('session_updated handler (#1381)', () => {
     });
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'session_updated',
@@ -1418,7 +1406,7 @@ describe('session_updated handler (#1381)', () => {
     });
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'session_updated',
@@ -1438,7 +1426,7 @@ describe('conversations_list handler', () => {
     });
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     const mockConversations = [
       { conversationId: 'conv-1', projectName: 'project-a', lastModified: Date.now(), preview: 'hello', sizeBytes: 1024 },
@@ -1462,7 +1450,7 @@ describe('conversations_list handler', () => {
     });
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'conversations_list',
@@ -1497,7 +1485,7 @@ describe('unknown message type (default case)', () => {
     });
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({ type: 'some_future_feature' });
 
@@ -1516,7 +1504,7 @@ describe('unknown message type (default case)', () => {
     });
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({ type: 'some_future_feature' });
 
@@ -1532,7 +1520,7 @@ describe('unknown message type (default case)', () => {
     });
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({ type: 'some_future_feature' });
 
@@ -1565,7 +1553,7 @@ describe('client_focus_changed follow mode', () => {
     });
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'client_focus_changed',
@@ -1595,7 +1583,7 @@ describe('client_focus_changed follow mode', () => {
     });
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'client_focus_changed',
@@ -1627,7 +1615,7 @@ describe('client_focus_changed follow mode', () => {
     });
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'client_focus_changed',
@@ -1659,7 +1647,7 @@ describe('client_focus_changed follow mode', () => {
     });
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'client_focus_changed',
@@ -1678,7 +1666,7 @@ describe('server_mode handler (PTY removal)', () => {
       viewMode: 'chat',
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({ type: 'server_mode', mode: 'cli' });
     // serverMode now lives in the lifecycle store (canonical source)
@@ -1690,7 +1678,7 @@ describe('server_mode handler (PTY removal)', () => {
       viewMode: 'chat',
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({ type: 'server_mode', mode: 'terminal' });
     // serverMode now lives in the lifecycle store (canonical source)
@@ -1709,7 +1697,7 @@ describe('git result handlers', () => {
 
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'git_status_result',
@@ -1737,7 +1725,7 @@ describe('git result handlers', () => {
 
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     expect(() => {
       _testMessageHandler.handle({
@@ -1760,7 +1748,7 @@ describe('git result handlers', () => {
 
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'git_branches_result',
@@ -1785,7 +1773,7 @@ describe('git result handlers', () => {
 
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({ type: 'git_stage_result' });
 
@@ -1802,7 +1790,7 @@ describe('git result handlers', () => {
 
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({ type: 'git_unstage_result' });
 
@@ -1819,7 +1807,7 @@ describe('git result handlers', () => {
 
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({ type: 'git_stage_result', error: 'failed to stage' });
 
@@ -1836,7 +1824,7 @@ describe('git result handlers', () => {
 
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'git_commit_result',
@@ -1861,7 +1849,7 @@ describe('git result handlers', () => {
 
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'git_commit_result',
@@ -1893,7 +1881,7 @@ describe('permission_request rich notification details', () => {
     });
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'permission_request',
@@ -1929,7 +1917,7 @@ describe('permission_request rich notification details', () => {
     });
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     const longCommand = 'a'.repeat(200);
     _testMessageHandler.handle({
@@ -1962,7 +1950,7 @@ describe('permission_request rich notification details', () => {
     });
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'permission_request',
@@ -1996,7 +1984,7 @@ describe('plan_ready notification', () => {
     });
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'plan_ready',
@@ -2026,7 +2014,7 @@ describe('plan_ready notification', () => {
     });
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'plan_ready',
@@ -2050,7 +2038,7 @@ describe('session subscription (#1692)', () => {
     });
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'session_list',
@@ -2079,7 +2067,7 @@ describe('session subscription (#1692)', () => {
     });
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'session_list',
@@ -2102,7 +2090,7 @@ describe('session subscription (#1692)', () => {
     });
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     // Create enough sessions to require chunking: 1 active + (CHUNK_SIZE + 4) non-active
     const nonActiveCount = SUBSCRIBE_SESSIONS_CHUNK_SIZE + 4;
@@ -2133,7 +2121,7 @@ describe('session subscription (#1692)', () => {
     });
 
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'subscriptions_updated',
@@ -2153,7 +2141,7 @@ describe('user_input cross-client echo', () => {
       },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'user_input',
@@ -2179,7 +2167,7 @@ describe('user_input cross-client echo', () => {
       },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'user_input',
@@ -2216,7 +2204,7 @@ describe('stream_start handler', () => {
 
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({ type: 'stream_start', messageId: 'msg-1', sessionId: 's1' });
 
@@ -2235,7 +2223,7 @@ describe('stream_start handler', () => {
 
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({ type: 'stream_start', messageId: 'msg-1', sessionId: 's1' });
 
@@ -2255,7 +2243,7 @@ describe('stream_start handler', () => {
 
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({ type: 'stream_start', messageId: 'msg-1', sessionId: 's1' });
 
@@ -2280,7 +2268,7 @@ describe('reconnect replay dedup', () => {
       sessionStates: { s1: { ...createEmptySessionState(), messages, streamingMessageId: null } },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
     // Enter reconnect replay mode (no fullHistory = not a session switch)
     _testMessageHandler.handle({ type: 'history_replay_start', sessionId: 's1' });
     return store;
@@ -2478,7 +2466,7 @@ describe('reconnect replay dedup', () => {
       sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'message', messageType: 'user_input', content: 'live echo',
@@ -2509,7 +2497,7 @@ describe('stream_delta handler', () => {
 
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({ type: 'stream_start', messageId: 'msg-1', sessionId: 's1' });
     _testMessageHandler.handle({ type: 'stream_delta', messageId: 'msg-1', sessionId: 's1', delta: 'Hello' });
@@ -2534,7 +2522,7 @@ describe('stream_delta handler', () => {
       sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
     try {
@@ -2566,7 +2554,7 @@ describe('stream_delta handler', () => {
       sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({ type: 'stream_start', messageId: 'msg-1', sessionId: 's1', serverTs: 1_700_000_000_000 });
     _testMessageHandler.handle({ type: 'stream_delta', messageId: 'msg-1', sessionId: 's1', delta: 'Hello', serverTs: 1_700_000_000_010 });
@@ -2588,7 +2576,7 @@ describe('stream_delta handler', () => {
 
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({ type: 'stream_start', messageId: 'msg-1', sessionId: 's1' });
     _testMessageHandler.handle({ type: 'stream_delta', messageId: 'msg-1', sessionId: 's1', delta: 'Content' });
@@ -2614,7 +2602,7 @@ describe('stream_delta handler', () => {
       sessionStates: { s1: { ...createEmptySessionState(), messages: [toolMsg] } },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     // Skip stream_start — simulate the dropped/raced case
     _testMessageHandler.handle({ type: 'stream_delta', messageId: 'msg-1', sessionId: 's1', delta: 'After tool ' });
@@ -2642,7 +2630,7 @@ describe('stream_delta handler', () => {
       sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     // Step 1: dispatch delta when no message exists at this id — defensive
     // remap can't catch the collision since the tool_use isn't there yet.
@@ -2689,7 +2677,7 @@ describe('stream_delta handler', () => {
       sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     // Skip stream_start — simulate the dropped/raced case
     _testMessageHandler.handle({ type: 'stream_delta', messageId: 'msg-orphan', sessionId: 's1', delta: 'After tool ' });
@@ -2743,7 +2731,7 @@ describe('post-tool text chunks split into continuation slots (#4922 / #4889)', 
       sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     // text-A -> tool -> text-B -> tool -> text-C, all sharing messageId 'resp-1'
     _testMessageHandler.handle({ type: 'stream_start', messageId: 'resp-1', sessionId: 's1' });
@@ -2818,7 +2806,7 @@ describe('post-tool text chunks split into continuation slots (#4922 / #4889)', 
       sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({ type: 'stream_start', messageId: 'resp-1', sessionId: 's1' });
     // Sentence-terminated fixtures so #4975 mid-word peel doesn't kick in --
@@ -2865,7 +2853,7 @@ describe('post-tool text chunks split into continuation slots (#4922 / #4889)', 
       sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({ type: 'stream_start', messageId: 'resp-1', sessionId: 's1' });
     _testMessageHandler.handle({
@@ -2900,7 +2888,7 @@ describe('post-tool text chunks split into continuation slots (#4922 / #4889)', 
       sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({ type: 'stream_start', messageId: 'resp-1', sessionId: 's1' });
     // Sentence-terminated fixtures so #4975 mid-word peel doesn't fire --
@@ -2949,7 +2937,7 @@ describe('post-tool text chunks split into continuation slots (#4922 / #4889)', 
       sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     // Enter replay mode for s1 -- mirrors the live wire sequence: server emits
     // `history_replay_start` before streaming the cached transcript.
@@ -3013,7 +3001,7 @@ describe('post-tool text chunks split into continuation slots (#4922 / #4889)', 
         sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
       });
       setStore(store as any);
-      _testMessageHandler.setContext(createMockContext() as any);
+      _testMessageHandler.setContext(createMockMessageHandlerContext());
 
       // text "Starting Phase 1 — agent-review on PR #3.Del" -> tool ->
       // "egating...". The pre-tool content ends with `l` (mid-sentence),
@@ -3059,7 +3047,7 @@ describe('post-tool text chunks split into continuation slots (#4922 / #4889)', 
         sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
       });
       setStore(store as any);
-      _testMessageHandler.setContext(createMockContext() as any);
+      _testMessageHandler.setContext(createMockMessageHandlerContext());
 
       _testMessageHandler.handle({ type: 'stream_start', messageId: 'resp-1', sessionId: 's1' });
       // Skip jest.runAllTimers() so "PR #3.Del" stays in pendingDeltas
@@ -3100,7 +3088,7 @@ describe('post-tool text chunks split into continuation slots (#4922 / #4889)', 
         sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
       });
       setStore(store as any);
-      _testMessageHandler.setContext(createMockContext() as any);
+      _testMessageHandler.setContext(createMockMessageHandlerContext());
 
       _testMessageHandler.handle({ type: 'stream_start', messageId: 'resp-1', sessionId: 's1' });
       _testMessageHandler.handle({
@@ -3146,7 +3134,7 @@ describe('post-tool text chunks split into continuation slots (#4922 / #4889)', 
         sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
       });
       setStore(store as any);
-      _testMessageHandler.setContext(createMockContext() as any);
+      _testMessageHandler.setContext(createMockMessageHandlerContext());
 
       _testMessageHandler.handle({ type: 'stream_start', messageId: 'resp-1', sessionId: 's1' });
       // Prior delta ends with `Running` (word char `g`).
@@ -3195,7 +3183,7 @@ describe('post-tool text chunks split into continuation slots (#4922 / #4889)', 
         sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
       });
       setStore(store as any);
-      _testMessageHandler.setContext(createMockContext() as any);
+      _testMessageHandler.setContext(createMockMessageHandlerContext());
 
       _testMessageHandler.handle({ type: 'stream_start', messageId: 'resp-1', sessionId: 's1' });
       _testMessageHandler.handle({
@@ -3243,7 +3231,7 @@ describe('post-tool text chunks split into continuation slots (#4922 / #4889)', 
         sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
       });
       setStore(store as any);
-      _testMessageHandler.setContext(createMockContext() as any);
+      _testMessageHandler.setContext(createMockMessageHandlerContext());
 
       // Repro from #4999.
       _testMessageHandler.handle({ type: 'stream_start', messageId: 'resp-1', sessionId: 's1' });
@@ -3287,7 +3275,7 @@ describe('post-tool text chunks split into continuation slots (#4922 / #4889)', 
         sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
       });
       setStore(store as any);
-      _testMessageHandler.setContext(createMockContext() as any);
+      _testMessageHandler.setContext(createMockMessageHandlerContext());
 
       _testMessageHandler.handle({ type: 'stream_start', messageId: 'resp-1', sessionId: 's1' });
       _testMessageHandler.handle({
@@ -3329,7 +3317,7 @@ describe('post-tool text chunks split into continuation slots (#4922 / #4889)', 
         sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
       });
       setStore(store as any);
-      _testMessageHandler.setContext(createMockContext() as any);
+      _testMessageHandler.setContext(createMockMessageHandlerContext());
 
       _testMessageHandler.handle({ type: 'stream_start', messageId: 'resp-1', sessionId: 's1' });
       _testMessageHandler.handle({
@@ -3368,7 +3356,7 @@ describe('post-tool text chunks split into continuation slots (#4922 / #4889)', 
         sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
       });
       setStore(store as any);
-      _testMessageHandler.setContext(createMockContext() as any);
+      _testMessageHandler.setContext(createMockMessageHandlerContext());
 
       _testMessageHandler.handle({ type: 'stream_start', messageId: 'resp-1', sessionId: 's1' });
       _testMessageHandler.handle({
@@ -3413,7 +3401,7 @@ describe('post-tool text chunks split into continuation slots (#4922 / #4889)', 
         sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
       });
       setStore(store as any);
-      _testMessageHandler.setContext(createMockContext() as any);
+      _testMessageHandler.setContext(createMockMessageHandlerContext());
 
       _testMessageHandler.handle({ type: 'stream_start', messageId: 'resp-1', sessionId: 's1' });
       _testMessageHandler.handle({
@@ -3453,7 +3441,7 @@ describe('post-tool text chunks split into continuation slots (#4922 / #4889)', 
         sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
       });
       setStore(store as any);
-      _testMessageHandler.setContext(createMockContext() as any);
+      _testMessageHandler.setContext(createMockMessageHandlerContext());
 
       _testMessageHandler.handle({ type: 'stream_start', messageId: 'resp-1', sessionId: 's1' });
       _testMessageHandler.handle({
@@ -3496,7 +3484,7 @@ describe('post-tool text chunks split into continuation slots (#4922 / #4889)', 
         sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
       });
       setStore(store as any);
-      _testMessageHandler.setContext(createMockContext() as any);
+      _testMessageHandler.setContext(createMockMessageHandlerContext());
 
       _testMessageHandler.handle({ type: 'stream_start', messageId: 'resp-1', sessionId: 's1' });
       _testMessageHandler.handle({
@@ -3536,7 +3524,7 @@ describe('post-tool text chunks split into continuation slots (#4922 / #4889)', 
         sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
       });
       setStore(store as any);
-      _testMessageHandler.setContext(createMockContext() as any);
+      _testMessageHandler.setContext(createMockMessageHandlerContext());
 
       _testMessageHandler.handle({ type: 'stream_start', messageId: 'resp-1', sessionId: 's1' });
       _testMessageHandler.handle({
@@ -3576,7 +3564,7 @@ describe('post-tool text chunks split into continuation slots (#4922 / #4889)', 
         sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
       });
       setStore(store as any);
-      _testMessageHandler.setContext(createMockContext() as any);
+      _testMessageHandler.setContext(createMockMessageHandlerContext());
 
       _testMessageHandler.handle({ type: 'stream_start', messageId: 'resp-1', sessionId: 's1' });
       _testMessageHandler.handle({
@@ -3616,7 +3604,7 @@ describe('post-tool text chunks split into continuation slots (#4922 / #4889)', 
         sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
       });
       setStore(store as any);
-      _testMessageHandler.setContext(createMockContext() as any);
+      _testMessageHandler.setContext(createMockMessageHandlerContext());
 
       _testMessageHandler.handle({ type: 'stream_start', messageId: 'resp-1', sessionId: 's1' });
       _testMessageHandler.handle({
@@ -3659,7 +3647,7 @@ describe('post-tool text chunks split into continuation slots (#4922 / #4889)', 
         sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
       });
       setStore(store as any);
-      _testMessageHandler.setContext(createMockContext() as any);
+      _testMessageHandler.setContext(createMockMessageHandlerContext());
 
       _testMessageHandler.handle({ type: 'stream_start', messageId: 'resp-1', sessionId: 's1' });
       _testMessageHandler.handle({
@@ -3708,7 +3696,7 @@ describe('stream_end handler', () => {
 
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({ type: 'stream_start', messageId: 'msg-1', sessionId: 's1' });
     _testMessageHandler.handle({ type: 'stream_delta', messageId: 'msg-1', sessionId: 's1', delta: 'Final text' });
@@ -3731,7 +3719,7 @@ describe('tool_start handler', () => {
 
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'tool_start',
@@ -3767,7 +3755,7 @@ describe('tool_start handler', () => {
       },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'tool_start',
@@ -3795,7 +3783,7 @@ describe('tool_start handler', () => {
       },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'tool_start',
@@ -3819,7 +3807,7 @@ describe('tool_start handler', () => {
       },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'tool_start',
@@ -3859,7 +3847,7 @@ describe('agent_idle handler (#3171)', () => {
       },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({ type: 'agent_idle', sessionId: 's1' });
 
@@ -3877,7 +3865,7 @@ describe('agent_idle handler (#3171)', () => {
       },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({ type: 'agent_idle', sessionId: 's1' });
 
@@ -3902,7 +3890,7 @@ describe('tool_result handler', () => {
 
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'tool_result',
@@ -3923,7 +3911,7 @@ describe('tool_result handler', () => {
 
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     expect(() => {
       _testMessageHandler.handle({ type: 'tool_result', sessionId: 's1' });
@@ -3951,7 +3939,7 @@ describe('result handler', () => {
       sessionNotifications: [],
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'result',
@@ -3987,7 +3975,7 @@ describe('result handler', () => {
       sessionNotifications: [],
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'result',
@@ -4056,7 +4044,7 @@ describe('permission_resolved handler', () => {
 
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'permission_resolved',
@@ -4091,7 +4079,7 @@ describe('permission_resolved handler', () => {
 
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'permission_resolved',
@@ -4110,7 +4098,7 @@ describe('permission_resolved handler', () => {
       sessionStates: {},
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     // Should not throw when no session has the requestId
     _testMessageHandler.handle({
@@ -4135,7 +4123,7 @@ describe('permission_resolved handler', () => {
       ],
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'permission_resolved',
@@ -4175,7 +4163,7 @@ describe('permission_expired handler', () => {
       ],
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'permission_expired',
@@ -4229,7 +4217,7 @@ describe('permission_expired handler', () => {
 
   function expire(store: ReturnType<typeof createMockStore>) {
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
     _testMessageHandler.handle({
       type: 'permission_expired',
       requestId: 'req-race',
@@ -4371,7 +4359,7 @@ describe('permission_expired handler', () => {
       sessionNotifications: [],
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
     for (const k of ['a', 'b', 'c']) {
       _testMessageHandler.handle({
         type: 'permission_expired',
@@ -4414,7 +4402,7 @@ describe('permission_expired handler', () => {
       sessionNotifications: [],
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
     _testMessageHandler.handle({
       type: 'permission_expired',
       requestId: 'req-race',
@@ -4438,7 +4426,7 @@ describe('permission_request message handler', () => {
       sessionNotifications: [],
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
     clearPermissionSplits();
 
     _testMessageHandler.handle({
@@ -4473,7 +4461,7 @@ describe('permission_request message handler', () => {
       sessionNotifications: [],
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
     clearPermissionSplits();
 
     _testMessageHandler.handle({
@@ -4501,7 +4489,7 @@ describe('permission_request message handler', () => {
       sessionNotifications: [],
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
     clearPermissionSplits();
 
     _testMessageHandler.handle({
@@ -4533,7 +4521,7 @@ describe('permission_request message handler', () => {
       sessionNotifications: [],
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
     clearPermissionSplits();
 
     _testMessageHandler.handle({
@@ -4567,7 +4555,7 @@ describe('permission_request message handler', () => {
       sessionNotifications: [],
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
     clearPermissionSplits();
 
     _testMessageHandler.handle({
@@ -4594,7 +4582,7 @@ describe('permission_request message handler', () => {
       sessionNotifications: [],
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
     clearPermissionSplits();
 
     _testMessageHandler.handle({
@@ -4619,7 +4607,7 @@ describe('permission_request message handler', () => {
       sessionNotifications: [],
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
     clearPermissionSplits();
 
     _testMessageHandler.handle({
@@ -4642,7 +4630,7 @@ describe('session_context handler', () => {
 
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'session_context',
@@ -4669,7 +4657,7 @@ describe('session_context handler', () => {
 
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     expect(() => {
       _testMessageHandler.handle({
@@ -4697,7 +4685,7 @@ describe('user_question handler', () => {
       sessionNotifications: [],
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'user_question',
@@ -4727,7 +4715,7 @@ describe('user_question handler', () => {
       sessionNotifications: [],
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({ type: 'user_question', sessionId: 's1', questions: [] });
 
@@ -4743,7 +4731,7 @@ describe('permission_rules_updated handler', () => {
       sessionStates: { s1: createEmptySessionState() },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'permission_rules_updated',
@@ -4765,7 +4753,7 @@ describe('permission_rules_updated handler', () => {
       },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'permission_rules_updated',
@@ -4789,7 +4777,7 @@ describe('permission_rules_updated handler', () => {
       },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'permission_rules_updated',
@@ -4807,7 +4795,7 @@ describe('permission_rules_updated handler', () => {
       sessionStates: { s1: createEmptySessionState() },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'permission_rules_updated',
@@ -4826,7 +4814,7 @@ describe('permission_rules_updated handler', () => {
       sessionStates: { s1: createEmptySessionState() },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     expect(() => {
       _testMessageHandler.handle({
@@ -4861,7 +4849,7 @@ describe('permission_timeout handler', () => {
       serverErrors: [],
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'permission_timeout',
@@ -4900,7 +4888,7 @@ describe('permission_timeout handler', () => {
       serverErrors: [],
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'permission_timeout',
@@ -4935,7 +4923,7 @@ describe('permission_timeout handler', () => {
       ],
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'permission_timeout',
@@ -4971,7 +4959,7 @@ describe('permission_timeout handler', () => {
       serverErrors: [],
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'permission_timeout',
@@ -4995,7 +4983,7 @@ describe('permission_timeout handler', () => {
       serverErrors: [],
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'permission_timeout',
@@ -5016,7 +5004,7 @@ describe('permission_timeout handler', () => {
       serverErrors: [],
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     expect(() => {
       _testMessageHandler.handle({
@@ -5038,7 +5026,7 @@ describe('error handler', () => {
       sessionStates: { s1: createEmptySessionState() },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     expect(() => {
       _testMessageHandler.handle({
@@ -5057,7 +5045,7 @@ describe('error handler', () => {
       sessionStates: { s1: createEmptySessionState() },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'error',
@@ -5076,7 +5064,7 @@ describe('error handler', () => {
       sessionStates: { s1: createEmptySessionState() },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     expect(() => {
       _testMessageHandler.handle({ type: 'error' });
@@ -5100,7 +5088,7 @@ describe('error handler', () => {
         sessionStates: { s1: createEmptySessionState() },
       });
       setStore(store as any);
-      _testMessageHandler.setContext(createMockContext() as any);
+      _testMessageHandler.setContext(createMockMessageHandlerContext());
 
       _testMessageHandler.handle({
         type: 'error',
@@ -5135,7 +5123,7 @@ describe('error handler', () => {
         sessionStates: { s1: createEmptySessionState() },
       });
       setStore(store as any);
-      _testMessageHandler.setContext(createMockContext() as any);
+      _testMessageHandler.setContext(createMockMessageHandlerContext());
 
       _testMessageHandler.handle({
         type: 'error',
@@ -5162,7 +5150,7 @@ describe('error handler', () => {
         sessionStates: { s1: createEmptySessionState() },
       });
       setStore(store as any);
-      _testMessageHandler.setContext(createMockContext() as any);
+      _testMessageHandler.setContext(createMockMessageHandlerContext());
 
       _testMessageHandler.handle({
         type: 'error',
@@ -5188,7 +5176,7 @@ describe('web_task_error SESSION_TOKEN_MISMATCH UX', () => {
       webTasks: [],
     } as any);
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'web_task_error',
@@ -5225,7 +5213,7 @@ describe('web_task_error SESSION_TOKEN_MISMATCH UX', () => {
       clearSavedConnection,
     } as any);
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'web_task_error',
@@ -5255,7 +5243,7 @@ describe('web_task_error SESSION_TOKEN_MISMATCH UX', () => {
       webTasks: [],
     } as any);
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'web_task_error',
@@ -5282,7 +5270,7 @@ describe('web_task_error SESSION_TOKEN_MISMATCH UX', () => {
       webTasks: [],
     } as any);
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'web_task_error',
@@ -5318,7 +5306,7 @@ describe('set_permission_mode CAPABILITY_NOT_SUPPORTED rejection', () => {
       pendingPermissionConfirm: { mode: 'auto', warning: 'Are you sure?' } as any,
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     // Simulate the connection-store action: optimistically apply 'auto' and
     // register the pending request with the previous mode 'plan'.
@@ -5357,7 +5345,7 @@ describe('set_permission_mode CAPABILITY_NOT_SUPPORTED rejection', () => {
       sessionStates: { s1: createEmptySessionState() },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'error',
@@ -5377,7 +5365,7 @@ describe('set_permission_mode CAPABILITY_NOT_SUPPORTED rejection', () => {
       sessionStates: { s1: createEmptySessionState() },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     registerPendingPermissionModeRequest('perm-mode-req-2', {
       sessionId: 's1',
@@ -5426,7 +5414,7 @@ describe('set_permission_mode CAPABILITY_NOT_SUPPORTED rejection', () => {
       sessionStates: { s1: session },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     // Tap #1: plan → auto (request A in flight)
     registerPendingPermissionModeRequest('perm-mode-req-A', {
@@ -5489,7 +5477,7 @@ describe('set_permission_mode CAPABILITY_NOT_SUPPORTED rejection', () => {
       sessionStates: { s1: session },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     // Pending request is for 'auto' but the current mode has already moved
     // on to 'acceptEdits' (e.g. a later request landed first).
@@ -5533,7 +5521,7 @@ describe('history replay must not reset activity timers (#4492)', () => {
       sessionStates: { s1: { ...createEmptySessionState(), ...extra } },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
     return store;
   }
 
@@ -5616,7 +5604,7 @@ describe('replay flag is per-session (#4512)', () => {
       },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
     return store;
   }
 
@@ -5667,7 +5655,7 @@ describe('replay flag is per-session (#4512)', () => {
     // wrongly gated against a session that no longer thinks it's replaying.
     const store = seedTwoSessions({ lastClientActivityAt: 100 }, { lastClientActivityAt: 100 });
     // Reconnect context preserves session state through auth_ok.
-    _testMessageHandler.setContext({ ...createMockContext(), isReconnect: true } as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext({ isReconnect: true }));
     _testMessageHandler.handle({ type: 'history_replay_start', sessionId: 'sA' });
     _testMessageHandler.handle({ type: 'history_replay_start', sessionId: 'sB' });
     // Reconnect: auth_ok must drop both entries.
@@ -5728,7 +5716,7 @@ describe('replay flag is per-session (#4512)', () => {
       },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     // Session A starts replay. Session B is NOT replaying.
     _testMessageHandler.handle({ type: 'history_replay_start', sessionId: 'sA' });
@@ -5784,7 +5772,7 @@ describe('server_error session-scoped routing (#3141)', () => {
       serverErrors: [],
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'server_error',
@@ -5809,7 +5797,7 @@ describe('server_error session-scoped routing (#3141)', () => {
       serverErrors: [],
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'server_error',
@@ -5833,7 +5821,7 @@ describe('server_error session-scoped routing (#3141)', () => {
       serverErrors: [],
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'server_error',
@@ -5859,7 +5847,7 @@ describe('multi_question_intervention handler (#4764)', () => {
       sessionStates: { s1: createEmptySessionState() },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'multi_question_intervention',
@@ -5887,7 +5875,7 @@ describe('multi_question_intervention handler (#4764)', () => {
       sessionStates: { s1: createEmptySessionState() },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'multi_question_intervention',
@@ -5920,7 +5908,7 @@ describe('multi_question_intervention handler (#4764)', () => {
       sessionStates: { s1: createEmptySessionState() },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     const payload = {
       type: 'multi_question_intervention' as const,
@@ -5946,7 +5934,7 @@ describe('multi_question_intervention handler (#4764)', () => {
       sessionStates: { s1: createEmptySessionState() },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'multi_question_intervention',
@@ -5981,7 +5969,7 @@ describe('multi_question_intervention handler (#4764)', () => {
       },
     });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'multi_question_intervention',
@@ -6006,15 +5994,15 @@ describe('multi_question_intervention handler (#4764)', () => {
 // SKIPS the 3 connect-time list requests; against an old server (no flag) it
 // requests them as before. The list_* refresh paths stay live.
 describe('auth_bootstrap (#5555)', () => {
-  function sentTypes(ctx: ReturnType<typeof createMockContext>) {
+  function sentTypes(ctx: ConnectionContext) {
     return (ctx.socket.send as jest.Mock).mock.calls.map((c) => JSON.parse(c[0]).type);
   }
 
   it('skips the 3 connect-time list requests when capabilities.authBootstrap is set', () => {
     const store = createMockStore({ sessionStates: {} });
     setStore(store as any);
-    const ctx = createMockContext();
-    _testMessageHandler.setContext(ctx as any);
+    const ctx = createMockMessageHandlerContext();
+    _testMessageHandler.setContext(ctx);
 
     _testMessageHandler.handle({
       type: 'auth_ok',
@@ -6032,8 +6020,8 @@ describe('auth_bootstrap (#5555)', () => {
   it('requests the 3 lists when authBootstrap is absent (old server)', () => {
     const store = createMockStore({ sessionStates: {} });
     setStore(store as any);
-    const ctx = createMockContext();
-    _testMessageHandler.setContext(ctx as any);
+    const ctx = createMockMessageHandlerContext();
+    _testMessageHandler.setContext(ctx);
 
     _testMessageHandler.handle({
       type: 'auth_ok',
@@ -6050,7 +6038,7 @@ describe('auth_bootstrap (#5555)', () => {
   it('folds availablePermissionModes from auth_ok into the store', () => {
     const store = createMockStore({ sessionStates: {} });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
 
     _testMessageHandler.handle({
       type: 'auth_ok',
@@ -6065,8 +6053,8 @@ describe('auth_bootstrap (#5555)', () => {
   it('applies a subsequent auth_bootstrap burst to the provider/slash/agent stores', () => {
     const store = createMockStore({ sessionStates: {}, activeSessionId: null });
     setStore(store as any);
-    const ctx = createMockContext();
-    _testMessageHandler.setContext(ctx as any);
+    const ctx = createMockMessageHandlerContext();
+    _testMessageHandler.setContext(ctx);
 
     _testMessageHandler.handle({
       type: 'auth_ok',
@@ -6089,7 +6077,7 @@ describe('auth_bootstrap (#5555)', () => {
   it('#5555 (sub-item 7): an auth_bootstrap burst with tunnelUrl re-learns the rotated URL', () => {
     const store = createMockStore({ sessionStates: {}, activeSessionId: null });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
     useConnectionLifecycleStore.getState().setSavedConnection({
       url: 'wss://old.trycloudflare.com',
       token: 'tok',
@@ -6120,7 +6108,7 @@ describe('tunnel_url_changed (#5555 sub-item 7)', () => {
   it('repoints the persisted tunnelUrl when the push arrives', () => {
     const store = createMockStore({ sessionStates: {} });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
     useConnectionLifecycleStore.getState().setSavedConnection({
       url: 'wss://old.trycloudflare.com',
       token: 'tok',
@@ -6141,7 +6129,7 @@ describe('tunnel_url_changed (#5555 sub-item 7)', () => {
   it('ignores a malformed push (no url) without throwing', () => {
     const store = createMockStore({ sessionStates: {} });
     setStore(store as any);
-    _testMessageHandler.setContext(createMockContext() as any);
+    _testMessageHandler.setContext(createMockMessageHandlerContext());
     useConnectionLifecycleStore.getState().setSavedConnection({
       url: 'wss://old.trycloudflare.com',
       token: 'tok',

--- a/packages/app/src/__tests__/store/terminal-mirror.test.ts
+++ b/packages/app/src/__tests__/store/terminal-mirror.test.ts
@@ -3,7 +3,7 @@ import {
   createEmptySessionState,
   _testMessageHandler,
 } from '../../store/connection';
-import { createMockMessageHandlerContext } from '../../test-utils/mock-message-handler-context';
+import { createMockConnectionContext } from '../../test-utils/mock-connection-context';
 
 // #5835 / #5987 — read-only PTY mirror channel on mobile (PR1). Covers the new
 // store actions (terminal_subscribe / terminal_unsubscribe / terminal_resize)
@@ -162,7 +162,7 @@ describe('terminal_output receive', () => {
   const mockSocket = { readyState: 1, send: jest.fn(), close: jest.fn() } as unknown as WebSocket;
 
   beforeEach(() => {
-    _testMessageHandler.setContext(createMockMessageHandlerContext({ socket: mockSocket }));
+    _testMessageHandler.setContext(createMockConnectionContext({ socket: mockSocket }));
   });
   afterEach(() => _testMessageHandler.clearContext());
 

--- a/packages/app/src/__tests__/store/terminal-mirror.test.ts
+++ b/packages/app/src/__tests__/store/terminal-mirror.test.ts
@@ -3,6 +3,7 @@ import {
   createEmptySessionState,
   _testMessageHandler,
 } from '../../store/connection';
+import { createMockMessageHandlerContext } from '../../test-utils/mock-message-handler-context';
 
 // #5835 / #5987 — read-only PTY mirror channel on mobile (PR1). Covers the new
 // store actions (terminal_subscribe / terminal_unsubscribe / terminal_resize)
@@ -161,10 +162,7 @@ describe('terminal_output receive', () => {
   const mockSocket = { readyState: 1, send: jest.fn(), close: jest.fn() } as unknown as WebSocket;
 
   beforeEach(() => {
-    _testMessageHandler.setContext({
-      url: 'wss://test', token: 'tok', isReconnect: false,
-      silent: false, socket: mockSocket,
-    });
+    _testMessageHandler.setContext(createMockMessageHandlerContext({ socket: mockSocket }));
   });
   afterEach(() => _testMessageHandler.clearContext());
 

--- a/packages/app/src/test-utils/mock-connection-context.ts
+++ b/packages/app/src/test-utils/mock-connection-context.ts
@@ -17,14 +17,23 @@
 import type { ConnectionContext } from '../store/types';
 
 /**
- * Build a `ConnectionContext` for message-handler tests.
+ * Build a `ConnectionContext` for message-handler tests. (Named for the type
+ * it actually returns — `MessageHandlerContext` is a DIFFERENT, module-private
+ * type in message-handler.ts; review N2 on #7463.)
  *
  * Pass `overrides` for the per-suite differences that are load-bearing (a
  * reconnect context, a socket whose `send` a test asserts against, …) so the
  * intent stays visible at the call site rather than hiding in a private copy.
  */
-export function createMockMessageHandlerContext(
-  overrides: Partial<ConnectionContext> = {},
+export function createMockConnectionContext<
+  // Review on #7463 (S1): a typed-return factory checks the BASE literal, but
+  // a variable-held override could smuggle an unknown field straight onto the
+  // returned object — the fossil condition re-entering through the override
+  // door. The mapped-`never` constraint rejects any key not on the real type,
+  // for inline AND variable-held overrides alike.
+  T extends Partial<ConnectionContext>,
+>(
+  overrides?: T & Record<Exclude<keyof T, keyof ConnectionContext>, never>,
 ): ConnectionContext {
   const base: ConnectionContext = {
     url: 'wss://test.example.com',
@@ -37,5 +46,5 @@ export function createMockMessageHandlerContext(
     // is checked against the real type.
     socket: { readyState: 1, send: jest.fn(), close: jest.fn() } as unknown as WebSocket,
   };
-  return { ...base, ...overrides };
+  return { ...base, ...(overrides ?? {}) };
 }

--- a/packages/app/src/test-utils/mock-message-handler-context.ts
+++ b/packages/app/src/test-utils/mock-message-handler-context.ts
@@ -1,0 +1,41 @@
+/**
+ * Shared mock for the message handler's injected connection context (#7451).
+ *
+ * `message-handler.ts` reads its per-connection state off a single injected
+ * `ConnectionContext` (`_testMessageHandler.setContext` / `setConnectionContext`),
+ * so every store suite that dispatches a message has to hand it one. Four
+ * suites used to hand-build that literal independently, which meant a
+ * one-field change to the context touched four files (PR #7446) and the copies
+ * had already drifted apart.
+ *
+ * The return type is the REAL `ConnectionContext`, so the object literal below
+ * is the compiler backstop the four copies never had: a field removed from the
+ * context fails HERE ("Property 'x' is missing"), and a stale field left behind
+ * fails HERE too (excess-property check on a typed literal) instead of being
+ * silently swallowed by the `as any` at each call site.
+ */
+import type { ConnectionContext } from '../store/types';
+
+/**
+ * Build a `ConnectionContext` for message-handler tests.
+ *
+ * Pass `overrides` for the per-suite differences that are load-bearing (a
+ * reconnect context, a socket whose `send` a test asserts against, …) so the
+ * intent stays visible at the call site rather than hiding in a private copy.
+ */
+export function createMockMessageHandlerContext(
+  overrides: Partial<ConnectionContext> = {},
+): ConnectionContext {
+  const base: ConnectionContext = {
+    url: 'wss://test.example.com',
+    token: 'test-token',
+    isReconnect: false,
+    silent: false,
+    // A real WebSocket can't be constructed under jest, and the handler only
+    // ever touches `readyState` / `send` / `close` on it. This is the one cast
+    // in the factory and it is scoped to this single field — everything else
+    // is checked against the real type.
+    socket: { readyState: 1, send: jest.fn(), close: jest.fn() } as unknown as WebSocket,
+  };
+  return { ...base, ...overrides };
+}


### PR DESCRIPTION
## What

Extracts one shared, **typed** `createMockMessageHandlerContext(overrides?)` into
`packages/app/src/test-utils/mock-message-handler-context.ts` and routes every
hand-rolled connection-context mock in `packages/app/src/__tests__/` through it,
plus the one remaining copy in the other jest root.

A `ConnectionContext` field change is now a one-file edit, and — the part the
issue's follow-up comment asks for — it now **fails at the factory** instead of
nowhere.

Closes #7451

## The divergence, and what it turned out to be

The four `createMockContext()` copies named in the issue:

| suite | fields in its local literal |
|---|---|
| `src/__tests__/store/agent-event-handler.test.ts` | `socket`, `serverUrl`, `apiToken`, `connectionId`, `reconnecting`, `connectedAt`, `activeSessionIdAtConnect` |
| `src/__tests__/store/message-handler.test.ts` | same 7 |
| `src/__tests__/store/message-handler-activity.test.ts` | same 7 **+ `replayingSessions`** |
| `src/__tests__/store/message-handler-permission-input.test.ts` | same 7 **+ `replayingSessions`** |
| `__tests__/PushTokenError.test.ts` (5th copy, other root) | `url`, `token`, `isReconnect`, `silent`, `socket` |

The real type is `ConnectionContext` (`@chroxy/store-core`, re-exported from
`src/store/types.ts`):

```ts
interface ConnectionContext { url: string; token: string; isReconnect: boolean; silent: boolean; socket: WebSocket }
```

So the divergence is bigger than "two carry `replayingSessions`": **the four
store copies share exactly one field name with the real type.** All seven of
their fields are absent from `ConnectionContext`, and four of its five real
fields were missing. That is precisely the blind spot the follow-up comment
predicted — the `as any` at each call site meant neither direction diagnosed.

Every stale field is inert, verified before removal:

- `replayingSessions` — the handler only ever reads `_ctx.replayingSessions`,
  its own module-private `MessageHandlerContext`; the injected connection
  context is never consulted for it (`grep -rn 'ctx\.replayingSessions' src/store/`
  returns `_ctx.` sites only). The two suites that carried it drive replay state
  through the real `history_replay_start` path, not through the mock.
- `serverUrl` / `apiToken` / `connectionId` / `activeSessionIdAtConnect` — zero
  occurrences in `src/store/message-handler.ts`.
- `reconnecting` — never read; the real field is `isReconnect`, and the one test
  that needed it was already spreading `{ ...createMockContext(), isReconnect: true }`
  on top. That is now the explicit override `createMockMessageHandlerContext({ isReconnect: true })`.

## Factory contract

```ts
export function createMockMessageHandlerContext(
  overrides: Partial<ConnectionContext> = {},
): ConnectionContext
```

- **Return type is the real `ConnectionContext`**, and the base is a typed object
  literal — so both a missing field (TS2741) and an excess field (TS2353) fail
  inside the factory.
- **One cast, scoped to one field**: `socket` (a real `WebSocket` can't be
  constructed under jest). Defaults to `{ readyState: 1, send: jest.fn(), close: jest.fn() }`.
- **`_testMessageHandler.setContext` already takes `ConnectionContext`**, so the
  parameter type forced no cast — every call site drops its `as any` outright.
- Per-suite differences are explicit `overrides` at the call site: `{ isReconnect: true }`
  for the reconnect test, `{ socket: mockSocket }` where a suite asserts on its own
  socket spy.

## Red-first evidence (both directions, on the final tree)

Mutate the factory, run `npx tsc --noEmit`, restore (`cp` from a backup, not
`git checkout --`). Mutant landing was asserted by grep count each time.

**A — delete a required field (`silent`)** → exit 2, one diagnostic, at the factory:

```
src/test-utils/mock-message-handler-context.ts(29,9): error TS2741:
  Property 'silent' is missing in type '{ url: string; token: string; isReconnect: false; socket: WebSocket; }'
  but required in type 'ConnectionContext'.
```

**B — add an excess field** (shaped from the original bug: re-add the stale
`replayingSessions` the old copies carried) → exit 2, one diagnostic, at the factory:

```
src/test-utils/mock-message-handler-context.ts(32,5): error TS2353:
  Object literal may only specify known properties, and 'replayingSessions' does not exist in type 'ConnectionContext'.
```

A plain bogus field (`bogusField: 'nope'`) produces the same TS2353. Restored → `tsc --noEmit` exit 0.

**Control — the same two mutations against the PRE-CHANGE hand-rolled literal**
(rename `apiToken` → `bogusField` in `message-handler.test.ts`'s old
`createMockContext`, i.e. delete a field *and* add an unknown one in one edit):

```
TSC_EXIT = 0   # zero diagnostics — both mutations invisible
```

The baseline is itself the strongest control: on `main`, four mocks carrying
seven fields that don't exist on `ConnectionContext` and missing four that do
typecheck clean.

## Suites

`packages/app`, node 22, `--coverage=false`:

| run | suites | tests |
|---|---|---|
| baseline `src/__tests__/store` (before) | 34 passed / 34 | 731 passed / 731 |
| after, `src/__tests__/store` + `__tests__/PushTokenError.test.ts` | 35 passed / 35 | 733 passed / 733 |
| after, **full app suite** (`npx jest`, both roots) | 181 passed / 181 | 2372 passed / 2372 |

`+1 suite / +2 tests` is exactly `PushTokenError.test.ts` joining the selection.
No assertion was added, removed, or changed — the diff on
`message-handler.test.ts` is 177 mechanical call-site swaps plus four targeted
edits (import, factory removal, the `isReconnect` override, and `sentTypes`'
parameter type going from `ReturnType<typeof createMockContext>` to
`ConnectionContext`). `npx tsc --noEmit` is clean on the committed tree.

## Both jest roots surveyed

Scope grew slightly past the issue's four, because `src/__tests__/` had two more
files repeating the same literal inline seven times:

| file | sites | action |
|---|---|---|
| `src/__tests__/store/agent-event-handler.test.ts` | 3 | folded in |
| `src/__tests__/store/message-handler.test.ts` | 181 | folded in |
| `src/__tests__/store/message-handler-activity.test.ts` | 9 | folded in |
| `src/__tests__/store/message-handler-permission-input.test.ts` | 7 | folded in |
| `src/__tests__/store/connection.test.ts` | 6 inline literals | folded in (`{ socket: mockSocket }`) |
| `src/__tests__/store/terminal-mirror.test.ts` | 1 inline literal | folded in (`{ socket: mockSocket }`) |
| `__tests__/PushTokenError.test.ts` | 2 | folded in |

`src/__tests__/` now contains **no** hand-rolled connection-context literal.

**Surveyed and deliberately not folded in** — the other root's
`setConnectionContext(...)` family (`__tests__/dispatch-activity.test.ts`,
`__tests__/message-handler.test.ts`, `__tests__/contract-switch.test.ts`,
`__tests__/message-handler.encryption-gate.test.ts`,
`__tests__/AutoResumeOnReconnect.test.ts`). These are a different pattern: they
inject through the production setter, and the only non-trivial field — `socket` —
is a suite-local spy the assertions read back
(`expect(mockSocket.close).toHaveBeenCalled()`). Two of them deliberately pass
`socket: {} as WebSocket`, a stub that would *throw* if the handler touched it;
the factory's default socket would silently convert "must not touch the socket"
into "may touch it", changing what those suites exercise. Routing them through
the factory would mean overriding `socket` (and `url`/`token` where the value is
load-bearing) at every site, leaving `silent`/`isReconnect` as the only shared
content — churn without dedup. `encryption-gate` already has its own local
`ctx(overrides)` factory bound to its `mockSocket`.
