### PR TITLE
feat(ci): lint write-only fields on the app's MessageHandlerContext

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1266,6 +1266,25 @@ jobs:
       - name: Run lint-no-nul-bytes golden test
         run: bash scripts/__tests__/lint-no-nul-bytes.test.sh
 
+      - name: Run lint-write-only-ctx-fields tests
+        run: node scripts/__tests__/lint-write-only-ctx-fields.test.mjs
+
+      - name: No write-only fields on the app's MessageHandlerContext
+        # #7452 — a field on the app store's `_ctx` that is written but never
+        # read compiles, type-checks and passes every test: writing to a field
+        # nobody reads is indistinguishable from working code, and
+        # `noUnusedLocals` does not reach interface members. It has happened
+        # twice in a row in the same file — #7421's `isSessionSwitchReplay`,
+        # then `pendingSwitchSessionId`, orphaned by the very PR removing the
+        # first and caught only by a review pass.
+        #
+        # It runs HERE, not in an App job, because it is a pure-node source scan
+        # with no dependencies: this job has setup-node and deliberately no
+        # `npm ci`, which is the same reason `compile-skill-targets --check`
+        # lives here. Exit 2 (cannot check) is a distinct, loud outcome from
+        # exit 0.
+        run: node scripts/lint-write-only-ctx-fields.mjs
+
       - name: Check compiled skill artifacts are in sync with .claude/commands
         # #7253 — .claude/commands/<name>.md is the neutral source, but
         # .claude/skills/<name>/SKILL.md is what Claude actually LOADS (the

--- a/scripts/__tests__/lint-write-only-ctx-fields.test.mjs
+++ b/scripts/__tests__/lint-write-only-ctx-fields.test.mjs
@@ -38,7 +38,7 @@ const SCRIPT = resolve(HERE, '..', 'lint-write-only-ctx-fields.mjs')
 
 // Every case in this file. Bump it when you add one — a case that vanishes
 // should break the run rather than quietly shrink it (#7447).
-const MIN_CASES = 50
+const MIN_CASES = 53
 
 let pass = 0
 let fail = 0

--- a/scripts/__tests__/lint-write-only-ctx-fields.test.mjs
+++ b/scripts/__tests__/lint-write-only-ctx-fields.test.mjs
@@ -505,6 +505,32 @@ test('CLI reports the classification stats it acted on', () => {
   assert(/1 field\(s\), 1 source file\(s\), 2 reference\(s\) classified/.test(r.stdout), r.stdout)
 })
 
+// --- #7464 review C1/S3: the classification windows and the quote lexer ----
+
+test('a comment-padded write still classifies as a WRITE (C1: the 8-byte window)', () => {
+  // Stripping a comment leaves blanks between the reference and `=`; the old
+  // 8-byte lookahead filed this as a READ, and one rescued write silences a
+  // whole write-only field (demonstrated on the real #7421 regression).
+  const stmt = '_ctx.n /* review on #7464, a padded write */ = 1;'
+  const { reads, writes } = classifyReferences(stripComments(stmt), 'n', RECEIVERS)
+  assert(writes.length === 1 && reads.length === 0, `padded write misclassified: ${reads.length}r ${writes.length}w`)
+})
+
+test('a comment-padded delete still classifies as a WRITE (C1: the lookbehind window)', () => {
+  const stmt = 'delete /* the mirror case */ _ctx.n;'
+  const { reads, writes } = classifyReferences(stripComments(stmt), 'n', RECEIVERS)
+  assert(writes.length === 1 && reads.length === 0, `padded delete misclassified: ${reads.length}r ${writes.length}w`)
+})
+
+test("a lone apostrophe in JSX prose cannot open a blind span (S3: quote spans stop at newline)", () => {
+  // Live shape from CreateSessionModal.tsx: `server's` has no closing quote on
+  // its line. The old lexer swallowed everything to the next apostrophe —
+  // including a following `// _ctx.n = 1` line the stripper should have blanked.
+  const src = "const label = <p>the server's daemon</p>;\n// _ctx.n = 1\n_ctx.n = 2;\n"
+  const { reads, writes } = classifyReferences(stripComments(src), 'n', RECEIVERS)
+  assert(writes.length === 1 && reads.length === 0, `blind span altered classification: ${reads.length}r ${writes.length}w`)
+})
+
 // ---------------------------------------------------------------------------
 
 for (const d of tmpDirs) rmSync(d, { recursive: true, force: true })

--- a/scripts/__tests__/lint-write-only-ctx-fields.test.mjs
+++ b/scripts/__tests__/lint-write-only-ctx-fields.test.mjs
@@ -1,0 +1,524 @@
+#!/usr/bin/env node
+/**
+ * lint-write-only-ctx-fields.test.mjs — pins scripts/lint-write-only-ctx-fields.mjs (#7452).
+ *
+ * The lint exists because a write-only context field is INVISIBLE: it compiles,
+ * type-checks and passes every test. Its own failure mode is the same shape —
+ * a classifier that quietly stops matching, or an extractor that quietly finds
+ * zero fields, reports "clean", and is indistinguishable from a healthy run. So
+ * this suite is built around four kinds of case:
+ *
+ *   1. RED — a write-only field must fail, and the failure must NAME the field
+ *      and its write sites. Anchored on the two real regressions (#7421's
+ *      `isSessionSwitchReplay`, PR #7446's `pendingSwitchSessionId`).
+ *   2. GREEN — a field with any reader must pass. Every read SHAPE the app
+ *      actually uses gets its own case, because "no reads found" is how this
+ *      lint produces a false positive, and one missed shape would fail a
+ *      legitimate field.
+ *   3. CANNOT-CHECK — a missing interface, an empty interface, an unterminated
+ *      body, an empty scan set and a malformed allowlist must each exit 2.
+ *      Never 0. "Cannot check" silently read as "nothing to check" is the
+ *      catalogued false-safety shape (docs/false-safety-guards.md) and is the
+ *      only way this lint could be green while checking nothing.
+ *   4. The isEntryPoint CALL SITE, in both directions — see section 0, which
+ *      runs BEFORE this file imports the module and explains why it must.
+ *
+ * No external test framework. Run from repo root:
+ *   node scripts/__tests__/lint-write-only-ctx-fields.test.mjs
+ */
+
+import { spawnSync } from 'node:child_process'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const SCRIPT = resolve(HERE, '..', 'lint-write-only-ctx-fields.mjs')
+
+// Every case in this file. Bump it when you add one — a case that vanishes
+// should break the run rather than quietly shrink it (#7447).
+const MIN_CASES = 50
+
+let pass = 0
+let fail = 0
+const failures = []
+
+const test = (name, fn) => {
+  try {
+    fn()
+    pass++
+    process.stdout.write(`  ok ${name}\n`)
+  } catch (err) {
+    fail++
+    failures.push({ name, err })
+    process.stdout.write(`  FAIL ${name}: ${err.message}\n`)
+  }
+}
+
+const assert = (cond, msg) => {
+  if (!cond) throw new Error(msg || 'assertion failed')
+}
+
+const throws = (fn, Type, match) => {
+  let caught = null
+  try {
+    fn()
+  } catch (err) {
+    caught = err
+  }
+  assert(caught !== null, 'expected a throw, got none')
+  assert(caught instanceof Type, `expected ${Type.name}, got ${caught.constructor.name}: ${caught.message}`)
+  if (match) assert(match.test(caught.message), `message did not match ${match}: ${caught.message}`)
+}
+
+// ---------------------------------------------------------------------------
+// Fixture trees + CLI driver (needed by section 0, so defined before it)
+// ---------------------------------------------------------------------------
+
+const DECL_REL = 'packages/app/src/store/message-handler.ts'
+const tmpDirs = []
+
+function fixtureRoot(declText, extra = {}) {
+  const dir = mkdtempSync(join(tmpdir(), 'chroxy-woctx-'))
+  tmpDirs.push(dir)
+  mkdirSync(join(dir, dirname(DECL_REL)), { recursive: true })
+  writeFileSync(join(dir, DECL_REL), declText)
+  for (const [rel, text] of Object.entries(extra)) {
+    mkdirSync(join(dir, dirname(rel)), { recursive: true })
+    writeFileSync(join(dir, rel), text)
+  }
+  return dir
+}
+
+const runCliOn = (dir, ...args) =>
+  spawnSync(process.execPath, [SCRIPT, '--root', dir, ...args], { encoding: 'utf8' })
+
+const CLEAN_DECL = `
+interface MessageHandlerContext {
+  flag: boolean;
+}
+let _ctx: MessageHandlerContext = { flag: false };
+export function run(): void { _ctx.flag = true; if (_ctx.flag) console.log('x'); }
+`
+const WRITE_ONLY_DECL = `
+interface MessageHandlerContext {
+  flag: boolean;
+}
+let _ctx: MessageHandlerContext = { flag: false };
+export function run(): void { _ctx.flag = true; }
+`
+
+// ---------------------------------------------------------------------------
+// 0. The isEntryPoint CALL SITE — and why it is FIRST, before the import below.
+//
+// The module ends in `process.exit(runCli())` under `isEntryPoint()`. If that
+// guard ever read TRUE on a plain import, the static import this file would
+// otherwise open with would run the lint against the real repo and exit —
+// before a single case ran, printing nothing, exiting 0 on a clean tree. A
+// green run and a DELETED suite would be the same observable outcome, which is
+// exactly the trap recorded as "an entry-point call site needs its own test
+// file" (#7236): a file that imports the module cannot witness it auto-running.
+//
+// The resolution here is ordering rather than a second file. These two cases
+// run out of process, the failure gate below is hard (exit 1 immediately), and
+// only then does this file import the module. Mutating the guard to a literal
+// `true` therefore fails HERE, by name, instead of erasing the run.
+// ---------------------------------------------------------------------------
+
+test('importing the module does NOT run the lint (a guard stuck TRUE would erase this suite)', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'chroxy-woctx-probe-'))
+  tmpDirs.push(dir)
+  const probe = join(dir, 'probe.mjs')
+  writeFileSync(
+    probe,
+    `import { TARGETS } from ${JSON.stringify(pathToFileURL(SCRIPT).href)}\n` +
+    "process.stdout.write('IMPORT-RETURNED:' + TARGETS.length + '\\n')\n",
+  )
+  const r = spawnSync(process.execPath, [probe], { encoding: 'utf8' })
+  assert(r.status === 0, `probe exited ${r.status}\n${r.stdout}${r.stderr}`)
+  assert(
+    /IMPORT-RETURNED:1/.test(r.stdout),
+    `the import never returned — the module ran and exited on import\n${r.stdout}${r.stderr}`,
+  )
+  assert(
+    !/\[write-only-ctx\]/.test(r.stdout + r.stderr),
+    `importing the module produced lint output\n${r.stdout}${r.stderr}`,
+  )
+})
+
+test('running the module directly DOES run it — positive control for the case above', () => {
+  // Without this, "no lint output on import" would pass just as happily against
+  // a module that produces no output at all, ever.
+  const r = runCliOn(fixtureRoot(CLEAN_DECL))
+  assert(/\[write-only-ctx\]/.test(r.stdout), `direct run produced no lint output\n${r.stdout}${r.stderr}`)
+})
+
+if (fail > 0) {
+  for (const f of failures) process.stdout.write(`\n--- ${f.name}\n${f.err.stack}\n`)
+  process.stdout.write(
+    '\nFAIL: the entry-point call site is broken. Stopping BEFORE importing the module, ' +
+    'because a guard stuck TRUE would exit this process during that import.\n',
+  )
+  process.exit(1)
+}
+
+const {
+  CannotCheckError,
+  analyzeTarget,
+  classifyReferences,
+  extractInterfaceFields,
+  stripComments,
+} = await import(pathToFileURL(SCRIPT).href)
+
+// ---------------------------------------------------------------------------
+// Fixture builder — a minimal stand-in for message-handler.ts
+// ---------------------------------------------------------------------------
+
+const RECEIVERS = ['_ctx', 'ctx']
+
+/** Analyse a single in-memory module as both the declaration and the source. */
+const analyzeOne = (text, opts = {}) =>
+  analyzeTarget({
+    declText: text,
+    interfaceName: 'Ctx',
+    receivers: RECEIVERS,
+    sources: [{ path: 'fixture.ts', text }],
+    ...opts,
+  })
+
+const withField = (decl, body) => `
+interface Ctx {
+  ${decl}
+  keep: number;
+}
+function build(): Ctx {
+  return { ${decl.split(':')[0].trim()}: null as never, keep: 0 };
+}
+let _ctx: Ctx = build();
+export function run(): void {
+${body}
+  void _ctx.keep;
+}
+`
+
+// ---------------------------------------------------------------------------
+// 1. RED — write-only fields fail
+// ---------------------------------------------------------------------------
+
+test('a field with writes and no reads FAILS and names the field', () => {
+  const r = analyzeOne(withField('flag: boolean;', '  _ctx.flag = true;\n  _ctx.flag = false;'))
+  assert(r.failures.length === 1, `expected 1 failure, got ${r.failures.length}`)
+  assert(/Ctx\.flag is WRITE-ONLY/.test(r.failures[0]), r.failures[0])
+})
+
+test('the failure lists EVERY write site with a line number', () => {
+  const r = analyzeOne(withField('flag: boolean;', '  _ctx.flag = true;\n  _ctx.flag = false;'))
+  const sites = r.failures[0].match(/write: fixture\.ts:\d+/g) || []
+  assert(sites.length === 2, `expected 2 write sites, got ${sites.length}: ${r.failures[0]}`)
+})
+
+test('#7421 shape: isSessionSwitchReplay written in four handlers, read nowhere', () => {
+  const src = `
+interface Ctx {
+  isSessionSwitchReplay: boolean;
+  replayingSessions: Set<string>;
+}
+let _ctx: Ctx = { isSessionSwitchReplay: false, replayingSessions: new Set() };
+export function reset(): void { _ctx.isSessionSwitchReplay = false; _ctx.replayingSessions.clear(); }
+export function a(): void { _ctx.isSessionSwitchReplay = true; }
+export function b(): void { _ctx.isSessionSwitchReplay = true; }
+export function c(): void { _ctx.isSessionSwitchReplay = false; }
+`
+  const r = analyzeOne(src)
+  assert(r.failures.length === 1, `expected 1, got ${r.failures.length}`)
+  assert(/isSessionSwitchReplay is WRITE-ONLY: 4 write site\(s\)/.test(r.failures[0]), r.failures[0])
+})
+
+test('PR #7446 shape: the setter plus three clears, reader deleted', () => {
+  const src = `
+interface Ctx {
+  pendingSwitchSessionId: string | null;
+  replayingSessions: Set<string>;
+}
+let _ctx: Ctx = { pendingSwitchSessionId: null, replayingSessions: new Set() };
+export function setPendingSwitchSessionId(id: string | null): void { _ctx.pendingSwitchSessionId = id; }
+export function resetReplayFlags(): void { _ctx.replayingSessions.clear(); _ctx.pendingSwitchSessionId = null; }
+export function onAuthOk(): void { _ctx.pendingSwitchSessionId = null; }
+export function onSwitched(): void { _ctx.pendingSwitchSessionId = null; }
+`
+  const r = analyzeOne(src)
+  assert(r.failures.length === 1, `expected 1, got ${r.failures.length}`)
+  assert(/pendingSwitchSessionId is WRITE-ONLY: 4 write site\(s\)/.test(r.failures[0]), r.failures[0])
+})
+
+test('a COMMENTED-OUT reader does not rescue a write-only field', () => {
+  // The realistic regression: the reader is commented out rather than deleted.
+  const r = analyzeOne(withField('flag: boolean;', '  _ctx.flag = true;\n  // if (_ctx.flag) doThing();'))
+  assert(r.failures.length === 1, `a commented reader was counted as a read: ${JSON.stringify(r.failures)}`)
+})
+
+test('a reader that lives only in a TEST file does not rescue the field', () => {
+  const prod = withField('flag: boolean;', '  _ctx.flag = true;')
+  const r = analyzeTarget({
+    declText: prod,
+    interfaceName: 'Ctx',
+    receivers: RECEIVERS,
+    // The CLI filters test paths out of `sources` before this point; passing
+    // only production files here is that contract. The CLI-level case in
+    // section 9 proves the filter itself.
+    sources: [{ path: 'fixture.ts', text: prod }],
+  })
+  assert(r.failures.length === 1, 'expected the write-only failure to stand')
+})
+
+// ---------------------------------------------------------------------------
+// 2. GREEN — every read shape the app actually uses
+// ---------------------------------------------------------------------------
+
+const readShapes = [
+  ['an if condition', '  _ctx.flag = true;\n  if (_ctx.flag) { doThing(); }'],
+  ['a right-hand side', '  _ctx.flag = true;\n  const x = _ctx.flag;\n  void x;'],
+  ['a method call through the field', '  _ctx.flag = true;\n  _ctx.flag.valueOf();'],
+  ['an argument', '  _ctx.flag = true;\n  doThing(_ctx.flag);'],
+  ['a template interpolation', '  _ctx.flag = true;\n  const s = `v=${_ctx.flag}`;\n  void s;'],
+  ['optional chaining', '  _ctx.flag = true;\n  void _ctx?.flag;'],
+  ['a multi-line reference', '  _ctx.flag = true;\n  void _ctx\n    .flag;'],
+  ['an equality comparison (=== is not an assignment)', '  _ctx.flag = true;\n  if (_ctx.flag === true) doThing();'],
+  ['a loose equality (== is not an assignment)', '  _ctx.flag = true;\n  if (_ctx.flag == true) doThing();'],
+  ['an arrow body (=> is not an assignment)', '  _ctx.flag = true;\n  const f = () => _ctx.flag;\n  void f;'],
+  ['the local `ctx` receiver used while building the context', '  ctx.flag = true;\n  void ctx.flag;'],
+]
+for (const [label, body] of readShapes) {
+  test(`a field read via ${label} PASSES`, () => {
+    const r = analyzeOne(withField('flag: boolean;', body))
+    assert(r.failures.length === 0, `false positive: ${JSON.stringify(r.failures)}`)
+  })
+}
+
+test('the real-world read shapes are COUNTED, not merely tolerated', () => {
+  const stripped = stripComments('_ctx.set.clear(); if (_ctx.set) {} const a = _ctx.set;')
+  const { reads, writes } = classifyReferences(stripped, 'set', RECEIVERS)
+  assert(reads.length === 3, `expected 3 reads, got ${reads.length}`)
+  assert(writes.length === 0, `expected 0 writes, got ${writes.length}`)
+})
+
+// ---------------------------------------------------------------------------
+// 3. Write shapes
+// ---------------------------------------------------------------------------
+
+const writeShapes = [
+  ['plain assignment', '_ctx.n = 1;'],
+  ['compound assignment', '_ctx.n += 1;'],
+  ['logical assignment', '_ctx.n ??= 1;'],
+  ['unsigned right shift assignment', '_ctx.n >>>= 1;'],
+  ['postfix increment', '_ctx.n++;'],
+  ['prefix decrement', '--_ctx.n;'],
+  ['delete', 'delete _ctx.n;'],
+]
+for (const [label, stmt] of writeShapes) {
+  test(`${label} classifies as a WRITE`, () => {
+    const { reads, writes } = classifyReferences(stripComments(stmt), 'n', RECEIVERS)
+    assert(writes.length === 1 && reads.length === 0, `reads=${reads.length} writes=${writes.length}`)
+  })
+}
+
+// ---------------------------------------------------------------------------
+// 4. Comment stripping — must not eat live code
+// ---------------------------------------------------------------------------
+
+test('a `//` inside a string literal does not start a comment', () => {
+  const src = "const u = 'http://x'; if (_ctx.flag) doThing();"
+  const { reads } = classifyReferences(stripComments(src), 'flag', RECEIVERS)
+  assert(reads.length === 1, `the read after a URL string was eaten (reads=${reads.length})`)
+})
+
+test('a regex literal containing an escaped `//` does not start a comment', () => {
+  const src = 'const re = /a\\/\\/b/; if (_ctx.flag) doThing();'
+  const { reads } = classifyReferences(stripComments(src), 'flag', RECEIVERS)
+  assert(reads.length === 1, `the read after a regex was eaten (reads=${reads.length})`)
+})
+
+test('division is not mistaken for a regex', () => {
+  const src = 'const q = a / b; const r = c / d; if (_ctx.flag) doThing();'
+  const { reads } = classifyReferences(stripComments(src), 'flag', RECEIVERS)
+  assert(reads.length === 1, `division confused the lexer (reads=${reads.length})`)
+})
+
+test('stripping preserves byte offsets and line numbers', () => {
+  const src = 'a\n// comment here\nif (_ctx.flag) doThing();\n'
+  const out = stripComments(src)
+  assert(out.length === src.length, `length changed: ${out.length} vs ${src.length}`)
+  assert(out.split('\n').length === src.split('\n').length, 'line count changed')
+  const { reads } = classifyReferences(out, 'flag', RECEIVERS)
+  assert(reads[0] === 3, `expected the read on line 3, got ${reads[0]}`)
+})
+
+// ---------------------------------------------------------------------------
+// 5. Interface extraction
+// ---------------------------------------------------------------------------
+
+test('fields are extracted, and nested object-type members are NOT', () => {
+  const src = `
+interface Ctx {
+  a: Map<string, { serverTs: number; recvAt: number }>;
+  b?: string | null;
+  readonly c: number;
+  method(): void;
+  [key: string]: unknown;
+}
+`
+  const fields = extractInterfaceFields(src, 'Ctx')
+  assert(JSON.stringify(fields) === JSON.stringify(['a', 'b', 'c']), `got ${JSON.stringify(fields)}`)
+})
+
+test('base-interface fields are included when followExtends is on', () => {
+  const src = `
+interface Base { encryptionState: unknown; }
+interface Ctx extends Base { own: number; }
+`
+  const fields = extractInterfaceFields(src, 'Ctx', { followExtends: true })
+  assert(fields.includes('own') && fields.includes('encryptionState'), `got ${JSON.stringify(fields)}`)
+})
+
+test('a base interface declared in ANOTHER module is skipped, not fatal', () => {
+  const src = 'interface Ctx extends Imported { own: number; }'
+  const fields = extractInterfaceFields(src, 'Ctx', { followExtends: true })
+  assert(JSON.stringify(fields) === JSON.stringify(['own']), `got ${JSON.stringify(fields)}`)
+})
+
+// ---------------------------------------------------------------------------
+// 6. CANNOT-CHECK — every one of these must be loud, never exit 0
+// ---------------------------------------------------------------------------
+
+test('an EMPTY interface is a cannot-check, not a clean run', () => {
+  throws(() => extractInterfaceFields('interface Ctx {}', 'Ctx'), CannotCheckError, /ZERO fields/)
+})
+
+test('a MISSING interface is a cannot-check', () => {
+  throws(() => extractInterfaceFields('type Ctx = { a: number };', 'Ctx'), CannotCheckError, /not found/)
+})
+
+test('an UNTERMINATED interface body is a cannot-check', () => {
+  throws(() => extractInterfaceFields('interface Ctx { a: number;', 'Ctx'), CannotCheckError, /unterminated/)
+})
+
+test('an EMPTY scan set is a cannot-check', () => {
+  throws(
+    () => analyzeTarget({ declText: 'interface Ctx { a: number; }', interfaceName: 'Ctx', receivers: RECEIVERS, sources: [] }),
+    CannotCheckError,
+    /no source files/,
+  )
+})
+
+// ---------------------------------------------------------------------------
+// 7. Allowlist
+// ---------------------------------------------------------------------------
+
+test('an allowlist entry WITH a justification admits a write-only field', () => {
+  const src = withField('flag: boolean;', '  _ctx.flag = true;')
+  const r = analyzeOne(src, { allow: { flag: 'kept as a debugger-visible marker; see #1234' } })
+  assert(r.failures.length === 0, `allowlist did not admit: ${JSON.stringify(r.failures)}`)
+  assert(r.stats.allowlisted === 1, `stats.allowlisted=${r.stats.allowlisted}`)
+})
+
+test('an allowlist entry WITHOUT a justification is refused', () => {
+  const src = withField('flag: boolean;', '  _ctx.flag = true;')
+  throws(() => analyzeOne(src, { allow: { flag: '   ' } }), CannotCheckError, /no justification/)
+})
+
+test('an allowlist entry naming a field that no longer exists is refused', () => {
+  const src = withField('flag: boolean;', '  _ctx.flag = true;\n  void _ctx.flag;')
+  throws(() => analyzeOne(src, { allow: { gone: 'why' } }), CannotCheckError, /not declared/)
+})
+
+test('an allowlist entry for a field that regained a reader is refused as STALE', () => {
+  const src = withField('flag: boolean;', '  _ctx.flag = true;\n  if (_ctx.flag) doThing();')
+  throws(() => analyzeOne(src, { allow: { flag: 'was write-only' } }), CannotCheckError, /stale/)
+})
+
+// ---------------------------------------------------------------------------
+// 8. Unreferenced fields warn (and do not fail) — pinned so it stays deliberate
+// ---------------------------------------------------------------------------
+
+test('a field with no reference at all WARNS rather than failing', () => {
+  const src = `
+interface Ctx { held: number; used: number; }
+let _ctx: Ctx = { held: 0, used: 0 };
+export function run(): void { void _ctx.used; }
+`
+  const r = analyzeOne(src)
+  assert(r.failures.length === 0, `expected no failure, got ${JSON.stringify(r.failures)}`)
+  assert(r.warnings.length === 1 && /held is UNREFERENCED/.test(r.warnings[0]), JSON.stringify(r.warnings))
+})
+
+// ---------------------------------------------------------------------------
+// 9. CLI end-to-end — exit codes are the contract CI reads
+// ---------------------------------------------------------------------------
+
+test('CLI exits 0 on a clean fixture tree', () => {
+  const r = runCliOn(fixtureRoot(CLEAN_DECL))
+  assert(r.status === 0, `exit ${r.status}\n${r.stdout}${r.stderr}`)
+})
+
+test('CLI exits 1 on a write-only field and names it on stderr', () => {
+  const r = runCliOn(fixtureRoot(WRITE_ONLY_DECL))
+  assert(r.status === 1, `exit ${r.status}\n${r.stdout}${r.stderr}`)
+  assert(/MessageHandlerContext\.flag is WRITE-ONLY/.test(r.stderr), r.stderr)
+  assert(/write: packages\/app\/src\/store\/message-handler\.ts:\d+/.test(r.stderr), r.stderr)
+})
+
+test('CLI exits 2 when the declaring file is missing', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'chroxy-woctx-'))
+  tmpDirs.push(dir)
+  const r = runCliOn(dir)
+  assert(r.status === 2, `exit ${r.status}\n${r.stdout}${r.stderr}`)
+  assert(/cannot read/.test(r.stderr), r.stderr)
+})
+
+test('CLI exits 2 on an EMPTY interface — never 0', () => {
+  const dir = fixtureRoot('interface MessageHandlerContext {}\nlet _ctx: MessageHandlerContext = {} as never;\n')
+  const r = runCliOn(dir)
+  assert(r.status === 2, `exit ${r.status}\n${r.stdout}${r.stderr}`)
+  assert(/CANNOT CHECK/.test(r.stderr) && /ZERO fields/.test(r.stderr), r.stderr)
+})
+
+test('CLI exits 2 on an unparseable (unterminated) interface — never 0', () => {
+  const dir = fixtureRoot('interface MessageHandlerContext {\n  flag: boolean;\n')
+  const r = runCliOn(dir)
+  assert(r.status === 2, `exit ${r.status}\n${r.stdout}${r.stderr}`)
+  assert(/CANNOT CHECK/.test(r.stderr), r.stderr)
+})
+
+test('CLI ignores a reader that lives in a test file', () => {
+  // The ONLY read is in a __tests__ path; the field must still fail.
+  const dir = fixtureRoot(WRITE_ONLY_DECL, {
+    'packages/app/src/__tests__/store/message-handler.test.ts':
+      "export const seen = (_ctx: any) => _ctx.flag;\n",
+  })
+  const r = runCliOn(dir)
+  assert(r.status === 1, `a test-file read masked the write-only field (exit ${r.status})\n${r.stderr}`)
+})
+
+test('CLI reports the classification stats it acted on', () => {
+  const r = runCliOn(fixtureRoot(CLEAN_DECL))
+  assert(/1 field\(s\), 1 source file\(s\), 2 reference\(s\) classified/.test(r.stdout), r.stdout)
+})
+
+// ---------------------------------------------------------------------------
+
+for (const d of tmpDirs) rmSync(d, { recursive: true, force: true })
+
+const total = pass + fail
+process.stdout.write(`\n${pass}/${total} passed\n`)
+if (total < MIN_CASES) {
+  process.stdout.write(
+    `FAIL: only ${total} cases ran, expected at least ${MIN_CASES}. A case stopped being ` +
+    'discovered — that is a shrinking suite, not a passing one.\n',
+  )
+  process.exit(1)
+}
+if (fail > 0) {
+  for (const f of failures) process.stdout.write(`\n--- ${f.name}\n${f.err.stack}\n`)
+  process.exit(1)
+}

--- a/scripts/lint-write-only-ctx-fields.mjs
+++ b/scripts/lint-write-only-ctx-fields.mjs
@@ -66,11 +66,21 @@
  *   - ALIASING. `const c = _ctx; c.field` is invisible unless `c` is listed in
  *     the target's `receivers`. So are `Object.assign(_ctx, {...})`, a spread
  *     copy, a bracket access `_ctx['field']`, and the closure-capture shape
- *     described above. All of these read as ZERO references, i.e. a warning.
+ *     described above. A FULLY aliased field reads as ZERO references — a
+ *     warning; a field with mixed direct and aliased references keeps its
+ *     direct classification, which can land in the failure bucket (#7464 N1) —
+ *     the safe-direction claim holds only for the all-aliased case.
  *   - DESTRUCTURING. `const { field } = _ctx` is a read the classifier does not
  *     count. If a field's ONLY reader destructures, it reads as write-only and
  *     fails — a false positive, resolved by an allowlist entry naming the
- *     destructure site.
+ *     destructure site. The WRITE direction is the unsafe mirror (#7464 S2):
+ *     `({ f: _ctx.field } = o)` and `[_ctx.field] = arr` classify as READS, so
+ *     a field written only that way is invisibly rescued. No such write exists
+ *     in the tree; a real parser is the honest fix.
+ *   - SELF-REFERENTIAL RHS (#7464 S1). `_ctx.f = _ctx.f + 1` counts its own
+ *     right-hand side as a read, so a field consumed only by its own
+ *     read-modify-write never fails — partially negating the `++`-is-not-a-read
+ *     rule above. Zero such writes exist in the tree today.
  *   - STRINGS. Comments are stripped, so a commented-out reader cannot mask a
  *     write-only field — dead readers are routinely left commented out, which
  *     is the whole point. String and template-literal CONTENT is deliberately

--- a/scripts/lint-write-only-ctx-fields.mjs
+++ b/scripts/lint-write-only-ctx-fields.mjs
@@ -1,0 +1,585 @@
+#!/usr/bin/env node
+/**
+ * lint-write-only-ctx-fields.mjs — fail a handler-context field that is WRITTEN
+ * but never READ (#7452; the class #7421 named).
+ *
+ * THE CLASS
+ * ---------
+ * `packages/app/src/store/message-handler.ts` keeps all resettable
+ * per-connection state on one module-level object, `_ctx`. A field there can
+ * lose its last reader — a guard is deleted, a branch is simplified, a handler
+ * moves to store-core — while every `_ctx.field = ...` assignment survives. The
+ * result compiles, type-checks, lints, and passes every test: writing to a
+ * field nobody reads is indistinguishable from working code. TypeScript has
+ * nothing to say about it either — `noUnusedLocals` does not reach interface
+ * members, and the field IS "used", by its own writes.
+ *
+ * It has now happened twice in a row, in the same file:
+ *   - #7421  `isSessionSwitchReplay` — four write sites, zero readers, found
+ *            only by a hand archaeology pass across the app store.
+ *   - PR #7446, first commit — the FIX for #7421 removed the last reader of
+ *            `pendingSwitchSessionId` and left its setter plus three clears
+ *            behind. Caught by the review panel on the PR that existed to
+ *            remove exactly this shape, and fixed in 052227e36.
+ *
+ * Two instances, the second created while removing the first, with nothing
+ * automated in between. That is what this lint is for.
+ *
+ * THE HEURISTIC
+ * -------------
+ * For each field declared on the target interface (and on base interfaces it
+ * `extends` that are declared in the same file), every reference of the form
+ * `<receiver>.<field>` in the target's non-test sources is classified:
+ *
+ *   WRITE  the reference is the TARGET of an assignment — `=` (not `==`, `===`
+ *          or `=>`), any compound assignment (`+=`, `??=`, `>>>=`, …), a
+ *          `++`/`--` in either position, or a `delete`.
+ *   READ   anything else — a condition, a right-hand side, a property or method
+ *          access through it (`_ctx.set.clear()` must read `_ctx.set` first), a
+ *          template interpolation, an argument.
+ *
+ * A field with at least one WRITE and zero READs FAILS the lint, naming the
+ * field and every write site.
+ *
+ * `++`/`--` counts as a write and NOT as a read, deliberately. A field whose
+ * only consumer is its own increment has no reader in any sense that matters.
+ *
+ * A field with NO reference at all is a WARNING, not a failure — and the
+ * distinction is load-bearing rather than squeamish. Zero references is the
+ * signature of both "dead field" and "reached some way this regex cannot see",
+ * and the live tree contains the second: `rttSmoother` is held on the context
+ * so that replacing the context replaces it, while its two consumers close over
+ * the LOCAL `const rttSmoother` that `createDefaultContext` built it from.
+ * `_ctx.rttSmoother` is never written either, so it is not the #7421 class and
+ * failing on it would buy an allowlist entry that suppresses a whole category
+ * rather than a case. The warning names the field on every run (as a GitHub
+ * `::warning::` annotation) so it stays visible instead of silent.
+ *
+ * WHAT IT CANNOT SEE — read this before trusting a green run
+ * ----------------------------------------------------------
+ * The classifier is a regex over comment-stripped source, not a type-aware
+ * parse. `scripts/` sits outside every workspace package and installs no
+ * dependencies — the Scripts Tests CI job does not run `npm ci` at all — so a
+ * real TS parse is not available here. The gaps, stated rather than papered
+ * over:
+ *
+ *   - ALIASING. `const c = _ctx; c.field` is invisible unless `c` is listed in
+ *     the target's `receivers`. So are `Object.assign(_ctx, {...})`, a spread
+ *     copy, a bracket access `_ctx['field']`, and the closure-capture shape
+ *     described above. All of these read as ZERO references, i.e. a warning.
+ *   - DESTRUCTURING. `const { field } = _ctx` is a read the classifier does not
+ *     count. If a field's ONLY reader destructures, it reads as write-only and
+ *     fails — a false positive, resolved by an allowlist entry naming the
+ *     destructure site.
+ *   - STRINGS. Comments are stripped, so a commented-out reader cannot mask a
+ *     write-only field — dead readers are routinely left commented out, which
+ *     is the whole point. String and template-literal CONTENT is deliberately
+ *     left intact, because `${_ctx.field}` is a genuine read. A field name
+ *     inside a quoted string spelled exactly `_ctx.field` would therefore read
+ *     as a reference; no such string exists today.
+ *   - TEST FILES ARE NOT SCANNED, on either side. A test asserting on a
+ *     write-only field would otherwise mask it — which is not hypothetical:
+ *     every mock context under `packages/app/src/__tests__/store/` carried
+ *     `isSessionSwitchReplay: false` for the whole life of that bug. A field
+ *     read only by a test is still write-only in production.
+ *   - Multi-line references (`_ctx\n  .field`) and optional chaining
+ *     (`_ctx?.field`) ARE handled: each file is matched as one string with
+ *     newline-tolerant separators, never line by line. A line-anchored grep
+ *     undercounts exactly this shape.
+ *
+ * ALLOWLIST
+ * ---------
+ * A field that is genuinely write-only on purpose goes in its target's `allow`
+ * map WITH a justification string. An entry with an empty justification is
+ * refused, and so is a STALE entry — one naming a field that no longer exists,
+ * or one whose field has since gained a reader. An allowlist that cannot expire
+ * is a second way to be wrong quietly. There are no entries today.
+ *
+ * FAIL-LOUD
+ * ---------
+ * Every "cannot check" is exit 2, never exit 0: a missing declaring file, an
+ * interface that is not found (renamed, moved, converted to a type alias), an
+ * unterminated interface body, an interface that yields ZERO fields, a scan
+ * root with no source files, or a bad allowlist entry. "Could not check" and
+ * "nothing to check" must never be the same observable outcome
+ * (docs/false-safety-guards.md).
+ *
+ * Usage:
+ *   node scripts/lint-write-only-ctx-fields.mjs [--root <dir>] [--verbose] [--quiet]
+ *
+ * Exit: 0 clean · 1 a write-only field · 2 cannot check.
+ */
+
+import { readdirSync, readFileSync } from 'node:fs'
+import { dirname, join, relative, resolve, sep } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { isEntryPoint } from './lib/is-entry-point.mjs'
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+
+/**
+ * The contexts under guard.
+ *
+ * `receivers` is the set of identifiers a field is reached through. `_ctx` is
+ * the module-level singleton; `ctx` is the local name `createDefaultContext`
+ * uses for the same object while building it. Both are message-handler-local —
+ * `_ctx` appears nowhere else in the app outside two unrelated comments.
+ *
+ * The dashboard's store keeps its per-connection state in module-level `let`
+ * bindings rather than on a context object, so there is no interface for this
+ * lint to read fields off. Its equivalent guard is a different shape and is not
+ * in scope here.
+ */
+export const TARGETS = [
+  {
+    id: 'app/MessageHandlerContext',
+    declFile: 'packages/app/src/store/message-handler.ts',
+    interfaceName: 'MessageHandlerContext',
+    followExtends: true,
+    receivers: ['_ctx', 'ctx'],
+    scanDirs: ['packages/app/src'],
+    // field: 'why it is legitimately write-only'
+    allow: {},
+  },
+]
+
+const SOURCE_EXT = ['.ts', '.tsx']
+
+// A test file's references are excluded from BOTH sides — see the header.
+const TEST_PATH = /(^|[/\\])__tests__[/\\]|\.(test|spec)\.[cm]?tsx?$/
+
+// ---------------------------------------------------------------------------
+// Comment stripping
+// ---------------------------------------------------------------------------
+
+// A `/` starts a REGEX literal (rather than a division) when the last
+// significant character is one of these, or the last identifier was one of the
+// keywords below. Getting this wrong is what would blank a live line: a naive
+// stripper reads `/a\/\/b/` as a `//` comment and erases the rest of the line.
+const REGEX_MAY_FOLLOW = new Set([
+  '(', ',', '=', ':', '[', '!', '&', '|', '?', '{', '}', ';', '+', '-', '*',
+  '%', '~', '^', '<', '>', '\n',
+])
+const REGEX_MAY_FOLLOW_WORD = new Set([
+  'return', 'typeof', 'case', 'in', 'of', 'instanceof', 'new', 'delete',
+  'void', 'do', 'else', 'yield', 'await',
+])
+
+/**
+ * Blank out `//` and block comments, preserving every byte offset and line
+ * break so reported line numbers still match the file on disk.
+ *
+ * Strings, template literals and regex literals are lexed only well enough to
+ * avoid mistaking their contents for a comment start; their content is left
+ * untouched. `${...}` inside a template literal is treated as string content,
+ * so a `//` comment written inside an interpolation is not stripped — an
+ * accepted, documented gap.
+ */
+export function stripComments(text) {
+  const out = text.split('')
+  const blank = (from, to) => {
+    for (let i = from; i < to && i < out.length; i++) {
+      if (out[i] !== '\n') out[i] = ' '
+    }
+  }
+  let i = 0
+  let lastSignificant = '\n'
+  let lastWord = ''
+  while (i < text.length) {
+    const c = text[i]
+    const next = text[i + 1]
+    if (c === '/' && next === '/') {
+      let j = i + 2
+      while (j < text.length && text[j] !== '\n') j++
+      blank(i, j)
+      i = j
+      continue
+    }
+    if (c === '/' && next === '*') {
+      let j = i + 2
+      while (j < text.length && !(text[j] === '*' && text[j + 1] === '/')) j++
+      j = Math.min(j + 2, text.length)
+      blank(i, j)
+      i = j
+      continue
+    }
+    if (c === '"' || c === "'" || c === '`') {
+      let j = i + 1
+      while (j < text.length) {
+        if (text[j] === '\\') { j += 2; continue }
+        if (text[j] === c) { j++; break }
+        j++
+      }
+      i = j
+      lastSignificant = c
+      lastWord = ''
+      continue
+    }
+    if (c === '/' && (REGEX_MAY_FOLLOW.has(lastSignificant) || REGEX_MAY_FOLLOW_WORD.has(lastWord))) {
+      let j = i + 1
+      let inClass = false
+      while (j < text.length) {
+        const d = text[j]
+        if (d === '\\') { j += 2; continue }
+        if (d === '\n') break
+        if (d === '[') inClass = true
+        else if (d === ']') inClass = false
+        else if (d === '/' && !inClass) { j++; break }
+        j++
+      }
+      i = j
+      lastSignificant = '/'
+      lastWord = ''
+      continue
+    }
+    if (/\s/.test(c)) {
+      // Whitespace does NOT reset `lastWord`: `return /re/` must still see the
+      // keyword. It does reset `lastSignificant` on a newline so a regex at the
+      // start of a line is recognised.
+      if (c === '\n') lastSignificant = '\n'
+      i++
+      continue
+    }
+    lastWord = /[A-Za-z_$]/.test(c) || (lastWord !== '' && /[\w$]/.test(c)) ? lastWord + c : ''
+    lastSignificant = c
+    i++
+  }
+  return out.join('')
+}
+
+// ---------------------------------------------------------------------------
+// Interface field extraction
+// ---------------------------------------------------------------------------
+
+export class CannotCheckError extends Error {}
+
+function interfaceBody(text, name) {
+  const decl = new RegExp(`(?:^|[^\\w$])interface\\s+${name}\\b`, 'm')
+  const m = decl.exec(text)
+  if (!m) {
+    throw new CannotCheckError(
+      `interface ${name} not found — renamed, moved, or converted to a type alias? ` +
+      'This lint cannot check what it cannot find.',
+    )
+  }
+  const open = text.indexOf('{', m.index + m[0].length)
+  if (open === -1) throw new CannotCheckError(`interface ${name}: no opening brace found`)
+  const header = text.slice(m.index, open)
+  const extendsMatch = /\bextends\s+([^{]+)/.exec(header)
+  const bases = extendsMatch
+    ? extendsMatch[1].split(',').map((s) => s.trim().replace(/<.*$/, '')).filter(Boolean)
+    : []
+
+  let depth = 0
+  let close = -1
+  for (let i = open; i < text.length; i++) {
+    if (text[i] === '{') depth++
+    else if (text[i] === '}') {
+      depth--
+      if (depth === 0) { close = i; break }
+    }
+  }
+  if (close === -1) {
+    throw new CannotCheckError(`interface ${name}: unterminated body (unbalanced braces)`)
+  }
+  return { body: text.slice(open + 1, close), bases }
+}
+
+/**
+ * Property names declared directly on `name`'s body (depth 0 of that body).
+ *
+ * Method signatures (`foo(): void`), index signatures and members of nested
+ * object types are all skipped: only `name:`/`name?:` at the top level of the
+ * body is a state field.
+ *
+ * @throws {CannotCheckError} if the interface is absent, unterminated, or
+ *   yields zero fields.
+ */
+export function extractInterfaceFields(text, name, { followExtends = false, _seen = new Set(), _top = true } = {}) {
+  if (_seen.has(name)) return []
+  _seen.add(name)
+  const stripped = stripComments(text)
+  const { body, bases } = interfaceBody(stripped, name)
+
+  const fields = []
+  let depth = 0
+  let atMemberStart = true
+  const member = /(?:readonly\s+)?([A-Za-z_$][\w$]*)\s*\??\s*:/y
+  for (let i = 0; i < body.length; i++) {
+    const c = body[i]
+    if (c === '{' || c === '(' || c === '[') { depth++; atMemberStart = false; continue }
+    if (c === '}' || c === ')' || c === ']') { depth--; atMemberStart = false; continue }
+    if (depth === 0 && (c === ';' || c === ',' || c === '\n')) { atMemberStart = true; continue }
+    if (/\s/.test(c)) continue
+    if (depth === 0 && atMemberStart) {
+      member.lastIndex = i
+      const m = member.exec(body)
+      if (m) fields.push(m[1])
+    }
+    atMemberStart = false
+  }
+
+  let all = fields
+  if (followExtends) {
+    for (const base of bases) {
+      // Only a base declared in THIS file can be followed. One imported from
+      // another module contributes nothing and is not an error: it is out of
+      // this target's scope, not unreadable.
+      try {
+        all = all.concat(extractInterfaceFields(text, base, { followExtends, _seen, _top: false }))
+      } catch (err) {
+        if (!(err instanceof CannotCheckError)) throw err
+      }
+    }
+  }
+  const unique = [...new Set(all)]
+  if (_top && unique.length === 0) {
+    throw new CannotCheckError(
+      `interface ${name} yielded ZERO fields. Either it is empty or the extractor no ` +
+      'longer understands its shape — both are "cannot check", not "clean".',
+    )
+  }
+  return unique
+}
+
+// ---------------------------------------------------------------------------
+// Reference classification
+// ---------------------------------------------------------------------------
+
+const ASSIGN_AHEAD = /^\s*(?:=(?![=>])|\+=|-=|\*\*=|\*=|\/=|%=|<<=|>>>=|>>=|&&=|\|\|=|\?\?=|&=|\|=|\^=)/
+const INCDEC_AHEAD = /^\s*(?:\+\+|--)/
+const INCDEC_BEHIND = /(?:\+\+|--)\s*$/
+const DELETE_BEHIND = /\bdelete\s+$/
+
+function lineOf(text, index) {
+  let line = 1
+  for (let i = 0; i < index; i++) if (text[i] === '\n') line++
+  return line
+}
+
+/**
+ * Classify every `<receiver>.<field>` in one ALREADY comment-stripped source.
+ * Returns `{ reads, writes }`, each an array of 1-based line numbers.
+ */
+export function classifyReferences(strippedText, field, receivers) {
+  const recv = receivers.map((r) => r.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|')
+  // Newline-tolerant on BOTH separators: `_ctx\n  .field` and `_ctx?.\n field`
+  // are the same reference as `_ctx.field`. Never match line by line.
+  const re = new RegExp(`(?<![\\w$.])(?:${recv})\\s*\\??\\s*\\.\\s*${field}(?![\\w$])`, 'g')
+  const reads = []
+  const writes = []
+  let m
+  while ((m = re.exec(strippedText)) !== null) {
+    const end = m.index + m[0].length
+    const after = strippedText.slice(end, end + 8)
+    const before = strippedText.slice(Math.max(0, m.index - 12), m.index)
+    const isWrite =
+      ASSIGN_AHEAD.test(after) ||
+      INCDEC_AHEAD.test(after) ||
+      INCDEC_BEHIND.test(before) ||
+      DELETE_BEHIND.test(before)
+    ;(isWrite ? writes : reads).push(lineOf(strippedText, m.index))
+  }
+  return { reads, writes }
+}
+
+// ---------------------------------------------------------------------------
+// Target analysis
+// ---------------------------------------------------------------------------
+
+/**
+ * Analyse one target from in-memory sources.
+ *
+ * @param {object} t
+ * @param {string} t.declText   source of the file declaring the interface
+ * @param {string} t.interfaceName
+ * @param {boolean} [t.followExtends]
+ * @param {string[]} t.receivers
+ * @param {{path: string, text: string}[]} t.sources   non-test sources to scan
+ * @param {Record<string,string>} [t.allow]
+ * @returns {{fields: string[], perField: Map, failures: string[], warnings: string[], stats: object}}
+ * @throws {CannotCheckError}
+ */
+export function analyzeTarget({ declText, interfaceName, followExtends = false, receivers, sources, allow = {} }) {
+  if (!sources || sources.length === 0) {
+    throw new CannotCheckError(
+      `${interfaceName}: no source files to scan. An empty scan set reports every field clean, ` +
+      'which is the one answer a guard must never give.',
+    )
+  }
+  const fields = extractInterfaceFields(declText, interfaceName, { followExtends })
+  const stripped = sources.map((s) => ({ path: s.path, text: stripComments(s.text) }))
+
+  const perField = new Map()
+  let totalRefs = 0
+  for (const field of fields) {
+    const reads = []
+    const writes = []
+    for (const s of stripped) {
+      const r = classifyReferences(s.text, field, receivers)
+      for (const line of r.reads) reads.push(`${s.path}:${line}`)
+      for (const line of r.writes) writes.push(`${s.path}:${line}`)
+    }
+    totalRefs += reads.length + writes.length
+    perField.set(field, { reads, writes })
+  }
+
+  // Allowlist hygiene FIRST: a bad entry means the lint's own configuration no
+  // longer describes the code, which is a cannot-check rather than a finding.
+  for (const [field, why] of Object.entries(allow)) {
+    if (!fields.includes(field)) {
+      throw new CannotCheckError(
+        `allowlist names '${field}', which is not declared on ${interfaceName}. Remove the stale entry.`,
+      )
+    }
+    if (typeof why !== 'string' || why.trim() === '') {
+      throw new CannotCheckError(
+        `allowlist entry '${field}' has no justification. Every exemption must say why.`,
+      )
+    }
+    const { reads } = perField.get(field)
+    if (reads.length > 0) {
+      throw new CannotCheckError(
+        `allowlist entry '${field}' is stale — the field now has ${reads.length} read(s), ` +
+        `first at ${reads[0]}. Remove the exemption.`,
+      )
+    }
+  }
+
+  const failures = []
+  const warnings = []
+  for (const field of fields) {
+    if (Object.prototype.hasOwnProperty.call(allow, field)) continue
+    const { reads, writes } = perField.get(field)
+    if (reads.length > 0) continue
+    if (writes.length > 0) {
+      failures.push(
+        `${interfaceName}.${field} is WRITE-ONLY: ${writes.length} write site(s), 0 reads.\n` +
+        writes.map((w) => `      write: ${w}`).join('\n') +
+        '\n      Nothing consumes this field. Delete it and its writes, or add an allowlist ' +
+        'entry with a justification.',
+      )
+    } else {
+      warnings.push(
+        `${interfaceName}.${field} is UNREFERENCED through ` +
+        `${receivers.map((r) => `${r}.`).join(' / ')} — 0 reads, 0 writes. Either dead state, ` +
+        'or reached by an alias/closure this lint cannot see. Not a failure (see the header).',
+      )
+    }
+  }
+
+  return {
+    fields,
+    perField,
+    failures,
+    warnings,
+    stats: {
+      fields: fields.length,
+      files: sources.length,
+      references: totalRefs,
+      withReads: fields.filter((f) => perField.get(f).reads.length > 0).length,
+      writeOnly: failures.length,
+      unreferenced: warnings.length,
+      allowlisted: Object.keys(allow).length,
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+function listSources(root, dir) {
+  const abs = join(root, dir)
+  let entries
+  try {
+    entries = readdirSync(abs, { withFileTypes: true, recursive: true })
+  } catch (err) {
+    throw new CannotCheckError(`scan dir '${dir}' is unreadable (${err.code || err.message})`)
+  }
+  const out = []
+  for (const e of entries) {
+    if (!e.isFile()) continue
+    if (!SOURCE_EXT.some((ext) => e.name.endsWith(ext))) continue
+    const full = join(e.parentPath ?? e.path, e.name)
+    const rel = relative(root, full).split(sep).join('/')
+    if (TEST_PATH.test(rel)) continue
+    out.push(rel)
+  }
+  return out.sort()
+}
+
+export function runCli(argv = process.argv.slice(2)) {
+  const rootIdx = argv.indexOf('--root')
+  const root = rootIdx === -1 ? REPO_ROOT : resolve(argv[rootIdx + 1] ?? '')
+  const quiet = argv.includes('--quiet')
+  const verbose = argv.includes('--verbose')
+  const log = (...a) => { if (!quiet) console.log(...a) }
+
+  let failed = 0
+  for (const target of TARGETS) {
+    let declText
+    try {
+      declText = readFileSync(join(root, target.declFile), 'utf8')
+    } catch (err) {
+      console.error(
+        `::error::[write-only-ctx] ${target.id}: cannot read ${target.declFile} ` +
+        `(${err.code || err.message}). Moved or renamed? Update TARGETS in ` +
+        'scripts/lint-write-only-ctx-fields.mjs.',
+      )
+      return 2
+    }
+
+    let result
+    try {
+      const paths = target.scanDirs.flatMap((d) => listSources(root, d))
+      result = analyzeTarget({
+        declText,
+        interfaceName: target.interfaceName,
+        followExtends: target.followExtends,
+        receivers: target.receivers,
+        allow: target.allow,
+        sources: paths.map((p) => ({ path: p, text: readFileSync(join(root, p), 'utf8') })),
+      })
+    } catch (err) {
+      if (err instanceof CannotCheckError) {
+        console.error(`::error::[write-only-ctx] ${target.id}: CANNOT CHECK — ${err.message}`)
+        return 2
+      }
+      throw err
+    }
+
+    const { stats, failures, warnings, perField } = result
+    log(
+      `[write-only-ctx] ${target.id}: ${stats.fields} field(s), ${stats.files} source file(s), ` +
+      `${stats.references} reference(s) classified — ${stats.withReads} read, ` +
+      `${stats.writeOnly} write-only, ${stats.unreferenced} unreferenced, ` +
+      `${stats.allowlisted} allowlisted.`,
+    )
+    if (verbose) {
+      for (const [field, { reads, writes }] of perField) {
+        log(`  ${String(reads.length).padStart(3)}r ${String(writes.length).padStart(3)}w  ${field}`)
+      }
+    }
+    for (const w of warnings) console.warn(`::warning::[write-only-ctx] ${target.id}: ${w}`)
+    for (const f of failures) {
+      failed++
+      console.error(`::error::[write-only-ctx] ${target.id}: ${f}`)
+    }
+  }
+
+  if (failed > 0) {
+    console.error(
+      `\n[write-only-ctx] FAIL — ${failed} field(s) written but never read. See the header of ` +
+      'scripts/lint-write-only-ctx-fields.mjs for the heuristic and its limits.',
+    )
+    return 1
+  }
+  log('[write-only-ctx] OK — no context field is written without a reader.')
+  return 0
+}
+
+if (isEntryPoint(import.meta.url)) {
+  process.exit(runCli())
+}

--- a/scripts/lint-write-only-ctx-fields.mjs
+++ b/scripts/lint-write-only-ctx-fields.mjs
@@ -209,6 +209,10 @@ export function stripComments(text) {
       while (j < text.length) {
         if (text[j] === '\\') { j += 2; continue }
         if (text[j] === c) { j++; break }
+        // Review on #7464 (S3): a raw '\'' or '"' span cannot cross a newline
+        // in JS/TS. Without this stop, a lone JSX apostrophe opened a blind
+        // span that swallowed following lines (live case: CreateSessionModal).
+        if (c !== '`' && text[j] === '\n') break
         j++
       }
       i = j
@@ -372,8 +376,13 @@ export function classifyReferences(strippedText, field, receivers) {
   let m
   while ((m = re.exec(strippedText)) !== null) {
     const end = m.index + m[0].length
-    const after = strippedText.slice(end, end + 8)
-    const before = strippedText.slice(Math.max(0, m.index - 12), m.index)
+    // Review on #7464 (C1): an 8-byte lookahead filed a write as a READ when
+    // a stripped comment padded the gap before `=` — and one rescued write
+    // silences a whole write-only field (demonstrated on the real #7421
+    // regression by adding one inline comment). 64 bytes covers any stripped
+    // span this repo produces; both windows are pinned by tests.
+    const after = strippedText.slice(end, end + 64)
+    const before = strippedText.slice(Math.max(0, m.index - 64), m.index)
     const isWrite =
       ASSIGN_AHEAD.test(after) ||
       INCDEC_AHEAD.test(after) ||


### PR DESCRIPTION
## The class

A field on the app store's `_ctx` (`packages/app/src/store/message-handler.ts`) can lose its last
reader — a guard is deleted, a branch simplified, a handler moved to store-core — while every
`_ctx.field = ...` survives. The result compiles, type-checks, lints and passes every test:
**writing to a field nobody reads is indistinguishable from working code.** TypeScript has nothing
to say either — `noUnusedLocals` does not reach interface members, and the field *is* "used", by
its own writes.

It has happened twice in a row in the same file:

| | field | shape |
|---|---|---|
| #7421 | `isSessionSwitchReplay` | 5 write sites, 0 readers — found by a manual archaeology pass |
| PR #7446, first commit (b31d01ca) | `pendingSwitchSessionId` | the **fix** for #7421 deleted its only reader and left the setter + 3 clears; caught only by the review panel, fixed in 052227e3 |

Two instances, the second created while removing the first, with nothing automated in between.

## The heuristic, and what it cannot see

For each field declared on `MessageHandlerContext` (and on base interfaces declared in the same
file — `EncryptionContext`), every `_ctx.<field>` / `ctx.<field>` reference in the app's **non-test**
sources is classified:

- **WRITE** — assignment target: `=` (not `==`/`===`/`=>`), any compound assignment (`+=`, `??=`,
  `>>>=`, …), `++`/`--` in either position, `delete`.
- **READ** — everything else: conditions, right-hand sides, property/method access through the field
  (`_ctx.set.clear()` must read `_ctx.set` first), template interpolations, arguments.

**≥1 write and 0 reads → fail**, naming the field and every write site.

Deliberate design choices, each stated in the script header rather than left implicit:

- **Comments are stripped before classification** — a commented-out reader must not mask a
  write-only field, and commenting out the dead reader is exactly how this arrives. The lexer leaves
  string, template-literal and regex-literal content intact (`${_ctx.field}` is a genuine read;
  `/a\/\/b/` must not be read as a comment).
- **Whole-file matching, never line-anchored.** `_ctx\n  .field` and `_ctx?.field` count. A
  line-anchored grep undercounts exactly this shape.
- **Test files are excluded from BOTH sides.** Not hypothetical: every mock context under
  `src/__tests__/store/` carried `isSessionSwitchReplay: false` for the whole life of that bug. A
  field read only by a test is still write-only in production.
- **Zero references warns, and does not fail.** Zero is the signature of both "dead field" and
  "reached some way this regex cannot see", and the live tree contains the second: `rttSmoother` is
  held on the context so a reset replaces it, while its two consumers close over the *local*
  `const rttSmoother` it was built from. It is never written either, so it is not this class, and
  failing on it would buy an allowlist entry that suppresses a whole category rather than a case.
  It is emitted as a GitHub `::warning::` on every run so it stays visible.
- **Not seen:** aliasing (`const c = _ctx; c.field`), `Object.assign`, spread copies,
  `_ctx['field']`, and destructuring reads. Aliasing lands in the warning bucket (safe direction); a
  field whose *only* reader destructures would be a false positive, resolved by an allowlist entry.
- **No new dependencies.** `scripts/` sits outside every workspace package and installs nothing —
  the Scripts Tests job does not run `npm ci` — so a real TS parse is not available here. The
  heuristic is honest about that rather than pretending to a parse it does not have.

**Allowlist:** entries require a justification string and expire — an entry naming a field that no
longer exists, or one whose field regained a reader, is refused as stale. **There are none today.**

**Fail-loud:** every "cannot check" is **exit 2, never exit 0** — missing declaring file, interface
not found (renamed / moved / converted to a type alias), unterminated body, **zero fields
extracted**, empty scan set, malformed allowlist entry. "Cannot check" silently read as "nothing to
check" is the catalogued false-safety shape (`docs/false-safety-guards.md`) and is the only way this
lint could be green while checking nothing.

## Red first

Proven red by restoring the real regressions in the working tree (byte backup + `cp` restore, every
scripted edit grep-verified, restored file SHA-256 re-checked against the backup).

**1. `git apply -R` of 052227e3 — PR #7446's first commit, exactly:**

```
::error::[write-only-ctx] app/MessageHandlerContext: MessageHandlerContext.pendingSwitchSessionId
  is WRITE-ONLY: 4 write site(s), 0 reads.
      write: packages/app/src/store/message-handler.ts:770
      write: packages/app/src/store/message-handler.ts:775
      write: packages/app/src/store/message-handler.ts:1861
      write: packages/app/src/store/message-handler.ts:2326
EXIT=1
```

The `#3121` comment block at line 2324 *mentions* the field; it is stripped, and correctly does not
count as a read.

**2. `git apply -R` of b31d01ca as well — the pre-#7446 tree, which is the two-sided control:**

```
::error::[write-only-ctx] app/MessageHandlerContext: MessageHandlerContext.isSessionSwitchReplay
  is WRITE-ONLY: 5 write site(s), 0 reads.
      write: .../message-handler.ts:777, 1864, 2335, 2455, 2581
EXIT=1
```

At that commit `pendingSwitchSessionId` still had its reader (the
`_ctx.pendingSwitchSessionId === switched.newSessionId` comparison) — and the lint **passes** it.
The same field is clean at one commit and red at the next, which is the sharpest false-positive
control available.

**3. Restored:** file SHA-256 identical to the pre-mutation backup, `git status` clean, lint exit 0.

## Controls and stats on current `main`

```
[write-only-ctx] app/MessageHandlerContext: 17 field(s), 111 source file(s),
  122 reference(s) classified — 16 read, 0 write-only, 1 unreferenced, 0 allowlisted.
```

- **Positive control:** exit 0 on `main` unmutated.
- **False-positive control (`--verbose`):** `replayingSessions` 10 reads / 0 writes;
  `postPermissionSplits` 5 / 0; `deltaIdRemaps` 8 / 0; `messageQueue` 10 / 0; `deltaFlusher` 8 / 0;
  `heartbeat` 7r/1w; `pendingKeyPair` 9r/9w; `pendingSalt` 7r/8w; `encryptionState` 7r/4w;
  `lastLatencyLogAt` 2r/2w; `terminalWriteTimer` 5r/3w; `pendingTerminalWrites` 2r/3w;
  `serverWillBootstrap` 2r/1w; `deltaServerTs` 5r/0w; `tokenToRender` / `clientRender` 2r/0w each.
  16 of 17 fields carry ≥1 read; the 17th is `rttSmoother` (the closure case above).
- **17 fields** = 14 declared on `MessageHandlerContext` + 3 inherited from `EncryptionContext`.

## The lint's own test

`scripts/__tests__/lint-write-only-ctx-fields.test.mjs` — 50 cases, no framework, exit-code based,
matching the sibling harnesses, with a `MIN_CASES` floor so a case that stops being discovered
breaks the run rather than shrinking it (#7447).

Covers: both real regressions as fixtures; a commented-out reader not rescuing a field; a test-file
reader not rescuing it; 11 read shapes and 7 write shapes individually; comment-lexer cases (a `//`
in a string, an escaped `//` in a regex, division vs regex, offset/line preservation); interface
extraction (nested object-type members, method and index signatures excluded, `extends` followed,
an imported base skipped); **every cannot-check path** (empty interface, missing interface,
unterminated body, empty scan set) at both the function and CLI-exit-code level; all four allowlist
refusals; the unreferenced-warns behaviour; and CLI exit codes 0/1/2 end to end against fixture
trees.

**Section 0 runs before this file imports the module, deliberately.** The module ends in
`process.exit(runCli())` under `isEntryPoint()`. If that guard read TRUE on a plain import, a static
import at the top would run the lint against the real repo and exit — before a single case ran,
printing nothing, exiting 0. A green run and a deleted suite would be identical (the "an entry-point
call site needs its own test file" trap, #7236). So the two call-site cases run out of process
first, behind a hard failure gate, and only then is the module imported. Mutating the guard to a
literal `true` now fails **by name** instead of erasing the run — verified.

**11 mutants, all killed** (module restored byte-identically after each; every mutation asserted to
have applied at exactly one site before the run):

| mutant | killed by |
|---|---|
| `isWrite` hardwired false | every RED case |
| comment stripping disabled | "a commented-out reader does not rescue" |
| zero-field extraction returns `[]` | empty-interface cannot-check + CLI exit 2 |
| allowlist justification unchecked | "an entry WITHOUT a justification is refused" |
| stale-allowlist check disabled | "an entry for a field that regained a reader" |
| empty scan set accepted as clean | "an EMPTY scan set is a cannot-check" |
| unterminated-body throw removed | "an UNTERMINATED interface body" |
| interface-not-found returns a stub | "a MISSING interface is a cannot-check" |
| test-path filter removed | "CLI ignores a reader in a test file" |
| optional-chaining / multi-line separators dropped from the matcher | those two read-shape cases |
| `isEntryPoint` stuck TRUE | section 0's probe |

## Where it runs

Two named steps in the **Scripts Tests** job (`.github/workflows/ci.yml`) — the test, then the lint
itself. That job has `setup-node` and deliberately no `npm ci`, which is exactly what a pure-node
dependency-free source scan needs; it is the same reason `compile-skill-targets --check` and the
AGENTS.md sync gate live there rather than in a package job. `ruby -ryaml` parse-checked, and
`packages/server/tests/ci-{workflow-reader,npm-cache-routing,cache-key}.test.js` re-run green
(30/30) against the edited workflow.

Also verified against the committed tree: `scripts/lint-no-nul-bytes.sh` clean, and
`packages/server/scripts/lint-entry-point-guard.mjs` clean (1989 files walked, 6 sanctioned).

## Deviations from the issue

- The issue's "and the dashboard's module-level `_ctx`-style state" is **not** covered: the
  dashboard keeps its per-connection state in module-level `let` bindings, not on a context object,
  so there is no interface to read fields off and its guard would be a different shape. The
  `TARGETS` table in the script is the place a second entry goes.
- The issue asks for a failure on zero-read fields generally; this fails on **write-only** and
  **warns** on zero-reference, for the `rttSmoother` reason above.

Closes #7452
