### PR TITLE
fix(dashboard): stale permission banners, a dangling active session, and the Devices-panel refresh loop

### DIFF
--- a/packages/dashboard/src/App.test.tsx
+++ b/packages/dashboard/src/App.test.tsx
@@ -3159,4 +3159,66 @@ describe('#7466 — cross-session permission banner, failed send', () => {
     fireEvent.click(screen.getByLabelText('Deny'))
     expect(dismissSessionNotification).toHaveBeenCalledWith('n-1')
   })
+
+  // #7466 review finding 1 — the App->banner WIRING of the third gate. The
+  // component's own behaviour is pinned in NotificationBannersStale.test.tsx;
+  // this pins that App actually feeds it `connectionPhase`, which is the
+  // "guard wired to only some of its callers" failure the component tests
+  // cannot see.
+  it('disables the banner buttons while the socket is down', () => {
+    stateOverrides = connectedWithBanner({ connectionPhase: 'reconnecting' })
+    render(<App />)
+    expect(screen.getByLabelText('Allow')).toBeDisabled()
+    expect(screen.getByLabelText('Deny')).toBeDisabled()
+    expect(screen.getByTestId('notification-banner-disconnected-hint')).toBeInTheDocument()
+  })
+
+  it('POSITIVE CONTROL: the same banner is enabled while connected', () => {
+    stateOverrides = connectedWithBanner()
+    render(<App />)
+    expect(screen.getByLabelText('Allow')).toBeEnabled()
+    expect(screen.queryByTestId('notification-banner-disconnected-hint')).not.toBeInTheDocument()
+  })
+
+  // #7466 review nit 5 — an INERT permission row retires by mark-read, not by
+  // deletion. Wiring-level: the component gets `onMarkRead`, and App must hand
+  // it `markSessionNotificationRead` rather than the removing `onDismiss`.
+  it('marks an inert permission row read instead of deleting it', () => {
+    const markSessionNotificationRead = vi.fn()
+    const dismissSessionNotification = vi.fn()
+    stateOverrides = connectedWithBanner({
+      markSessionNotificationRead,
+      dismissSessionNotification,
+      // A prompt the store has SEEN and knows is expired -> 'not-pending'.
+      // The rest of the SessionState shape is present because App reads several
+      // of these fields off the active session while rendering.
+      sessionStates: {
+        s1: {
+          messages: [{
+            id: 'm-1', type: 'prompt', content: 'Bash: rm -rf /tmp/x',
+            timestamp: 1, requestId: 'req-abc', expiresAt: Date.now() - 1,
+          }],
+          streamingMessageId: null,
+          activeModel: null,
+          permissionMode: null,
+          contextUsage: null,
+          sessionCost: null,
+          isIdle: true,
+          activeAgents: [],
+          isPlanPending: false,
+          systemMessages: [],
+          childAgentEvents: [],
+          sessionRules: [],
+          claudeReady: true,
+        },
+      },
+    })
+    render(<App />)
+
+    expect(screen.getByTestId('notification-banner-stale')).toBeInTheDocument()
+    expect(screen.queryByLabelText('Allow')).not.toBeInTheDocument()
+    fireEvent.click(screen.getByLabelText('Dismiss'))
+    expect(markSessionNotificationRead).toHaveBeenCalledWith('n-1')
+    expect(dismissSessionNotification).not.toHaveBeenCalled()
+  })
 })

--- a/packages/dashboard/src/App.test.tsx
+++ b/packages/dashboard/src/App.test.tsx
@@ -3077,3 +3077,86 @@ describe('App-level view-mode effect (#5998)', () => {
     expect(subscribeTerminalMirror).toHaveBeenLastCalledWith('s1')
   })
 })
+
+// ---------------------------------------------------------------------------
+// #7466 — a banner whose answer never went on the wire must not vanish
+// ---------------------------------------------------------------------------
+describe('#7466 — cross-session permission banner, failed send', () => {
+  const bannerSession = {
+    sessionId: 's1', name: 'Chroxy', cwd: '/tmp', type: 'cli' as const,
+    hasTerminal: true, model: null, permissionMode: null, isBusy: false,
+    createdAt: Date.now(), conversationId: null,
+  }
+
+  const livePermissionBanner = {
+    id: 'n-1',
+    sessionId: 's1',
+    sessionName: 'Chroxy',
+    eventType: 'permission' as const,
+    message: 'Bash: rm -rf /tmp/x',
+    timestamp: Date.now(),
+    requestId: 'req-abc',
+  }
+
+  function connectedWithBanner(overrides: Record<string, unknown> = {}) {
+    return {
+      connectionPhase: 'connected',
+      sessions: [bannerSession],
+      activeSessionId: 's1',
+      // No prompt message for req-abc anywhere: the banner's staleness gate is
+      // conservative on absence, so the buttons render. That keeps this case
+      // about the SEND result and nothing else.
+      sessionStates: {},
+      sessionNotifications: [livePermissionBanner],
+      ...overrides,
+    }
+  }
+
+  it('keeps the banner when sendPermissionResponse reports the send failed', () => {
+    // #6308/#5699: the socket can be OPEN at render and CLOSING by the click, and
+    // sendPermissionResponse returns false rather than throwing. Dismissing anyway
+    // deleted the row outright (dismissSessionNotification filters it out of the
+    // store) — so the operator's only record of the request was destroyed by a
+    // click that did nothing, and the banner stack collapsing under the cursor is
+    // what invites the second, mis-aimed click.
+    const sendPermissionResponse = vi.fn(() => false as const)
+    const dismissSessionNotification = vi.fn()
+    stateOverrides = connectedWithBanner({ sendPermissionResponse, dismissSessionNotification })
+    render(<App />)
+
+    fireEvent.click(screen.getByLabelText('Allow'))
+    expect(sendPermissionResponse).toHaveBeenCalledWith('req-abc', 'allow')
+    expect(dismissSessionNotification).not.toHaveBeenCalled()
+  })
+
+  it('keeps the banner when a Deny fails to send', () => {
+    const sendPermissionResponse = vi.fn(() => false as const)
+    const dismissSessionNotification = vi.fn()
+    stateOverrides = connectedWithBanner({ sendPermissionResponse, dismissSessionNotification })
+    render(<App />)
+
+    fireEvent.click(screen.getByLabelText('Deny'))
+    expect(sendPermissionResponse).toHaveBeenCalledWith('req-abc', 'deny')
+    expect(dismissSessionNotification).not.toHaveBeenCalled()
+  })
+
+  it('POSITIVE CONTROL: dismisses the banner when the answer WAS sent', () => {
+    const sendPermissionResponse = vi.fn(() => 'sent' as const)
+    const dismissSessionNotification = vi.fn()
+    stateOverrides = connectedWithBanner({ sendPermissionResponse, dismissSessionNotification })
+    render(<App />)
+
+    fireEvent.click(screen.getByLabelText('Allow'))
+    expect(dismissSessionNotification).toHaveBeenCalledWith('n-1')
+  })
+
+  it("POSITIVE CONTROL: dismisses on 'queued' too — a queued answer is not a failure", () => {
+    const sendPermissionResponse = vi.fn(() => 'queued' as const)
+    const dismissSessionNotification = vi.fn()
+    stateOverrides = connectedWithBanner({ sendPermissionResponse, dismissSessionNotification })
+    render(<App />)
+
+    fireEvent.click(screen.getByLabelText('Deny'))
+    expect(dismissSessionNotification).toHaveBeenCalledWith('n-1')
+  })
+})

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -57,7 +57,7 @@ import { BillingWarningBanner } from './components/BillingWarningBanner'
 import { ConnectionAnnouncer } from './components/ConnectionAnnouncer'
 import { StdinDisabledBanner } from './components/StdinDisabledBanner'
 import { WelcomeScreen } from './components/WelcomeScreen'
-import { NotificationBanners, isPermissionNotificationActionable } from './components/NotificationBanners'
+import { NotificationBanners, permissionNotificationStatus } from './components/NotificationBanners'
 import { PendingPairRequests } from './components/PendingPairRequests'
 import { type ToastItem } from './components/Toast'
 import { FileBrowserPanel } from './components/FileBrowserPanel'
@@ -2049,19 +2049,26 @@ export function App() {
     return result
   }, [sendUserQuestionResponse])
 
-  // #7466 — the banner's staleness gate. `sessionStates` is the store's own
-  // record of every prompt, and `isLivePermissionPrompt` (inside the helper) is
-  // the SAME signal the tab badge and jump-to-pending already use, so this adds
-  // no second notion of "still pending". Read at render time: `sessionStates` is
-  // replaced on every WS event, so a prompt the server retires (#7335 stamps
-  // `expiresAt`) disarms its banner on the next event, and a prompt that simply
-  // times out disarms on the next render past its deadline — the same way the
-  // inline PermissionPrompt's own countdown retires its buttons. The CLICK-time
-  // re-check lives in NotificationBanners itself (it calls the predicate again
+  // #7466 — the banner's staleness + connectivity gate. `sessionStates` is the
+  // store's own record of every prompt, and `isLivePermissionPrompt` (inside the
+  // helper) is the SAME signal the tab badge and jump-to-pending already use, so
+  // this adds no second notion of "still pending". Read at render time:
+  // `sessionStates` is replaced on every WS event, so a prompt the server retires
+  // (#7335 stamps `expiresAt`) disarms its banner on the next event, and a prompt
+  // that simply times out disarms on the next render past its deadline — the same
+  // way the inline PermissionPrompt's own countdown retires its buttons. The
+  // CLICK-time re-check lives in NotificationBanners itself (it calls this again
   // inside onClick): one place to gate, and reachable from a component test.
-  const isPermissionActionable = useCallback(
-    (n: SessionNotification) => isPermissionNotificationActionable(n, sessionStates, Date.now()),
-    [sessionStates],
+  //
+  // `connectionPhase === 'connected'` is the third gate, matching
+  // PermissionPrompt's `connected` — without it the banner showed ENABLED
+  // Allow/Deny over a dead socket, and since the handlers below correctly refuse
+  // to dismiss when the send fails, that click produced no observable change at
+  // all.
+  const permissionStatus = useCallback(
+    (n: SessionNotification) =>
+      permissionNotificationStatus(n, sessionStates, Date.now(), connectionPhase === 'connected'),
+    [sessionStates, connectionPhase],
   )
 
   // #6222/#6224: respondToPermission (sendPermissionResponse) now marks the
@@ -2593,8 +2600,9 @@ export function App() {
             onApprove={handleBannerApprove}
             onDeny={handleBannerDeny}
             onDismiss={dismissSessionNotification}
+            onMarkRead={markSessionNotificationRead}
             onSwitchSession={handleSwitchSession}
-            isPermissionActionable={isPermissionActionable}
+            permissionStatus={permissionStatus}
           />
         )}
 

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -2072,13 +2072,21 @@ export function App() {
   // consumers expect) and unconditional (it ran even when the send was refused
   // while disconnected, falsely clearing the prompt). Dropped in favour of the
   // single choke point.
+  // #7466 — dismiss ONLY when the answer actually went on the wire.
+  // `sendPermissionResponse` returns false without throwing when the socket is
+  // down or flipped OPEN -> CLOSING mid-send (#5699 / #6308), and
+  // `dismissSessionNotification` REMOVES the row from the store outright. So a
+  // click that achieved nothing used to delete the operator's only record of
+  // the request, and the banner stack collapsing under the cursor is what
+  // invites the second, mis-aimed click. 'queued' is not a failure — the
+  // message will send — so only an explicit `false` holds the row.
   const handleBannerApprove = useCallback((requestId: string, notificationId: string) => {
-    respondToPermission(requestId, 'allow')
+    if (respondToPermission(requestId, 'allow') === false) return
     dismissSessionNotification(notificationId)
   }, [respondToPermission, dismissSessionNotification])
 
   const handleBannerDeny = useCallback((requestId: string, notificationId: string) => {
-    respondToPermission(requestId, 'deny')
+    if (respondToPermission(requestId, 'deny') === false) return
     dismissSessionNotification(notificationId)
   }, [respondToPermission, dismissSessionNotification])
 

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -24,6 +24,7 @@ import {
 } from '@chroxy/store-core'
 import { useConnectionStore } from './store/connection'
 import type { BaseSessionState, ContextOccupancy } from '@chroxy/store-core'
+import type { SessionNotification } from './store/types'
 
 import { Sidebar, type RepoNode, type ContextMenuTarget } from './components/Sidebar'
 import { resolveActivePrimaryClientId } from './components/ViewersIndicator'
@@ -56,7 +57,7 @@ import { BillingWarningBanner } from './components/BillingWarningBanner'
 import { ConnectionAnnouncer } from './components/ConnectionAnnouncer'
 import { StdinDisabledBanner } from './components/StdinDisabledBanner'
 import { WelcomeScreen } from './components/WelcomeScreen'
-import { NotificationBanners } from './components/NotificationBanners'
+import { NotificationBanners, isPermissionNotificationActionable } from './components/NotificationBanners'
 import { PendingPairRequests } from './components/PendingPairRequests'
 import { type ToastItem } from './components/Toast'
 import { FileBrowserPanel } from './components/FileBrowserPanel'
@@ -2048,6 +2049,21 @@ export function App() {
     return result
   }, [sendUserQuestionResponse])
 
+  // #7466 — the banner's staleness gate. `sessionStates` is the store's own
+  // record of every prompt, and `isLivePermissionPrompt` (inside the helper) is
+  // the SAME signal the tab badge and jump-to-pending already use, so this adds
+  // no second notion of "still pending". Read at render time: `sessionStates` is
+  // replaced on every WS event, so a prompt the server retires (#7335 stamps
+  // `expiresAt`) disarms its banner on the next event, and a prompt that simply
+  // times out disarms on the next render past its deadline — the same way the
+  // inline PermissionPrompt's own countdown retires its buttons. The CLICK-time
+  // re-check lives in NotificationBanners itself (it calls the predicate again
+  // inside onClick): one place to gate, and reachable from a component test.
+  const isPermissionActionable = useCallback(
+    (n: SessionNotification) => isPermissionNotificationActionable(n, sessionStates, Date.now()),
+    [sessionStates],
+  )
+
   // #6222/#6224: respondToPermission (sendPermissionResponse) now marks the
   // prompt answered with the canonical decision token itself — only when the
   // answer actually went over the wire (after the disconnected-socket guard).
@@ -2570,6 +2586,7 @@ export function App() {
             onDeny={handleBannerDeny}
             onDismiss={dismissSessionNotification}
             onSwitchSession={handleSwitchSession}
+            isPermissionActionable={isPermissionActionable}
           />
         )}
 

--- a/packages/dashboard/src/components/NotificationBanners.test.tsx
+++ b/packages/dashboard/src/components/NotificationBanners.test.tsx
@@ -1,11 +1,11 @@
 /**
  * NotificationBanners — cross-session notification banners with quick-approve (#1369)
  *
- * Every render here passes `isPermissionActionable={() => true}` (#7466): these
- * cases predate the staleness gate and are about the LIVE-prompt rendering they
- * were written for. The gate's own behaviour — including that the prop is
- * required precisely so no call site can silently reopen the hole — is pinned in
- * NotificationBannersStale.test.tsx.
+ * Every render here passes `permissionStatus={() => 'actionable'}` (#7466): these
+ * cases predate the staleness/connectivity gate and are about the LIVE-prompt
+ * rendering they were written for. The gate's own behaviour — including that the
+ * prop is required precisely so no call site can silently reopen the hole — is
+ * pinned in NotificationBannersStale.test.tsx.
  */
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import { render, screen, fireEvent, cleanup } from '@testing-library/react'
@@ -38,7 +38,8 @@ describe('NotificationBanners', () => {
         onDeny={vi.fn()}
         onDismiss={vi.fn()}
         onSwitchSession={vi.fn()}
-        isPermissionActionable={() => true}
+        onMarkRead={vi.fn()}
+        permissionStatus={() => 'actionable' as const}
       />
     )
     expect(container.querySelector('.notification-banners')).not.toBeInTheDocument()
@@ -52,7 +53,8 @@ describe('NotificationBanners', () => {
         onDeny={vi.fn()}
         onDismiss={vi.fn()}
         onSwitchSession={vi.fn()}
-        isPermissionActionable={() => true}
+        onMarkRead={vi.fn()}
+        permissionStatus={() => 'actionable' as const}
       />
     )
     expect(screen.getByText('My Session')).toBeInTheDocument()
@@ -67,7 +69,8 @@ describe('NotificationBanners', () => {
         onDeny={vi.fn()}
         onDismiss={vi.fn()}
         onSwitchSession={vi.fn()}
-        isPermissionActionable={() => true}
+        onMarkRead={vi.fn()}
+        permissionStatus={() => 'actionable' as const}
       />
     )
     expect(screen.getByRole('button', { name: /allow/i })).toBeInTheDocument()
@@ -83,7 +86,8 @@ describe('NotificationBanners', () => {
         onDeny={vi.fn()}
         onDismiss={vi.fn()}
         onSwitchSession={vi.fn()}
-        isPermissionActionable={() => true}
+        onMarkRead={vi.fn()}
+        permissionStatus={() => 'actionable' as const}
       />
     )
     fireEvent.click(screen.getByRole('button', { name: /allow/i }))
@@ -99,7 +103,8 @@ describe('NotificationBanners', () => {
         onDeny={onDeny}
         onDismiss={vi.fn()}
         onSwitchSession={vi.fn()}
-        isPermissionActionable={() => true}
+        onMarkRead={vi.fn()}
+        permissionStatus={() => 'actionable' as const}
       />
     )
     fireEvent.click(screen.getByRole('button', { name: /deny/i }))
@@ -114,7 +119,8 @@ describe('NotificationBanners', () => {
         onDeny={vi.fn()}
         onDismiss={vi.fn()}
         onSwitchSession={vi.fn()}
-        isPermissionActionable={() => true}
+        onMarkRead={vi.fn()}
+        permissionStatus={() => 'actionable' as const}
       />
     )
     expect(screen.queryByRole('button', { name: /allow/i })).not.toBeInTheDocument()
@@ -130,7 +136,8 @@ describe('NotificationBanners', () => {
         onDeny={vi.fn()}
         onDismiss={onDismiss}
         onSwitchSession={vi.fn()}
-        isPermissionActionable={() => true}
+        onMarkRead={vi.fn()}
+        permissionStatus={() => 'actionable' as const}
       />
     )
     fireEvent.click(screen.getByRole('button', { name: /dismiss/i }))
@@ -146,7 +153,8 @@ describe('NotificationBanners', () => {
         onDeny={vi.fn()}
         onDismiss={vi.fn()}
         onSwitchSession={onSwitch}
-        isPermissionActionable={() => true}
+        onMarkRead={vi.fn()}
+        permissionStatus={() => 'actionable' as const}
       />
     )
     fireEvent.click(screen.getByText('My Session'))
@@ -168,7 +176,8 @@ describe('NotificationBanners', () => {
         onDeny={vi.fn()}
         onDismiss={vi.fn()}
         onSwitchSession={vi.fn()}
-        isPermissionActionable={() => true}
+        onMarkRead={vi.fn()}
+        permissionStatus={() => 'actionable' as const}
       />
     )
     // Should show 3 banners + overflow indicator
@@ -187,7 +196,8 @@ describe('NotificationBanners', () => {
         onDeny={vi.fn()}
         onDismiss={vi.fn()}
         onSwitchSession={vi.fn()}
-        isPermissionActionable={() => true}
+        onMarkRead={vi.fn()}
+        permissionStatus={() => 'actionable' as const}
       />
     )
     expect(screen.getByText(/Session crashed/)).toBeInTheDocument()
@@ -201,7 +211,8 @@ describe('NotificationBanners', () => {
         onDeny={vi.fn()}
         onDismiss={vi.fn()}
         onSwitchSession={vi.fn()}
-        isPermissionActionable={() => true}
+        onMarkRead={vi.fn()}
+        permissionStatus={() => 'actionable' as const}
       />
     )
     expect(screen.getByRole('log')).toBeInTheDocument()
@@ -225,7 +236,8 @@ describe('NotificationBanners — read/unread filtering (#4890)', () => {
         onDeny={vi.fn()}
         onDismiss={vi.fn()}
         onSwitchSession={vi.fn()}
-        isPermissionActionable={() => true}
+        onMarkRead={vi.fn()}
+        permissionStatus={() => 'actionable' as const}
       />
     )
     expect(container.querySelector('.notification-banners')).not.toBeInTheDocument()
@@ -242,7 +254,8 @@ describe('NotificationBanners — read/unread filtering (#4890)', () => {
         onDeny={vi.fn()}
         onDismiss={vi.fn()}
         onSwitchSession={vi.fn()}
-        isPermissionActionable={() => true}
+        onMarkRead={vi.fn()}
+        permissionStatus={() => 'actionable' as const}
       />
     )
     expect(screen.getByText('Unread Session')).toBeInTheDocument()
@@ -267,7 +280,8 @@ describe('NotificationBanners — read/unread filtering (#4890)', () => {
         onDeny={vi.fn()}
         onDismiss={vi.fn()}
         onSwitchSession={vi.fn()}
-        isPermissionActionable={() => true}
+        onMarkRead={vi.fn()}
+        permissionStatus={() => 'actionable' as const}
       />
     )
     expect(screen.getByText('Session 1')).toBeInTheDocument()

--- a/packages/dashboard/src/components/NotificationBanners.test.tsx
+++ b/packages/dashboard/src/components/NotificationBanners.test.tsx
@@ -1,5 +1,11 @@
 /**
  * NotificationBanners — cross-session notification banners with quick-approve (#1369)
+ *
+ * Every render here passes `isPermissionActionable={() => true}` (#7466): these
+ * cases predate the staleness gate and are about the LIVE-prompt rendering they
+ * were written for. The gate's own behaviour — including that the prop is
+ * required precisely so no call site can silently reopen the hole — is pinned in
+ * NotificationBannersStale.test.tsx.
  */
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import { render, screen, fireEvent, cleanup } from '@testing-library/react'
@@ -32,6 +38,7 @@ describe('NotificationBanners', () => {
         onDeny={vi.fn()}
         onDismiss={vi.fn()}
         onSwitchSession={vi.fn()}
+        isPermissionActionable={() => true}
       />
     )
     expect(container.querySelector('.notification-banners')).not.toBeInTheDocument()
@@ -45,6 +52,7 @@ describe('NotificationBanners', () => {
         onDeny={vi.fn()}
         onDismiss={vi.fn()}
         onSwitchSession={vi.fn()}
+        isPermissionActionable={() => true}
       />
     )
     expect(screen.getByText('My Session')).toBeInTheDocument()
@@ -59,6 +67,7 @@ describe('NotificationBanners', () => {
         onDeny={vi.fn()}
         onDismiss={vi.fn()}
         onSwitchSession={vi.fn()}
+        isPermissionActionable={() => true}
       />
     )
     expect(screen.getByRole('button', { name: /allow/i })).toBeInTheDocument()
@@ -74,6 +83,7 @@ describe('NotificationBanners', () => {
         onDeny={vi.fn()}
         onDismiss={vi.fn()}
         onSwitchSession={vi.fn()}
+        isPermissionActionable={() => true}
       />
     )
     fireEvent.click(screen.getByRole('button', { name: /allow/i }))
@@ -89,6 +99,7 @@ describe('NotificationBanners', () => {
         onDeny={onDeny}
         onDismiss={vi.fn()}
         onSwitchSession={vi.fn()}
+        isPermissionActionable={() => true}
       />
     )
     fireEvent.click(screen.getByRole('button', { name: /deny/i }))
@@ -103,6 +114,7 @@ describe('NotificationBanners', () => {
         onDeny={vi.fn()}
         onDismiss={vi.fn()}
         onSwitchSession={vi.fn()}
+        isPermissionActionable={() => true}
       />
     )
     expect(screen.queryByRole('button', { name: /allow/i })).not.toBeInTheDocument()
@@ -118,6 +130,7 @@ describe('NotificationBanners', () => {
         onDeny={vi.fn()}
         onDismiss={onDismiss}
         onSwitchSession={vi.fn()}
+        isPermissionActionable={() => true}
       />
     )
     fireEvent.click(screen.getByRole('button', { name: /dismiss/i }))
@@ -133,6 +146,7 @@ describe('NotificationBanners', () => {
         onDeny={vi.fn()}
         onDismiss={vi.fn()}
         onSwitchSession={onSwitch}
+        isPermissionActionable={() => true}
       />
     )
     fireEvent.click(screen.getByText('My Session'))
@@ -154,6 +168,7 @@ describe('NotificationBanners', () => {
         onDeny={vi.fn()}
         onDismiss={vi.fn()}
         onSwitchSession={vi.fn()}
+        isPermissionActionable={() => true}
       />
     )
     // Should show 3 banners + overflow indicator
@@ -172,6 +187,7 @@ describe('NotificationBanners', () => {
         onDeny={vi.fn()}
         onDismiss={vi.fn()}
         onSwitchSession={vi.fn()}
+        isPermissionActionable={() => true}
       />
     )
     expect(screen.getByText(/Session crashed/)).toBeInTheDocument()
@@ -185,6 +201,7 @@ describe('NotificationBanners', () => {
         onDeny={vi.fn()}
         onDismiss={vi.fn()}
         onSwitchSession={vi.fn()}
+        isPermissionActionable={() => true}
       />
     )
     expect(screen.getByRole('log')).toBeInTheDocument()
@@ -208,6 +225,7 @@ describe('NotificationBanners — read/unread filtering (#4890)', () => {
         onDeny={vi.fn()}
         onDismiss={vi.fn()}
         onSwitchSession={vi.fn()}
+        isPermissionActionable={() => true}
       />
     )
     expect(container.querySelector('.notification-banners')).not.toBeInTheDocument()
@@ -224,6 +242,7 @@ describe('NotificationBanners — read/unread filtering (#4890)', () => {
         onDeny={vi.fn()}
         onDismiss={vi.fn()}
         onSwitchSession={vi.fn()}
+        isPermissionActionable={() => true}
       />
     )
     expect(screen.getByText('Unread Session')).toBeInTheDocument()
@@ -248,6 +267,7 @@ describe('NotificationBanners — read/unread filtering (#4890)', () => {
         onDeny={vi.fn()}
         onDismiss={vi.fn()}
         onSwitchSession={vi.fn()}
+        isPermissionActionable={() => true}
       />
     )
     expect(screen.getByText('Session 1')).toBeInTheDocument()

--- a/packages/dashboard/src/components/NotificationBanners.tsx
+++ b/packages/dashboard/src/components/NotificationBanners.tsx
@@ -13,8 +13,18 @@
  * target session out on switch; the new model achieves the same visual
  * outcome — banners vanish for the active session — while keeping the
  * widget's history populated.
+ *
+ * #7466 — a permission banner's Allow/Deny is gated on `isPermissionActionable`.
+ * The inline `PermissionPrompt` has always had three gates (answered / its own
+ * countdown / connected); the banner had none, so a request that stopped being
+ * pending without an inbound `permission_expired` kept live buttons forever
+ * while the inline prompt for the SAME request had already gone inert. The prop
+ * is REQUIRED and has no default: defaulting to "actionable" is precisely the
+ * hole being closed, and a default would let a future call site reopen it
+ * silently.
  */
-import type { SessionNotification } from '../store/types'
+import { isLivePermissionPrompt } from '@chroxy/store-core'
+import type { ChatMessage, SessionNotification } from '../store/types'
 
 const MAX_VISIBLE = 3
 
@@ -25,12 +35,55 @@ const EVENT_LABELS: Record<SessionNotification['eventType'], string> = {
   error: 'Error',
 }
 
+/**
+ * #7466 — is this banner's permission still answerable?
+ *
+ * Reuses `isLivePermissionPrompt` (@chroxy/store-core), the single shared signal
+ * that already drives the per-tab pending badge and jump-to-pending, instead of
+ * inventing a second client-side notion of "still pending" (#7390).
+ *
+ * CONSERVATIVE ON ABSENCE. A banner can exist before `sessionStates` holds the
+ * prompt — that is exactly why `sendPermissionResponse` prefers the notification
+ * lookup over a `sessionStates` scan — so "no prompt found" returns true and the
+ * buttons stay. Only a prompt the store has SEEN and knows to be expired or
+ * already-decided disarms the row.
+ *
+ * The prompt is searched in the notification's own session first, then across
+ * every session: the banner is cross-session by definition, and a prompt can be
+ * filed under an id the notification does not name.
+ */
+export function isPermissionNotificationActionable(
+  n: SessionNotification,
+  sessionStates: Record<string, { messages: ChatMessage[] }>,
+  now: number,
+): boolean {
+  if (n.eventType !== 'permission' || !n.requestId) return true
+  const requestId = n.requestId
+  const match = (messages: ChatMessage[] | undefined) =>
+    messages?.find((m) => m.requestId === requestId && m.type === 'prompt')
+  const own = match(sessionStates[n.sessionId]?.messages)
+  if (own) return isLivePermissionPrompt(own, now)
+  for (const sid in sessionStates) {
+    if (sid === n.sessionId) continue
+    const found = match(sessionStates[sid]?.messages)
+    if (found) return isLivePermissionPrompt(found, now)
+  }
+  return true
+}
+
 export interface NotificationBannersProps {
   notifications: SessionNotification[]
   onApprove: (requestId: string, notificationId: string) => void
   onDeny: (requestId: string, notificationId: string) => void
   onDismiss: (notificationId: string) => void
   onSwitchSession: (sessionId: string) => void
+  /**
+   * #7466 — REQUIRED, deliberately without a default. Returns false once the
+   * store knows the request is no longer pending; the row then renders as an
+   * inert record (never as live buttons) with a Dismiss, so the trace of the
+   * request survives the way #7353 asks.
+   */
+  isPermissionActionable: (n: SessionNotification) => boolean
 }
 
 export function NotificationBanners({
@@ -39,6 +92,7 @@ export function NotificationBanners({
   onDeny,
   onDismiss,
   onSwitchSession,
+  isPermissionActionable,
 }: NotificationBannersProps) {
   // #4890 — render unread only; read history lives in the widget.
   const unread = notifications.filter((n) => n.readAt === undefined)
@@ -68,13 +122,19 @@ export function NotificationBanners({
             <span className="notification-banner-message">{n.message}</span>
           </div>
           <div className="notification-banner-actions">
-            {n.eventType === 'permission' && n.requestId ? (
+            {n.eventType === 'permission' && n.requestId && isPermissionActionable(n) ? (
               <>
                 <button
                   type="button"
                   className="notification-banner-btn notification-banner-btn--allow"
                   aria-label="Allow"
-                  onClick={() => onApprove(n.requestId!, n.id)}
+                  // #7466 — re-check at CLICK time. The render gate is
+                  // evaluated with the `Date.now()` of the LAST render, and
+                  // nothing re-renders on the mere passage of a deadline, so a
+                  // prompt can cross its expiry with the buttons still on
+                  // screen. A dead click that fires `permission_response` into
+                  // the void is the "the click ACTS" half of #7466.
+                  onClick={() => { if (isPermissionActionable(n)) onApprove(n.requestId!, n.id) }}
                 >
                   Allow
                 </button>
@@ -82,20 +142,33 @@ export function NotificationBanners({
                   type="button"
                   className="notification-banner-btn notification-banner-btn--deny"
                   aria-label="Deny"
-                  onClick={() => onDeny(n.requestId!, n.id)}
+                  onClick={() => { if (isPermissionActionable(n)) onDeny(n.requestId!, n.id) }}
                 >
                   Deny
                 </button>
               </>
             ) : (
-              <button
-                type="button"
-                className="notification-banner-btn notification-banner-btn--dismiss"
-                aria-label="Dismiss"
-                onClick={() => onDismiss(n.id)}
-              >
-                Dismiss
-              </button>
+              <>
+                {/* #7466 — say WHY the buttons are gone. A silently button-less
+                    permission banner reads as a rendering bug; this reads as the
+                    record it now is. */}
+                {n.eventType === 'permission' && n.requestId && (
+                  <span
+                    className="notification-banner-stale"
+                    data-testid="notification-banner-stale"
+                  >
+                    No longer pending
+                  </span>
+                )}
+                <button
+                  type="button"
+                  className="notification-banner-btn notification-banner-btn--dismiss"
+                  aria-label="Dismiss"
+                  onClick={() => onDismiss(n.id)}
+                >
+                  Dismiss
+                </button>
+              </>
             )}
           </div>
         </div>

--- a/packages/dashboard/src/components/NotificationBanners.tsx
+++ b/packages/dashboard/src/components/NotificationBanners.tsx
@@ -14,14 +14,25 @@
  * outcome — banners vanish for the active session — while keeping the
  * widget's history populated.
  *
- * #7466 — a permission banner's Allow/Deny is gated on `isPermissionActionable`.
+ * #7466 — a permission banner's Allow/Deny is gated on `permissionStatus`.
  * The inline `PermissionPrompt` has always had three gates (answered / its own
- * countdown / connected); the banner had none, so a request that stopped being
+ * countdown / connected); the banner had NONE, so a request that stopped being
  * pending without an inbound `permission_expired` kept live buttons forever
- * while the inline prompt for the SAME request had already gone inert. The prop
- * is REQUIRED and has no default: defaulting to "actionable" is precisely the
- * hole being closed, and a default would let a future call site reopen it
- * silently.
+ * while the inline prompt for the SAME request had already gone inert.
+ *
+ * The banner now honours all three, and they are NOT two implementations of one
+ * rule: the two shapes cannot share code, so they are cross-referenced instead.
+ * `PermissionPrompt` answers "can I act?" from a monotonic `performance.now()`
+ * countdown local to the mounted prompt (#3619) plus a `resolvedPermissions`
+ * lookup; the banner has no countdown and no mount lifetime to anchor one to, so
+ * it answers the same question from store state — `isLivePermissionPrompt` over
+ * the prompt ChatMessage, which is the signal the tab badge and jump-to-pending
+ * already use (#7390). Same three gates, two vantage points. If you change one,
+ * change the other: `PermissionPrompt.tsx` `respond()` and `showButtons`.
+ *
+ * The prop is REQUIRED and has no default: defaulting to "actionable" is
+ * precisely the hole being closed, and a default would let a future call site
+ * reopen it silently.
  */
 import { isLivePermissionPrompt } from '@chroxy/store-core'
 import type { ChatMessage, SessionNotification } from '../store/types'
@@ -36,7 +47,20 @@ const EVENT_LABELS: Record<SessionNotification['eventType'], string> = {
 }
 
 /**
- * #7466 — is this banner's permission still answerable?
+ * #7466 — the three states a permission banner's action area can be in.
+ *
+ * `disconnected` is deliberately NOT collapsed into `not-pending`: the request
+ * is still live and becomes answerable again on reconnect, so the row must keep
+ * its (disabled) buttons and say why — exactly what the inline prompt does with
+ * `disabled={submitting || !connected}` + `perm-disconnected-hint`. Rendering it
+ * as a dead record would be a lie, and silently leaving the buttons enabled is
+ * the dead click `sendPermissionResponse`'s own contract comment
+ * (`connection.ts:3718-3721`) exists to prevent.
+ */
+export type PermissionBannerStatus = 'actionable' | 'disconnected' | 'not-pending'
+
+/**
+ * #7466 — is this banner's permission still answerable, and if not, why not?
  *
  * Reuses `isLivePermissionPrompt` (@chroxy/store-core), the single shared signal
  * that already drives the per-tab pending badge and jump-to-pending, instead of
@@ -44,20 +68,33 @@ const EVENT_LABELS: Record<SessionNotification['eventType'], string> = {
  *
  * CONSERVATIVE ON ABSENCE. A banner can exist before `sessionStates` holds the
  * prompt — that is exactly why `sendPermissionResponse` prefers the notification
- * lookup over a `sessionStates` scan — so "no prompt found" returns true and the
- * buttons stay. Only a prompt the store has SEEN and knows to be expired or
- * already-decided disarms the row.
+ * lookup over a `sessionStates` scan — so "no prompt found" counts as pending and
+ * the buttons stay. Only a prompt the store has SEEN and knows to be expired or
+ * already-decided reports `not-pending`.
  *
  * The prompt is searched in the notification's own session first, then across
  * every session: the banner is cross-session by definition, and a prompt can be
  * filed under an id the notification does not name.
  */
-export function isPermissionNotificationActionable(
+export function permissionNotificationStatus(
+  n: SessionNotification,
+  sessionStates: Record<string, { messages: ChatMessage[] }>,
+  now: number,
+  connected: boolean,
+): PermissionBannerStatus {
+  if (n.eventType !== 'permission' || !n.requestId) return 'actionable'
+  if (!isStillPending(n, sessionStates, now)) return 'not-pending'
+  // Pending-ness is checked FIRST: a request that already expired is dead
+  // whether or not the socket is up, and offering "reconnect to answer" for a
+  // prompt nobody can answer any more would be the same overpromise in reverse.
+  return connected ? 'actionable' : 'disconnected'
+}
+
+function isStillPending(
   n: SessionNotification,
   sessionStates: Record<string, { messages: ChatMessage[] }>,
   now: number,
 ): boolean {
-  if (n.eventType !== 'permission' || !n.requestId) return true
   const requestId = n.requestId
   const match = (messages: ChatMessage[] | undefined) =>
     messages?.find((m) => m.requestId === requestId && m.type === 'prompt')
@@ -76,14 +113,25 @@ export interface NotificationBannersProps {
   onApprove: (requestId: string, notificationId: string) => void
   onDeny: (requestId: string, notificationId: string) => void
   onDismiss: (notificationId: string) => void
+  /**
+   * #7466 — how an INERT permission row is retired. `onDismiss` REMOVES the row
+   * from the store (`connection.ts` dismissSessionNotification), which is the
+   * wrong verb for a row whose entire remaining purpose is to be a record: it
+   * would erase the trace of the request the gate was added to preserve
+   * (#7353). Mark-read stamps `readAt`, which drops the row from this banner
+   * stack (it filters on `readAt === undefined`) while the #4890 notifications
+   * widget keeps it in its durable history. Non-permission banners keep the
+   * pre-existing `onDismiss` semantics — nothing about those changed.
+   */
+  onMarkRead: (notificationId: string) => void
   onSwitchSession: (sessionId: string) => void
   /**
-   * #7466 — REQUIRED, deliberately without a default. Returns false once the
-   * store knows the request is no longer pending; the row then renders as an
-   * inert record (never as live buttons) with a Dismiss, so the trace of the
-   * request survives the way #7353 asks.
+   * #7466 — REQUIRED, deliberately without a default. Reports whether the
+   * request is answerable right now, and when it is not, which of the two
+   * reasons applies. A default of 'actionable' is precisely the hole being
+   * closed, so there isn't one.
    */
-  isPermissionActionable: (n: SessionNotification) => boolean
+  permissionStatus: (n: SessionNotification) => PermissionBannerStatus
 }
 
 export function NotificationBanners({
@@ -91,8 +139,9 @@ export function NotificationBanners({
   onApprove,
   onDeny,
   onDismiss,
+  onMarkRead,
   onSwitchSession,
-  isPermissionActionable,
+  permissionStatus,
 }: NotificationBannersProps) {
   // #4890 — render unread only; read history lives in the widget.
   const unread = notifications.filter((n) => n.readAt === undefined)
@@ -103,7 +152,14 @@ export function NotificationBanners({
 
   return (
     <div className="notification-banners" role="log" aria-label="Background session notifications">
-      {visible.map((n) => (
+      {visible.map((n) => {
+        const isPermission = n.eventType === 'permission' && !!n.requestId
+        // Computed ONCE per row for the render branch; the click handlers call
+        // `permissionStatus` again rather than closing over this value, because
+        // the socket can drop (or the deadline pass) between the render and the
+        // click and nothing re-renders on either — the #6308 TOCTOU.
+        const status: PermissionBannerStatus = isPermission ? permissionStatus(n) : 'actionable'
+        return (
         <div
           key={n.id}
           className={`notification-banner notification-banner--${n.eventType}`}
@@ -122,19 +178,59 @@ export function NotificationBanners({
             <span className="notification-banner-message">{n.message}</span>
           </div>
           <div className="notification-banner-actions">
-            {n.eventType === 'permission' && n.requestId && isPermissionActionable(n) ? (
+            {!isPermission ? (
+              <button
+                type="button"
+                className="notification-banner-btn notification-banner-btn--dismiss"
+                aria-label="Dismiss"
+                onClick={() => onDismiss(n.id)}
+              >
+                Dismiss
+              </button>
+            ) : status === 'not-pending' ? (
+              <>
+                {/* #7466 — say WHY the buttons are gone. A silently button-less
+                    permission banner reads as a rendering bug; this reads as the
+                    record it now is. */}
+                <span
+                  className="notification-banner-stale"
+                  data-testid="notification-banner-stale"
+                >
+                  No longer pending
+                </span>
+                <button
+                  type="button"
+                  className="notification-banner-btn notification-banner-btn--dismiss"
+                  aria-label="Dismiss"
+                  // #7466 — mark-read, NOT remove. See `onMarkRead` above: this
+                  // row exists only as a record now, and `onDismiss` would
+                  // delete the very trace the gate was added to keep (#7353).
+                  onClick={() => onMarkRead(n.id)}
+                >
+                  Dismiss
+                </button>
+              </>
+            ) : (
               <>
                 <button
                   type="button"
                   className="notification-banner-btn notification-banner-btn--allow"
                   aria-label="Allow"
-                  // #7466 — re-check at CLICK time. The render gate is
-                  // evaluated with the `Date.now()` of the LAST render, and
+                  // #7466 — disabled while the socket is down, mirroring the
+                  // inline prompt. `sendPermissionResponse` refuses to send when
+                  // disconnected and returns false, and the banner handlers now
+                  // correctly decline to dismiss on that false — which, without
+                  // this, makes a disconnected click produce NO observable change
+                  // at all. A disabled button with a reason is the feedback
+                  // `connection.ts:3718-3721` promises.
+                  disabled={status === 'disconnected'}
+                  // Re-check at CLICK time. The render gate is evaluated with the
+                  // `Date.now()` and connection phase of the LAST render, and
                   // nothing re-renders on the mere passage of a deadline, so a
-                  // prompt can cross its expiry with the buttons still on
-                  // screen. A dead click that fires `permission_response` into
-                  // the void is the "the click ACTS" half of #7466.
-                  onClick={() => { if (isPermissionActionable(n)) onApprove(n.requestId!, n.id) }}
+                  // prompt can cross its expiry with the buttons still on screen.
+                  // A dead click that fires `permission_response` into the void is
+                  // the "the click ACTS" half of #7466.
+                  onClick={() => { if (permissionStatus(n) === 'actionable') onApprove(n.requestId!, n.id) }}
                 >
                   Allow
                 </button>
@@ -142,37 +238,29 @@ export function NotificationBanners({
                   type="button"
                   className="notification-banner-btn notification-banner-btn--deny"
                   aria-label="Deny"
-                  onClick={() => { if (isPermissionActionable(n)) onDeny(n.requestId!, n.id) }}
+                  disabled={status === 'disconnected'}
+                  onClick={() => { if (permissionStatus(n) === 'actionable') onDeny(n.requestId!, n.id) }}
                 >
                   Deny
                 </button>
-              </>
-            ) : (
-              <>
-                {/* #7466 — say WHY the buttons are gone. A silently button-less
-                    permission banner reads as a rendering bug; this reads as the
-                    record it now is. */}
-                {n.eventType === 'permission' && n.requestId && (
+                {status === 'disconnected' && (
+                  // Same words as the inline prompt's `perm-disconnected-hint`
+                  // (PermissionPrompt.tsx) on purpose — one vocabulary for one
+                  // condition, whichever surface the operator is looking at.
                   <span
-                    className="notification-banner-stale"
-                    data-testid="notification-banner-stale"
+                    className="notification-banner-hint"
+                    data-testid="notification-banner-disconnected-hint"
+                    role="status"
                   >
-                    No longer pending
+                    Disconnected — reconnect to answer.
                   </span>
                 )}
-                <button
-                  type="button"
-                  className="notification-banner-btn notification-banner-btn--dismiss"
-                  aria-label="Dismiss"
-                  onClick={() => onDismiss(n.id)}
-                >
-                  Dismiss
-                </button>
               </>
             )}
           </div>
         </div>
-      ))}
+        )
+      })}
       {overflow > 0 && (
         <div className="notification-banner-overflow">
           +{overflow} more

--- a/packages/dashboard/src/components/NotificationBannersStale.test.tsx
+++ b/packages/dashboard/src/components/NotificationBannersStale.test.tsx
@@ -4,7 +4,8 @@
  *
  * The inline `PermissionPrompt` has three independent gates on its buttons
  * (`answered`, its own `remaining <= 0` countdown, and `connected` —
- * PermissionPrompt.tsx). The banner had NONE: it rendered Allow/Deny for any
+ * PermissionPrompt.tsx). The banner now honours all three; it had NONE, and
+ * rendered Allow/Deny for any
  * unread notification with `eventType === 'permission'` and a `requestId`, and
  * `SessionNotification` carries no expiry of its own. So the banner depended
  * entirely on an inbound `permission_expired` / `permission_resolved` arriving
@@ -26,7 +27,7 @@ import { describe, it, expect, vi, afterEach } from 'vitest'
 import { render, screen, fireEvent, cleanup } from '@testing-library/react'
 import {
   NotificationBanners,
-  isPermissionNotificationActionable,
+  permissionNotificationStatus,
 } from './NotificationBanners'
 import type { ChatMessage, SessionNotification } from '../store/types'
 
@@ -63,68 +64,102 @@ function states(messages: ChatMessage[], sessionId = 'sess-1') {
   return { [sessionId]: { messages } }
 }
 
-describe('#7466 — isPermissionNotificationActionable', () => {
-  it('is TRUE for a prompt that is still live', () => {
+describe('#7466 — permissionNotificationStatus', () => {
+  it("is 'actionable' for a prompt that is still live on a live socket", () => {
     expect(
-      isPermissionNotificationActionable(notification(), states([prompt()]), NOW),
-    ).toBe(true)
+      permissionNotificationStatus(notification(), states([prompt()]), NOW, true),
+    ).toBe('actionable')
   })
 
-  it('is FALSE once the prompt has timed out (expiresAt in the past)', () => {
+  it("is 'not-pending' once the prompt has timed out (expiresAt in the past)", () => {
     expect(
-      isPermissionNotificationActionable(
+      permissionNotificationStatus(
         notification(),
         states([prompt({ expiresAt: NOW - 1 })]),
         NOW,
+        true,
       ),
-    ).toBe(false)
+    ).toBe('not-pending')
   })
 
-  it('is FALSE once the prompt carries a decision (answered elsewhere)', () => {
+  it("is 'not-pending' once the prompt carries a decision (answered elsewhere)", () => {
     expect(
-      isPermissionNotificationActionable(
+      permissionNotificationStatus(
         notification(),
         states([prompt({ answered: 'allow' } as Partial<ChatMessage>)]),
         NOW,
+        true,
       ),
-    ).toBe(false)
+    ).toBe('not-pending')
   })
 
-  it('is FALSE when the server retired the card by stamping expiresAt to now (#7335)', () => {
+  it("is 'not-pending' when the server retired the card by stamping expiresAt to now (#7335)", () => {
     expect(
-      isPermissionNotificationActionable(
+      permissionNotificationStatus(
         notification(),
         states([prompt({ expiresAt: NOW })]),
         NOW,
+        true,
       ),
-    ).toBe(false)
+    ).toBe('not-pending')
   })
 
   it('finds the prompt under ANOTHER session id — the banner is cross-session', () => {
     expect(
-      isPermissionNotificationActionable(
+      permissionNotificationStatus(
         notification({ sessionId: 'sess-not-seeded' }),
         states([prompt({ expiresAt: NOW - 1 })], 'sess-other'),
         NOW,
+        true,
       ),
-    ).toBe(false)
+    ).toBe('not-pending')
   })
 
-  it('CONSERVATIVE: is TRUE when the store has no prompt for the requestId at all', () => {
+  it("CONSERVATIVE: is 'actionable' when the store has no prompt for the requestId at all", () => {
     // A banner can exist before sessionStates holds the prompt (the same case
     // sendPermissionResponse's notification-first lookup exists for). Disarming
     // it on absence would break live prompts, so absence means "keep the buttons".
-    expect(isPermissionNotificationActionable(notification(), states([]), NOW)).toBe(true)
+    expect(permissionNotificationStatus(notification(), states([]), NOW, true)).toBe('actionable')
   })
 
-  it('CONSERVATIVE: is TRUE for a non-permission notification', () => {
+  it("CONSERVATIVE: is 'actionable' for a non-permission notification", () => {
     expect(
-      isPermissionNotificationActionable(
+      permissionNotificationStatus(
         notification({ eventType: 'completed', requestId: undefined }),
         states([]),
         NOW,
+        true,
       ),
-    ).toBe(true)
+    ).toBe('actionable')
+  })
+
+  // ---- the third gate (#7466 review finding 1) ----
+
+  it("is 'disconnected' for a LIVE prompt while the socket is down", () => {
+    expect(
+      permissionNotificationStatus(notification(), states([prompt()]), NOW, false),
+    ).toBe('disconnected')
+  })
+
+  it("prefers 'not-pending' over 'disconnected' for a DEAD prompt on a dead socket", () => {
+    // Order matters: an expired request is dead whether or not the socket is up,
+    // and offering "reconnect to answer" for a prompt nobody can answer any more
+    // would be the same overpromise in reverse.
+    expect(
+      permissionNotificationStatus(
+        notification(),
+        states([prompt({ expiresAt: NOW - 1 })]),
+        NOW,
+        false,
+      ),
+    ).toBe('not-pending')
+  })
+
+  it("is 'disconnected' on the conservative-absence path too", () => {
+    // Absence means "assume pending" — which must then still respect the socket,
+    // or the most common banner shape (no prompt in sessionStates yet) keeps
+    // fully enabled buttons over a dead socket, i.e. the whole hole reopens.
+    expect(permissionNotificationStatus(notification(), states([]), NOW, false)).toBe('disconnected')
   })
 })
 
@@ -137,7 +172,8 @@ describe('#7466 — NotificationBanners renders a stale permission inert', () =>
         onDeny={vi.fn()}
         onDismiss={vi.fn()}
         onSwitchSession={vi.fn()}
-        isPermissionActionable={() => true}
+        onMarkRead={vi.fn()}
+        permissionStatus={() => 'actionable'}
       />,
     )
     expect(screen.getByLabelText('Allow')).toBeInTheDocument()
@@ -153,7 +189,8 @@ describe('#7466 — NotificationBanners renders a stale permission inert', () =>
         onDeny={vi.fn()}
         onDismiss={vi.fn()}
         onSwitchSession={vi.fn()}
-        isPermissionActionable={() => false}
+        onMarkRead={vi.fn()}
+        permissionStatus={() => 'not-pending'}
       />,
     )
     expect(screen.queryByLabelText('Allow')).not.toBeInTheDocument()
@@ -161,7 +198,14 @@ describe('#7466 — NotificationBanners renders a stale permission inert', () =>
   })
 
   it('keeps the row and offers Dismiss instead — the record survives (#7353)', () => {
+    // Dismissing an INERT permission row MARKS IT READ; it does not delete it.
+    // `dismissSessionNotification` removes the entry from the store outright,
+    // which would erase the very trace this gate was added to preserve — the
+    // #7353 complaint, reintroduced by the affordance meant to answer it.
+    // Mark-read drops the row from THIS banner stack (it filters on
+    // `readAt === undefined`) while the #4890 widget keeps it in its history.
     const onDismiss = vi.fn()
+    const onMarkRead = vi.fn()
     render(
       <NotificationBanners
         notifications={[notification()]}
@@ -169,7 +213,8 @@ describe('#7466 — NotificationBanners renders a stale permission inert', () =>
         onDeny={vi.fn()}
         onDismiss={onDismiss}
         onSwitchSession={vi.fn()}
-        isPermissionActionable={() => false}
+        onMarkRead={onMarkRead}
+        permissionStatus={() => 'not-pending'}
       />,
     )
     // Still says what was asked, and by whom.
@@ -177,7 +222,31 @@ describe('#7466 — NotificationBanners renders a stale permission inert', () =>
     expect(screen.getByText(/rm -rf \/tmp\/x/)).toBeInTheDocument()
     expect(screen.getByTestId('notification-banner-stale')).toBeInTheDocument()
     fireEvent.click(screen.getByLabelText('Dismiss'))
+    expect(onMarkRead).toHaveBeenCalledWith('n-1')
+    expect(onDismiss).not.toHaveBeenCalled()
+  })
+
+  it('a NON-permission banner still deletes on Dismiss — those semantics are untouched', () => {
+    // The mark-read verb is scoped to the inert permission row. A 'completed' or
+    // 'error' banner is not a record of a dropped capability and keeps the
+    // pre-existing behaviour; widening it here would be an unrequested change to
+    // three other banner types.
+    const onDismiss = vi.fn()
+    const onMarkRead = vi.fn()
+    render(
+      <NotificationBanners
+        notifications={[notification({ eventType: 'completed', requestId: undefined })]}
+        onApprove={vi.fn()}
+        onDeny={vi.fn()}
+        onDismiss={onDismiss}
+        onSwitchSession={vi.fn()}
+        onMarkRead={onMarkRead}
+        permissionStatus={() => 'actionable'}
+      />,
+    )
+    fireEvent.click(screen.getByLabelText('Dismiss'))
     expect(onDismiss).toHaveBeenCalledWith('n-1')
+    expect(onMarkRead).not.toHaveBeenCalled()
   })
 
   it('gates per row: a live banner keeps its buttons while a stale sibling loses them', () => {
@@ -191,7 +260,8 @@ describe('#7466 — NotificationBanners renders a stale permission inert', () =>
         onDeny={vi.fn()}
         onDismiss={vi.fn()}
         onSwitchSession={vi.fn()}
-        isPermissionActionable={(n) => n.requestId === 'req-live'}
+        onMarkRead={vi.fn()}
+        permissionStatus={(n) => (n.requestId === 'req-live' ? 'actionable' : 'not-pending')}
       />,
     )
     expect(screen.getAllByLabelText('Allow')).toHaveLength(1)
@@ -213,7 +283,8 @@ describe('#7466 — NotificationBanners renders a stale permission inert', () =>
         onDeny={onDeny}
         onDismiss={vi.fn()}
         onSwitchSession={vi.fn()}
-        isPermissionActionable={() => live}
+        onMarkRead={vi.fn()}
+        permissionStatus={() => (live ? 'actionable' : 'not-pending')}
       />,
     )
     // Rendered live: the buttons exist.
@@ -236,12 +307,101 @@ describe('#7466 — NotificationBanners renders a stale permission inert', () =>
         onDeny={onDeny}
         onDismiss={vi.fn()}
         onSwitchSession={vi.fn()}
-        isPermissionActionable={() => true}
+        onMarkRead={vi.fn()}
+        permissionStatus={() => 'actionable'}
       />,
     )
     fireEvent.click(screen.getByLabelText('Allow'))
     expect(onApprove).toHaveBeenCalledWith('req-abc', 'n-1')
     fireEvent.click(screen.getByLabelText('Deny'))
     expect(onDeny).toHaveBeenCalledWith('req-abc', 'n-1')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// #7466 review finding 1 — the third gate: `connected`
+// ---------------------------------------------------------------------------
+describe('#7466 — a permission banner over a dead socket is VISIBLY inert', () => {
+  function renderDisconnected(handlers: Partial<{
+    onApprove: () => void
+    onDeny: () => void
+    onMarkRead: () => void
+    onDismiss: () => void
+  }> = {}) {
+    render(
+      <NotificationBanners
+        notifications={[notification()]}
+        onApprove={(handlers.onApprove ?? vi.fn()) as () => void}
+        onDeny={(handlers.onDeny ?? vi.fn()) as () => void}
+        onDismiss={(handlers.onDismiss ?? vi.fn()) as () => void}
+        onSwitchSession={vi.fn()}
+        onMarkRead={(handlers.onMarkRead ?? vi.fn()) as () => void}
+        permissionStatus={() => 'disconnected'}
+      />,
+    )
+  }
+
+  it('disables Allow and Deny rather than leaving them enabled', () => {
+    // The whole point of the finding: `sendPermissionResponse` refuses to send
+    // while the socket is down and returns false, and the banner handlers now
+    // (correctly) decline to dismiss on that false — so with the buttons still
+    // ENABLED a disconnected click produced NO observable change whatsoever.
+    // `connection.ts` states the contract this meets: the answer buttons gate on
+    // `connected` "so the operator gets clear feedback rather than a dead click".
+    renderDisconnected()
+    expect(screen.getByLabelText('Allow')).toBeDisabled()
+    expect(screen.getByLabelText('Deny')).toBeDisabled()
+  })
+
+  it('explains why, in the inline prompt\'s exact words', () => {
+    renderDisconnected()
+    const hint = screen.getByTestId('notification-banner-disconnected-hint')
+    expect(hint).toBeInTheDocument()
+    expect(hint).toHaveTextContent('Disconnected — reconnect to answer.')
+  })
+
+  it('does NOT render it as a dead record — the request is still pending', () => {
+    // A disconnected prompt is live and becomes answerable again on reconnect.
+    // Collapsing it into the 'not-pending' branch would tell the operator the
+    // request was gone when it is not, and would offer a Dismiss that retires a
+    // record still awaiting an answer.
+    renderDisconnected()
+    expect(screen.queryByTestId('notification-banner-stale')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Dismiss')).not.toBeInTheDocument()
+  })
+
+  it('cannot fire onApprove/onDeny even if a click is dispatched at it', () => {
+    const onApprove = vi.fn()
+    const onDeny = vi.fn()
+    renderDisconnected({ onApprove, onDeny })
+    fireEvent.click(screen.getByLabelText('Allow'))
+    fireEvent.click(screen.getByLabelText('Deny'))
+    expect(onApprove).not.toHaveBeenCalled()
+    expect(onDeny).not.toHaveBeenCalled()
+  })
+
+  it('refuses the CLICK when the socket dropped since the last render', () => {
+    // `disabled` is a render-time property, and the socket can drop between the
+    // render and the click with nothing re-rendering in between (#6308's TOCTOU).
+    // Flipping the status WITHOUT a re-render models exactly that window; the
+    // click-time re-check is the only thing covering it.
+    let connected = true
+    const onApprove = vi.fn()
+    render(
+      <NotificationBanners
+        notifications={[notification()]}
+        onApprove={onApprove}
+        onDeny={vi.fn()}
+        onDismiss={vi.fn()}
+        onSwitchSession={vi.fn()}
+        onMarkRead={vi.fn()}
+        permissionStatus={() => (connected ? 'actionable' : 'disconnected')}
+      />,
+    )
+    expect(screen.getByLabelText('Allow')).toBeEnabled()
+
+    connected = false
+    fireEvent.click(screen.getByLabelText('Allow'))
+    expect(onApprove).not.toHaveBeenCalled()
   })
 })

--- a/packages/dashboard/src/components/NotificationBannersStale.test.tsx
+++ b/packages/dashboard/src/components/NotificationBannersStale.test.tsx
@@ -1,0 +1,247 @@
+/**
+ * #7466 — a cross-session permission banner must not offer Allow/Deny for a
+ * request that is no longer pending.
+ *
+ * The inline `PermissionPrompt` has three independent gates on its buttons
+ * (`answered`, its own `remaining <= 0` countdown, and `connected` —
+ * PermissionPrompt.tsx). The banner had NONE: it rendered Allow/Deny for any
+ * unread notification with `eventType === 'permission'` and a `requestId`, and
+ * `SessionNotification` carries no expiry of its own. So the banner depended
+ * entirely on an inbound `permission_expired` / `permission_resolved` arriving
+ * to stamp `readAt` — and when one never came (turn moved on, reconnect, the
+ * request simply timed out), the banner kept live buttons indefinitely while the
+ * inline prompt for the SAME request had already gone inert. That asymmetry is
+ * the "stale accept/deny prompt was still rendered" half of the dogfood report.
+ *
+ * The gate reuses `isLivePermissionPrompt` from @chroxy/store-core — the shared
+ * signal that already drives the tab badge and jump-to-pending — rather than
+ * inventing a second notion of "still pending" (#7390's one-signal rule).
+ *
+ * Conservative by construction: the banner stays actionable unless the store
+ * POSITIVELY knows the request is dead. A notification whose prompt message the
+ * store has never seen keeps its buttons, because the alternative is silently
+ * disarming a live prompt.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import {
+  NotificationBanners,
+  isPermissionNotificationActionable,
+} from './NotificationBanners'
+import type { ChatMessage, SessionNotification } from '../store/types'
+
+afterEach(cleanup)
+
+const NOW = 1_700_000_000_000
+
+function notification(overrides: Partial<SessionNotification> = {}): SessionNotification {
+  return {
+    id: 'n-1',
+    sessionId: 'sess-1',
+    sessionName: 'Chroxy',
+    eventType: 'permission',
+    message: 'Bash: rm -rf /tmp/x',
+    timestamp: NOW - 1000,
+    requestId: 'req-abc',
+    ...overrides,
+  }
+}
+
+function prompt(overrides: Partial<ChatMessage> = {}): ChatMessage {
+  return {
+    id: 'm-1',
+    type: 'prompt',
+    content: 'Bash: rm -rf /tmp/x',
+    timestamp: NOW - 1000,
+    requestId: 'req-abc',
+    expiresAt: NOW + 60_000,
+    ...overrides,
+  } as ChatMessage
+}
+
+function states(messages: ChatMessage[], sessionId = 'sess-1') {
+  return { [sessionId]: { messages } }
+}
+
+describe('#7466 — isPermissionNotificationActionable', () => {
+  it('is TRUE for a prompt that is still live', () => {
+    expect(
+      isPermissionNotificationActionable(notification(), states([prompt()]), NOW),
+    ).toBe(true)
+  })
+
+  it('is FALSE once the prompt has timed out (expiresAt in the past)', () => {
+    expect(
+      isPermissionNotificationActionable(
+        notification(),
+        states([prompt({ expiresAt: NOW - 1 })]),
+        NOW,
+      ),
+    ).toBe(false)
+  })
+
+  it('is FALSE once the prompt carries a decision (answered elsewhere)', () => {
+    expect(
+      isPermissionNotificationActionable(
+        notification(),
+        states([prompt({ answered: 'allow' } as Partial<ChatMessage>)]),
+        NOW,
+      ),
+    ).toBe(false)
+  })
+
+  it('is FALSE when the server retired the card by stamping expiresAt to now (#7335)', () => {
+    expect(
+      isPermissionNotificationActionable(
+        notification(),
+        states([prompt({ expiresAt: NOW })]),
+        NOW,
+      ),
+    ).toBe(false)
+  })
+
+  it('finds the prompt under ANOTHER session id — the banner is cross-session', () => {
+    expect(
+      isPermissionNotificationActionable(
+        notification({ sessionId: 'sess-not-seeded' }),
+        states([prompt({ expiresAt: NOW - 1 })], 'sess-other'),
+        NOW,
+      ),
+    ).toBe(false)
+  })
+
+  it('CONSERVATIVE: is TRUE when the store has no prompt for the requestId at all', () => {
+    // A banner can exist before sessionStates holds the prompt (the same case
+    // sendPermissionResponse's notification-first lookup exists for). Disarming
+    // it on absence would break live prompts, so absence means "keep the buttons".
+    expect(isPermissionNotificationActionable(notification(), states([]), NOW)).toBe(true)
+  })
+
+  it('CONSERVATIVE: is TRUE for a non-permission notification', () => {
+    expect(
+      isPermissionNotificationActionable(
+        notification({ eventType: 'completed', requestId: undefined }),
+        states([]),
+        NOW,
+      ),
+    ).toBe(true)
+  })
+})
+
+describe('#7466 — NotificationBanners renders a stale permission inert', () => {
+  it('shows Allow/Deny while the request is actionable', () => {
+    render(
+      <NotificationBanners
+        notifications={[notification()]}
+        onApprove={vi.fn()}
+        onDeny={vi.fn()}
+        onDismiss={vi.fn()}
+        onSwitchSession={vi.fn()}
+        isPermissionActionable={() => true}
+      />,
+    )
+    expect(screen.getByLabelText('Allow')).toBeInTheDocument()
+    expect(screen.getByLabelText('Deny')).toBeInTheDocument()
+    expect(screen.queryByTestId('notification-banner-stale')).not.toBeInTheDocument()
+  })
+
+  it('shows NO Allow/Deny once the request is not actionable', () => {
+    render(
+      <NotificationBanners
+        notifications={[notification()]}
+        onApprove={vi.fn()}
+        onDeny={vi.fn()}
+        onDismiss={vi.fn()}
+        onSwitchSession={vi.fn()}
+        isPermissionActionable={() => false}
+      />,
+    )
+    expect(screen.queryByLabelText('Allow')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Deny')).not.toBeInTheDocument()
+  })
+
+  it('keeps the row and offers Dismiss instead — the record survives (#7353)', () => {
+    const onDismiss = vi.fn()
+    render(
+      <NotificationBanners
+        notifications={[notification()]}
+        onApprove={vi.fn()}
+        onDeny={vi.fn()}
+        onDismiss={onDismiss}
+        onSwitchSession={vi.fn()}
+        isPermissionActionable={() => false}
+      />,
+    )
+    // Still says what was asked, and by whom.
+    expect(screen.getByText('Chroxy')).toBeInTheDocument()
+    expect(screen.getByText(/rm -rf \/tmp\/x/)).toBeInTheDocument()
+    expect(screen.getByTestId('notification-banner-stale')).toBeInTheDocument()
+    fireEvent.click(screen.getByLabelText('Dismiss'))
+    expect(onDismiss).toHaveBeenCalledWith('n-1')
+  })
+
+  it('gates per row: a live banner keeps its buttons while a stale sibling loses them', () => {
+    render(
+      <NotificationBanners
+        notifications={[
+          notification({ id: 'n-live', requestId: 'req-live' }),
+          notification({ id: 'n-stale', requestId: 'req-stale' }),
+        ]}
+        onApprove={vi.fn()}
+        onDeny={vi.fn()}
+        onDismiss={vi.fn()}
+        onSwitchSession={vi.fn()}
+        isPermissionActionable={(n) => n.requestId === 'req-live'}
+      />,
+    )
+    expect(screen.getAllByLabelText('Allow')).toHaveLength(1)
+    expect(screen.getAllByTestId('notification-banner-stale')).toHaveLength(1)
+  })
+
+  it('refuses the CLICK when the request died since the last render', () => {
+    // The render gate runs with the `Date.now()` of the last render, and nothing
+    // re-renders on the mere passage of a deadline — so the buttons can still be
+    // on screen after the request stopped being answerable. Flipping the
+    // predicate WITHOUT re-rendering models exactly that window.
+    let live = true
+    const onApprove = vi.fn()
+    const onDeny = vi.fn()
+    render(
+      <NotificationBanners
+        notifications={[notification()]}
+        onApprove={onApprove}
+        onDeny={onDeny}
+        onDismiss={vi.fn()}
+        onSwitchSession={vi.fn()}
+        isPermissionActionable={() => live}
+      />,
+    )
+    // Rendered live: the buttons exist.
+    expect(screen.getByLabelText('Allow')).toBeInTheDocument()
+
+    live = false
+    fireEvent.click(screen.getByLabelText('Allow'))
+    fireEvent.click(screen.getByLabelText('Deny'))
+    expect(onApprove).not.toHaveBeenCalled()
+    expect(onDeny).not.toHaveBeenCalled()
+  })
+
+  it('POSITIVE CONTROL: the same click DOES fire while the request is live', () => {
+    const onApprove = vi.fn()
+    const onDeny = vi.fn()
+    render(
+      <NotificationBanners
+        notifications={[notification()]}
+        onApprove={onApprove}
+        onDeny={onDeny}
+        onDismiss={vi.fn()}
+        onSwitchSession={vi.fn()}
+        isPermissionActionable={() => true}
+      />,
+    )
+    fireEvent.click(screen.getByLabelText('Allow'))
+    expect(onApprove).toHaveBeenCalledWith('req-abc', 'n-1')
+    fireEvent.click(screen.getByLabelText('Deny'))
+    expect(onDeny).toHaveBeenCalledWith('req-abc', 'n-1')
+  })
+})

--- a/packages/dashboard/src/components/PairedDevicesPanel.tsx
+++ b/packages/dashboard/src/components/PairedDevicesPanel.tsx
@@ -18,8 +18,16 @@
  * `deviceName` field for the follow-up, and until then a device is identified by
  * its session binding + age.
  */
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { getAuthToken } from '../utils/auth'
+
+/**
+ * #7466 — the default fetch, allocated ONCE at module scope. See the block
+ * comment in the component for why this is not a `useMemo`.
+ */
+const WINDOW_FETCH: typeof fetch = (input: RequestInfo | URL, init?: RequestInit) =>
+  window.fetch(input, init)
+
 
 export interface PairedDevice {
   /** Stable, non-reversible wire id (never the token itself). */
@@ -162,15 +170,21 @@ export function PairedDevicesPanel({ fetchImpl, getToken }: PairedDevicesPanelPr
   // with no props (App.tsx); every existing test passed `fetchImpl`, which pinned
   // the identity and hid the loop. See PanelRefreshLoop.test.tsx.
   //
-  // `resolvedGetToken` deliberately gets NO memo: `getAuthToken` is a module
-  // import and the ternary's result changes exactly when the `getToken` prop
-  // does, so `useMemo(..., [getToken])` is a provable no-op — it was written,
-  // mutation-tested, survived its own mutant, and removed rather than shipped as
-  // a guard with no behaviour.
-  const resolvedFetch = useMemo<typeof fetch>(
-    () => fetchImpl ?? ((input: RequestInfo | URL, init?: RequestInit) => window.fetch(input, init)),
-    [fetchImpl],
-  )
+  // The fallback is a MODULE-LEVEL constant, not a `useMemo`. React documents a
+  // memoized value as discardable — it may be recomputed at any time — so a memo
+  // is a performance hint, and here identity stability IS the correctness
+  // property. The constant also has no dep list, which removes the guard's own
+  // weak spot: mutating a `[fetchImpl]` dep to `[]` left the whole suite green,
+  // because nothing proved `resolvedFetch` tracked a CHANGING `fetchImpl`. That
+  // mutant is now unwritable rather than merely unkilled, and the input it named
+  // is pinned anyway by the changing-`fetchImpl` control in PanelRefreshLoop.
+  //
+  // `resolvedGetToken` gets no wrapper for the same reason it never got a memo:
+  // `getAuthToken` is a module import and the ternary's result changes exactly
+  // when the `getToken` prop does, so any wrapper is a provable no-op — one was
+  // written, mutation-tested, survived its own mutant, and removed rather than
+  // shipped as a guard with no behaviour.
+  const resolvedFetch = fetchImpl ?? WINDOW_FETCH
   const resolvedGetToken = getToken ?? getAuthToken
 
   const refresh = useCallback(async () => {

--- a/packages/dashboard/src/components/PairedDevicesPanel.tsx
+++ b/packages/dashboard/src/components/PairedDevicesPanel.tsx
@@ -18,7 +18,7 @@
  * `deviceName` field for the follow-up, and until then a device is identified by
  * its session binding + age.
  */
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { getAuthToken } from '../utils/auth'
 
 export interface PairedDevice {
@@ -153,8 +153,24 @@ export function PairedDevicesPanel({ fetchImpl, getToken }: PairedDevicesPanelPr
   const [revokingAll, setRevokingAll] = useState<boolean>(false)
   const [confirmingAll, setConfirmingAll] = useState<boolean>(false)
 
-  const resolvedFetch: typeof fetch =
-    fetchImpl ?? ((input: RequestInfo | URL, init?: RequestInit) => window.fetch(input, init))
+  // #7466 — `resolvedFetch` MUST be identity-stable across renders. It feeds
+  // `refresh`'s useCallback dep list, and `refresh` is the sole dep of the mount
+  // effect below. Computed inline, the `??` fallback allocated a fresh arrow on
+  // EVERY render, so the effect re-fired on every render and its own setState
+  // re-rendered — an unbounded fetch/render loop that flashed the panel header's
+  // Loading…/Refresh label. It only ever bit PRODUCTION, which renders this panel
+  // with no props (App.tsx); every existing test passed `fetchImpl`, which pinned
+  // the identity and hid the loop. See PanelRefreshLoop.test.tsx.
+  //
+  // `resolvedGetToken` deliberately gets NO memo: `getAuthToken` is a module
+  // import and the ternary's result changes exactly when the `getToken` prop
+  // does, so `useMemo(..., [getToken])` is a provable no-op — it was written,
+  // mutation-tested, survived its own mutant, and removed rather than shipped as
+  // a guard with no behaviour.
+  const resolvedFetch = useMemo<typeof fetch>(
+    () => fetchImpl ?? ((input: RequestInfo | URL, init?: RequestInit) => window.fetch(input, init)),
+    [fetchImpl],
+  )
   const resolvedGetToken = getToken ?? getAuthToken
 
   const refresh = useCallback(async () => {

--- a/packages/dashboard/src/components/PanelRefreshLoop.test.tsx
+++ b/packages/dashboard/src/components/PanelRefreshLoop.test.tsx
@@ -169,4 +169,41 @@ describe('#7466 — panels rendered the way production renders them do not refet
       restore()
     }
   })
+
+  it('a CHANGING fetchImpl prop re-arms exactly once — the resolver tracks the prop', async () => {
+    // The mirror of the getToken control above, and the input that was missing:
+    // nothing proved `resolvedFetch` tracks a changing `fetchImpl`. While the
+    // fallback was a `useMemo`, mutating its dep list from `[fetchImpl]` to `[]`
+    // left the whole suite green at 17 passed / exit 0. The module-level constant
+    // makes that mutant unwritable, but "unwritable" is not "unnecessary" — this
+    // pins the behaviour the dep list was supposed to defend, so a future edit
+    // that reintroduces a wrapper cannot silently drop it.
+    const { restore } = installFetchSpy({ devices: [] })
+    try {
+      const calls: number[] = []
+      const makeFetch = (n: number) =>
+        (async () => {
+          calls.push(n)
+          return new Response(JSON.stringify({ devices: [] }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          })
+        }) as unknown as typeof fetch
+
+      render(<Bumper>{(n) => <PairedDevicesPanel fetchImpl={makeFetch(n)} />}</Bumper>)
+      await settle()
+      expect(calls).toEqual([0])
+
+      fireEvent.click(document.querySelector('[data-testid="bump"]')!)
+      await settle()
+      // Tracked the new prop (n=1 fetched, not n=0 again) and stopped there.
+      expect(calls).toEqual([0, 1])
+
+      fireEvent.click(document.querySelector('[data-testid="bump"]')!)
+      await settle()
+      expect(calls).toEqual([0, 1, 2])
+    } finally {
+      restore()
+    }
+  })
 })

--- a/packages/dashboard/src/components/PanelRefreshLoop.test.tsx
+++ b/packages/dashboard/src/components/PanelRefreshLoop.test.tsx
@@ -1,0 +1,172 @@
+/**
+ * #7466 — the Devices / Snapshots panels must fetch ONCE on mount, not forever.
+ *
+ * These two panels hoist a `resolvedFetch` fallback for testability:
+ *
+ *     const resolvedFetch = fetchImpl ?? ((input, init) => window.fetch(input, init))
+ *     const refresh = useCallback(..., [resolvedFetch, resolvedGetToken])
+ *     useEffect(() => { void refresh() }, [refresh])
+ *
+ * When `fetchImpl` is omitted — which is exactly what production does
+ * (`<PairedDevicesPanel />` / `<SnapshotsPanel />` in App.tsx) — the `??`
+ * allocates a FRESH arrow every render, so `refresh` gets a new identity every
+ * render, so the mount effect re-fires every render, so `refresh` sets state,
+ * which renders again. An unbounded fetch/render loop that flashes the panel
+ * header's "Loading…"/"Refresh" label.
+ *
+ * Every pre-existing test in PairedDevicesPanel.test.tsx / SnapshotsPanel.test.tsx
+ * passes `fetchImpl` as a prop, which pins the identity and hides the loop
+ * completely — the guard was false-safe because the tests never rendered the
+ * shape that ships. These tests render the PRODUCTION shape (no props) and are
+ * StrictMode-honest: production mounts under `<StrictMode>` (main.tsx), whose
+ * deliberate mount/unmount/remount doubles the legitimate mount fetch to two.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { StrictMode, useState } from 'react'
+import { render, cleanup, fireEvent } from '@testing-library/react'
+import { PairedDevicesPanel } from './PairedDevicesPanel'
+import { SnapshotsPanel } from './SnapshotsPanel'
+
+/**
+ * Yield to the macrotask queue repeatedly. A render→effect→fetch→setState cycle
+ * needs one full turn per iteration, so N turns give a runaway loop N chances to
+ * re-arm. 25 is far more than the 1 (or 2 under StrictMode) legitimate mount
+ * fetches, and keeps the test sub-second.
+ */
+async function settle(turns = 25) {
+  for (let i = 0; i < turns; i++) {
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  }
+}
+
+function installFetchSpy(payload: Record<string, unknown>) {
+  const spy = vi.fn(
+    async () =>
+      new Response(JSON.stringify(payload), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+  )
+  const original = window.fetch
+  // The panels call `window.fetch` explicitly, so stub that (not just the global).
+  Object.defineProperty(window, 'fetch', { value: spy, writable: true, configurable: true })
+  return {
+    spy,
+    restore: () => {
+      Object.defineProperty(window, 'fetch', { value: original, writable: true, configurable: true })
+    },
+  }
+}
+
+/**
+ * A parent that re-renders its child on demand. Re-rendering a parent is the
+ * OTHER way an unstable dep reaches the child — the loop tests above only
+ * exercise the child re-rendering itself. These two cases pin the bound: a bump
+ * that changes nothing must cost zero fetches, and a bump that genuinely swaps
+ * the token resolver must cost exactly ONE, not an unbounded run.
+ */
+function Bumper({ children }: { children: (n: number) => React.ReactNode }) {
+  const [n, setN] = useState(0)
+  return (
+    <div>
+      <button type="button" data-testid="bump" onClick={() => setN((v) => v + 1)}>
+        bump
+      </button>
+      {children(n)}
+    </div>
+  )
+}
+
+describe('#7466 — panels rendered the way production renders them do not refetch in a loop', () => {
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  it('PairedDevicesPanel with no props fetches once and stops', async () => {
+    const { spy, restore } = installFetchSpy({ devices: [] })
+    try {
+      render(<PairedDevicesPanel />)
+      await settle()
+      expect(spy.mock.calls.length).toBe(1)
+    } finally {
+      restore()
+    }
+  })
+
+  it('PairedDevicesPanel under StrictMode fetches exactly twice (the double mount) and stops', async () => {
+    const { spy, restore } = installFetchSpy({ devices: [] })
+    try {
+      render(
+        <StrictMode>
+          <PairedDevicesPanel />
+        </StrictMode>,
+      )
+      await settle()
+      expect(spy.mock.calls.length).toBe(2)
+    } finally {
+      restore()
+    }
+  })
+
+  it('SnapshotsPanel with no props fetches once and stops', async () => {
+    const { spy, restore } = installFetchSpy({ snapshots: [] })
+    try {
+      render(<SnapshotsPanel />)
+      await settle()
+      expect(spy.mock.calls.length).toBe(1)
+    } finally {
+      restore()
+    }
+  })
+
+  it('SnapshotsPanel under StrictMode fetches exactly twice (the double mount) and stops', async () => {
+    const { spy, restore } = installFetchSpy({ snapshots: [] })
+    try {
+      render(
+        <StrictMode>
+          <SnapshotsPanel />
+        </StrictMode>,
+      )
+      await settle()
+      expect(spy.mock.calls.length).toBe(2)
+    } finally {
+      restore()
+    }
+  })
+
+  it('a parent re-render does not re-arm the mount fetch (production shape, no props)', async () => {
+    const { spy, restore } = installFetchSpy({ devices: [] })
+    try {
+      render(<Bumper>{() => <PairedDevicesPanel />}</Bumper>)
+      await settle()
+      expect(spy.mock.calls.length).toBe(1)
+      fireEvent.click(document.querySelector('[data-testid="bump"]')!)
+      fireEvent.click(document.querySelector('[data-testid="bump"]')!)
+      await settle()
+      expect(spy.mock.calls.length).toBe(1)
+    } finally {
+      restore()
+    }
+  })
+
+  it('a parent re-render passing a fresh inline getToken does not re-arm the mount fetch', async () => {
+    const { spy, restore } = installFetchSpy({ devices: [] })
+    try {
+      // A NEW arrow every parent render, so `refresh` legitimately re-arms once
+      // per bump. The point is the CEILING: with `resolvedFetch` unmemoized this
+      // same input ran away to 35 fetches in 25 macrotask turns.
+      render(<Bumper>{(n) => <PairedDevicesPanel getToken={() => `tok-${n}`} />}</Bumper>)
+      await settle()
+      expect(spy.mock.calls.length).toBe(1)
+      fireEvent.click(document.querySelector('[data-testid="bump"]')!)
+      await settle()
+      // One extra fetch: the resolver prop genuinely changed (tok-0 -> tok-1), so
+      // re-reading the roster with the new credential is correct. What must NOT
+      // happen is an unbounded run — 25 macrotask turns produce exactly one.
+      expect(spy.mock.calls.length).toBe(2)
+    } finally {
+      restore()
+    }
+  })
+})

--- a/packages/dashboard/src/components/PermissionPrompt.tsx
+++ b/packages/dashboard/src/components/PermissionPrompt.tsx
@@ -17,6 +17,18 @@
  * #2852: guards Allow / Deny / Allow for Session and the keyboard shortcuts
  * behind a local `submitting` flag so double-click and key-repeat cannot
  * fire onRespond twice before the store's answered state catches up.
+ *
+ * #7466 — SECOND SURFACE. The cross-session notification banner
+ * (NotificationBanners.tsx) offers Allow/Deny for the same requests and must
+ * honour the same three gates: answered, expiry, and `connected`. It cannot
+ * share this component's code — the countdown below is anchored to a monotonic
+ * `performance.now()` taken at THIS prompt's mount (#3619), and a banner has no
+ * mount lifetime to anchor one to, so it answers from store state
+ * (`isLivePermissionPrompt` over the prompt ChatMessage) instead. Same three
+ * gates, two vantage points. Changing `respond()`'s bail conditions or
+ * `showButtons` here means changing `permissionNotificationStatus` there; the
+ * banner had NONE of the three until #7466 and shipped a live Allow for an
+ * already-expired request for the rest of its five minutes.
  */
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { useConnectionStore, isRuleEligibleTool, isRuleEligibleProvider, isDenyReasonHonoredProvider, DENY_REASON_MAX_LENGTH } from '../store/connection'

--- a/packages/dashboard/src/components/SnapshotsPanel.tsx
+++ b/packages/dashboard/src/components/SnapshotsPanel.tsx
@@ -17,7 +17,7 @@
  * `snapshotImage` through SessionManager / the WS protocol is a larger
  * surface than this panel can own on its own).
  */
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { getAuthToken } from '../utils/auth'
 
 export interface Snapshot {
@@ -170,8 +170,24 @@ export function SnapshotsPanel({ fetchImpl, getToken }: SnapshotsPanelProps = {}
 
   // Hoist for testability — production passes neither override and falls
   // back to the shared globals.
-  const resolvedFetch: typeof fetch =
-    fetchImpl ?? ((input: RequestInfo | URL, init?: RequestInit) => window.fetch(input, init))
+  // #7466 — `resolvedFetch` MUST be identity-stable across renders. It feeds
+  // `refresh`'s useCallback dep list, and `refresh` is the sole dep of the mount
+  // effect below. Computed inline, the `??` fallback allocated a fresh arrow on
+  // EVERY render, so the effect re-fired on every render and its own setState
+  // re-rendered — an unbounded fetch/render loop that flashed the panel header's
+  // Loading…/Refresh label. It only ever bit PRODUCTION, which renders this panel
+  // with no props (App.tsx); every existing test passed `fetchImpl`, which pinned
+  // the identity and hid the loop. See PanelRefreshLoop.test.tsx.
+  //
+  // `resolvedGetToken` deliberately gets NO memo: `getAuthToken` is a module
+  // import and the ternary's result changes exactly when the `getToken` prop
+  // does, so `useMemo(..., [getToken])` is a provable no-op — it was written,
+  // mutation-tested, survived its own mutant, and removed rather than shipped as
+  // a guard with no behaviour.
+  const resolvedFetch = useMemo<typeof fetch>(
+    () => fetchImpl ?? ((input: RequestInfo | URL, init?: RequestInit) => window.fetch(input, init)),
+    [fetchImpl],
+  )
   const resolvedGetToken = getToken ?? getAuthToken
 
   const refresh = useCallback(async () => {

--- a/packages/dashboard/src/components/SnapshotsPanel.tsx
+++ b/packages/dashboard/src/components/SnapshotsPanel.tsx
@@ -17,8 +17,16 @@
  * `snapshotImage` through SessionManager / the WS protocol is a larger
  * surface than this panel can own on its own).
  */
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { getAuthToken } from '../utils/auth'
+
+/**
+ * #7466 — the default fetch, allocated ONCE at module scope. See the block
+ * comment in the component for why this is not a `useMemo`.
+ */
+const WINDOW_FETCH: typeof fetch = (input: RequestInfo | URL, init?: RequestInit) =>
+  window.fetch(input, init)
+
 
 export interface Snapshot {
   tag: string
@@ -179,15 +187,21 @@ export function SnapshotsPanel({ fetchImpl, getToken }: SnapshotsPanelProps = {}
   // with no props (App.tsx); every existing test passed `fetchImpl`, which pinned
   // the identity and hid the loop. See PanelRefreshLoop.test.tsx.
   //
-  // `resolvedGetToken` deliberately gets NO memo: `getAuthToken` is a module
-  // import and the ternary's result changes exactly when the `getToken` prop
-  // does, so `useMemo(..., [getToken])` is a provable no-op — it was written,
-  // mutation-tested, survived its own mutant, and removed rather than shipped as
-  // a guard with no behaviour.
-  const resolvedFetch = useMemo<typeof fetch>(
-    () => fetchImpl ?? ((input: RequestInfo | URL, init?: RequestInit) => window.fetch(input, init)),
-    [fetchImpl],
-  )
+  // The fallback is a MODULE-LEVEL constant, not a `useMemo`. React documents a
+  // memoized value as discardable — it may be recomputed at any time — so a memo
+  // is a performance hint, and here identity stability IS the correctness
+  // property. The constant also has no dep list, which removes the guard's own
+  // weak spot: mutating a `[fetchImpl]` dep to `[]` left the whole suite green,
+  // because nothing proved `resolvedFetch` tracked a CHANGING `fetchImpl`. That
+  // mutant is now unwritable rather than merely unkilled, and the input it named
+  // is pinned anyway by the changing-`fetchImpl` control in PanelRefreshLoop.
+  //
+  // `resolvedGetToken` gets no wrapper for the same reason it never got a memo:
+  // `getAuthToken` is a module import and the ternary's result changes exactly
+  // when the `getToken` prop does, so any wrapper is a provable no-op — one was
+  // written, mutation-tested, survived its own mutant, and removed rather than
+  // shipped as a guard with no behaviour.
+  const resolvedFetch = fetchImpl ?? WINDOW_FETCH
   const resolvedGetToken = getToken ?? getAuthToken
 
   const refresh = useCallback(async () => {

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -3773,11 +3773,21 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     // Auto-switch to the session that owns this prompt (if different from active).
     // Prefer sessionNotifications lookup (covers prompts stored before sessionStates[sid] existed),
     // fall back to scanning sessionStates messages.
-    const { activeSessionId, sessionStates, sessionNotifications } = get();
+    const { activeSessionId, sessionStates, sessionNotifications, sessions } = get();
     const notifMatch = sessionNotifications.find((n) => n.requestId === requestId);
     const targetSid = notifMatch?.sessionId
       ?? Object.entries(sessionStates).find(([, ss]) => ss.messages.some((m) => m.requestId === requestId))?.[0];
-    if (targetSid && targetSid !== activeSessionId) get().switchSession(targetSid);
+    // #7466 — the owner id must still be a session the operator HAS. Both lookup
+    // sources outlive the session: `sessionNotifications` is never pruned on
+    // close, and `sessionStates` retains a closed session's transcript. Without
+    // this check, answering a STALE prompt (session closed, or a daemon restart
+    // regenerated ids) handed `switchSession` a dead id, which writes
+    // `activeSessionId` unconditionally — leaving the SessionBar with every tab
+    // unselected (`isActive: s.sessionId === activeSessionId` in App.tsx) and no
+    // way back except clicking a tab. The membership check keeps the legitimate
+    // cross-session jump and drops only the impossible one.
+    const targetIsLive = !!targetSid && sessions.some((s) => s.sessionId === targetSid);
+    if (targetIsLive && targetSid !== activeSessionId) get().switchSession(targetSid);
     // For allowSession: send a follow-up set_permission_rules to register
     // auto-approval for this tool. Skip tools the server won't accept as
     // auto-allow rules (execution/network tools). Mirrors the mobile app

--- a/packages/dashboard/src/store/permission-response-dead-session.test.ts
+++ b/packages/dashboard/src/store/permission-response-dead-session.test.ts
@@ -1,0 +1,189 @@
+/**
+ * #7466 — answering a permission must never make a session that no longer
+ * exists the active one.
+ *
+ * `sendPermissionResponse` auto-switches to the session that owns the prompt, so
+ * an operator who answers a cross-session banner lands on the asking session.
+ * The owner id is looked up from `sessionNotifications` (falling back to a scan
+ * of `sessionStates`) — and BOTH of those outlive the session itself:
+ * `sessionNotifications` is never pruned when a session closes, and
+ * `sessionStates` keeps a closed session's transcript. `switchSession` then
+ * writes `activeSessionId` unconditionally, with no membership check against
+ * `sessions`.
+ *
+ * So clicking Allow/Deny on a STALE prompt — one whose session is gone after a
+ * close or a daemon restart that regenerated ids — points `activeSessionId` at
+ * an id no tab carries. `SessionBar` marks a tab active purely by
+ * `s.sessionId === activeSessionId` (App.tsx), so the whole strip renders with
+ * NOTHING selected: the wedged tab bar in the dogfood report.
+ *
+ * The guard is a membership check, not a "don't switch" rule — the legitimate
+ * cross-session jump is the whole point of the feature and is pinned below as
+ * the positive control.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import type { SessionInfo, SessionNotification } from './types'
+
+vi.mock('./crypto', () => ({
+  createKeyPair: vi.fn(() => ({ publicKey: 'mock-pub', secretKey: 'mock-sec' })),
+  deriveSharedKey: vi.fn(),
+  encrypt: vi.fn(),
+  decrypt: vi.fn(),
+  generateConnectionSalt: vi.fn(() => 'mock-salt'),
+  deriveConnectionKey: vi.fn(() => new Uint8Array(32)),
+  DIRECTION_CLIENT: 0,
+  DIRECTION_SERVER: 1,
+}))
+
+function liveSocket(sent: unknown[]): WebSocket {
+  return {
+    send: vi.fn((raw: string) => {
+      try {
+        sent.push(JSON.parse(raw))
+      } catch {
+        /* noop */
+      }
+    }),
+    close: vi.fn(),
+    readyState: WebSocket.OPEN,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  } as unknown as WebSocket
+}
+
+function makeSession(sessionId: string, name: string): SessionInfo {
+  return {
+    sessionId,
+    name,
+    cwd: '/tmp',
+    type: 'cli',
+    hasTerminal: false,
+    model: null,
+    permissionMode: null,
+    isBusy: false,
+    createdAt: 1,
+    conversationId: null,
+  } as SessionInfo
+}
+
+function permissionNotification(sessionId: string, requestId: string): SessionNotification {
+  return {
+    id: `n-${requestId}`,
+    sessionId,
+    sessionName: sessionId,
+    eventType: 'permission',
+    message: 'Bash: rm -rf /tmp/x',
+    timestamp: Date.now(),
+    requestId,
+  }
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  vi.spyOn(console, 'warn').mockImplementation(() => {})
+})
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('#7466 — sendPermissionResponse auto-switch is membership-checked', () => {
+  it('does NOT switch to a prompt owner that is absent from `sessions` (notification lookup)', async () => {
+    const { useConnectionStore, createEmptySessionState } = await import('./connection')
+    const sent: unknown[] = []
+    useConnectionStore.setState({
+      socket: liveSocket(sent),
+      activeSessionId: 'sess-live',
+      sessions: [makeSession('sess-live', 'Chroxy')],
+      // The banner outlived its session: `sessionNotifications` is not pruned on
+      // close, so the row still names the dead id.
+      sessionNotifications: [permissionNotification('sess-dead', 'req-stale')],
+      sessionStates: { 'sess-live': createEmptySessionState() },
+      messages: [],
+    })
+
+    useConnectionStore.getState().sendPermissionResponse('req-stale', 'allow')
+
+    expect(useConnectionStore.getState().activeSessionId).toBe('sess-live')
+    // Nothing may have been asked of the server about the dead session either.
+    expect(sent.some((m) => (m as { type?: string }).type === 'switch_session')).toBe(false)
+  })
+
+  it('does NOT switch to a prompt owner that is absent from `sessions` (sessionStates scan)', async () => {
+    const { useConnectionStore, createEmptySessionState } = await import('./connection')
+    const sent: unknown[] = []
+    useConnectionStore.setState({
+      socket: liveSocket(sent),
+      activeSessionId: 'sess-live',
+      sessions: [makeSession('sess-live', 'Chroxy')],
+      sessionNotifications: [],
+      sessionStates: {
+        'sess-live': createEmptySessionState(),
+        // A closed session's transcript is retained in sessionStates, so the
+        // fallback scan finds the prompt under an id that has no tab.
+        'sess-dead': {
+          ...createEmptySessionState(),
+          messages: [
+            {
+              id: 'm-1',
+              type: 'prompt',
+              content: 'Bash: rm -rf /tmp/x',
+              timestamp: 1,
+              requestId: 'req-stale',
+              expiresAt: Date.now() + 60_000,
+            },
+          ],
+        },
+      },
+      messages: [],
+    })
+
+    useConnectionStore.getState().sendPermissionResponse('req-stale', 'allow')
+
+    expect(useConnectionStore.getState().activeSessionId).toBe('sess-live')
+    expect(sent.some((m) => (m as { type?: string }).type === 'switch_session')).toBe(false)
+  })
+
+  it('POSITIVE CONTROL: still switches to a prompt owner that IS in `sessions`', async () => {
+    const { useConnectionStore, createEmptySessionState } = await import('./connection')
+    const sent: unknown[] = []
+    useConnectionStore.setState({
+      socket: liveSocket(sent),
+      activeSessionId: 'sess-live',
+      sessions: [makeSession('sess-live', 'Chroxy'), makeSession('sess-other', 'DockKeeper')],
+      sessionNotifications: [permissionNotification('sess-other', 'req-live')],
+      sessionStates: {
+        'sess-live': createEmptySessionState(),
+        'sess-other': createEmptySessionState(),
+      },
+      messages: [],
+    })
+
+    useConnectionStore.getState().sendPermissionResponse('req-live', 'allow')
+
+    expect(useConnectionStore.getState().activeSessionId).toBe('sess-other')
+    expect(sent.some((m) => (m as { type?: string }).type === 'switch_session')).toBe(true)
+  })
+
+  it('POSITIVE CONTROL: the permission_response itself is still sent for a stale prompt', async () => {
+    // The membership check gates NAVIGATION only. The answer still goes to the
+    // server, which is the authority on whether the request is still pending —
+    // suppressing the send here would invent a second, client-side notion of
+    // "already handled" (#7390's one-signal rule).
+    const { useConnectionStore, createEmptySessionState } = await import('./connection')
+    const sent: unknown[] = []
+    useConnectionStore.setState({
+      socket: liveSocket(sent),
+      activeSessionId: 'sess-live',
+      sessions: [makeSession('sess-live', 'Chroxy')],
+      sessionNotifications: [permissionNotification('sess-dead', 'req-stale')],
+      sessionStates: { 'sess-live': createEmptySessionState() },
+      messages: [],
+    })
+
+    useConnectionStore.getState().sendPermissionResponse('req-stale', 'allow')
+
+    const responses = sent.filter((m) => (m as { type?: string }).type === 'permission_response')
+    expect(responses).toHaveLength(1)
+    expect(responses[0]).toMatchObject({ requestId: 'req-stale', decision: 'allow' })
+  })
+})

--- a/packages/dashboard/src/store/store.test.ts
+++ b/packages/dashboard/src/store/store.test.ts
@@ -1642,8 +1642,21 @@ describe('system message routing', () => {
 
 // ---------------------------------------------------------------------------
 // Permission response auto-switch (#1710)
+//
+// #7466 — the auto-switch is now membership-checked against `sessions`, so these
+// fixtures seed the roster as well as `sessionStates`. A world with a
+// sessionStates entry and no matching `sessions` row is not a state the server
+// can produce for a LIVE session; it is exactly the stale-prompt shape (session
+// closed, or a daemon restart regenerated ids) that must NOT navigate — pinned
+// on its own in permission-response-dead-session.test.ts.
 // ---------------------------------------------------------------------------
 describe('permission response auto-switch', () => {
+  const rosterEntry = (id: string) => ({
+    sessionId: id, name: id, cwd: '/tmp', type: 'cli' as const,
+    hasTerminal: false, model: null, permissionMode: null, isBusy: false,
+    createdAt: 0, conversationId: null,
+  });
+
   it('switches to session that owns the permission when different from active', async () => {
     const { useConnectionStore } = await import('./connection');
 
@@ -1657,6 +1670,7 @@ describe('permission response auto-switch', () => {
 
     useConnectionStore.setState({
       activeSessionId: 's1',
+      sessions: [rosterEntry('s1'), rosterEntry('s2')],
       sessionStates: {
         s1: { ...createEmptySessionState(), messages: [makeMsg('m1', 'req-a')] },
         s2: { ...createEmptySessionState(), messages: [makeMsg('m2', 'req-b')] },
@@ -1719,6 +1733,7 @@ describe('permission response auto-switch', () => {
 
     useConnectionStore.setState({
       activeSessionId: 's1',
+      sessions: [rosterEntry('s1'), rosterEntry('s2')],
       sessionStates: {
         s1: { ...createEmptySessionState(), messages: [makeMsg('m1', 'req-a')] },
         s2: { ...createEmptySessionState(), messages: [makeMsg('m2', 'req-b')] },
@@ -1732,7 +1747,12 @@ describe('permission response auto-switch', () => {
     expect(sentMessages[0]?.type).toBe('permission_response');
     const switchIdx = sentMessages.findIndex((m) => m.type === 'switch_session');
     const permIdx = sentMessages.findIndex((m) => m.type === 'permission_response');
-    expect(permIdx).toBeLessThan(switchIdx === -1 ? Infinity : switchIdx);
+    // #7466 — assert the switch actually happened. `switchIdx === -1 ? Infinity`
+    // made this pass just as happily when NO switch was sent, so it could not
+    // have caught the membership check silently suppressing the cross-session
+    // jump. Ordering is only meaningful once both frames exist.
+    expect(switchIdx).toBeGreaterThan(-1);
+    expect(permIdx).toBeLessThan(switchIdx);
 
     useConnectionStore.setState({ sessions: [], activeSessionId: null, sessionStates: {}, socket: null });
   });

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -5115,6 +5115,26 @@ button.sidebar-token-view-session-row:hover {
   opacity: 0.85;
 }
 
+/* #7466 — a permission banner over a dead socket keeps its buttons (the request
+   is still live and becomes answerable on reconnect) but must not accept a
+   click. Mirrors the inline prompt's disabled Allow/Deny + perm-disconnected-hint
+   rather than inventing a second visual language for one condition. */
+.notification-banner-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.notification-banner-btn:disabled:hover {
+  opacity: 0.45;
+}
+
+.notification-banner-hint {
+  font-size: var(--text-xs);
+  color: var(--text-secondary);
+  flex-shrink: 0;
+  align-self: center;
+}
+
 /* #5510 (epic #5509): pairing-approval primitive — host approval banner. */
 .pair-requests {
   display: flex;

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -5093,6 +5093,18 @@ button.sidebar-token-view-session-row:hover {
   color: #fff;
 }
 
+/* #7466 — a permission banner whose request is no longer pending keeps the row
+   (the record) but loses its Allow/Deny. This label says why, so a button-less
+   permission banner does not read as a rendering failure. */
+.notification-banner-stale {
+  font-size: var(--text-xs);
+  font-style: italic;
+  color: var(--text-secondary);
+  opacity: 0.8;
+  flex-shrink: 0;
+  align-self: center;
+}
+
 .notification-banner-btn--dismiss {
   background: transparent;
   color: var(--text-secondary);


### PR DESCRIPTION
All file:line references are against the branch point, `origin/main` @ `e3fd9731e`.

Investigation-first pass on the #7466 dogfood report. Three symptoms were reported as
possibly-tangled; **two are proven and fixed here, a fourth defect was found while
tracing the third, and one symptom is still unproven — this PR says so plainly** rather
than patching by guesswork. `Related to #7466` (not `Closes`) — the
issue stays open on the unproven third.

## Mechanism table

| # | Reported symptom | Mechanism | Evidence | Status |
|---|---|---|---|---|
| 1 | A **stale accept/deny prompt was still rendered** and still acted | The cross-session banner had **no staleness gate at all**. `NotificationBanners.tsx:71` rendered Allow/Deny for any unread notification with `eventType: 'permission'` + a `requestId`; `SessionNotification` (`store/types.ts:529`) carries no expiry, so the banner depended entirely on an inbound `permission_expired`/`permission_resolved` to stamp `readAt`. The inline `PermissionPrompt` has three gates on the same decision (`answered` / its own `remaining <= 0` countdown / `connected` — `PermissionPrompt.tsx:169`, `:204`). When no expiry event arrived, the banner kept live buttons while the inline prompt for the SAME request had already gone inert. | `components/NotificationBanners.tsx:71-89`, `store/types.ts:529-553`, `components/PermissionPrompt.tsx:169,204` | **PROVEN — fixed** |
| 2 | The click **navigated to the Devices tab** | See "What is NOT proven" below. Nothing in the dashboard sets `viewMode` to `'devices'` except the Devices button itself. A *session*-navigation-on-click does exist and is fixed (row 3a), and the precondition for a mis-click is fixed (row 4), but the view-tab jump itself has no named mechanism. | — | **UNPROVEN — precondition removed, mechanism not named** |
| 4 | (not reported directly — found while tracing 2) A failed answer still **deleted** the banner | `App.tsx:2059-2067` called `dismissSessionNotification` regardless of `respondToPermission`'s return. `sendPermissionResponse` returns `false` without throwing on a down or OPEN→CLOSING socket (`connection.ts:3722`, `:3752` — #5699/#6308), and `dismissSessionNotification` **removes** the row (`connection.ts:5239-5243`), it does not mark it read. So a click that achieved nothing destroyed the only record of the request — and collapsed the banner block under the cursor. | `App.tsx:2059-2067`, `store/connection.ts:3722,3752,5239` | **PROVEN — fixed** |
| 3a | The **session tab bar left with no tab selected** | `sendPermissionResponse` auto-switches to the prompt's owning session. The owner id comes from `sessionNotifications`, falling back to a scan of `sessionStates` — **both of which outlive the session**: notifications are never pruned on close, and `sessionStates` retains a closed session's transcript. `switchSession` then writes `activeSessionId` **unconditionally**, with no membership check against `sessions`. `SessionBar` marks a tab active purely by `s.sessionId === activeSessionId`, so a dangling id renders the whole strip unselected. | `store/connection.ts:3780` (pre-fix), `store/connection.ts:4828`/`:4864`, `App.tsx:1379` | **PROVEN — fixed** |
| 3b | The **header flashing in a refresh/loading loop** | `PairedDevicesPanel` (the Devices panel) computes `resolvedFetch = fetchImpl ?? ((i,n) => window.fetch(i,n))` inline, feeds it to `refresh`'s `useCallback` deps, and mounts with `useEffect(() => { void refresh() }, [refresh])`. With `fetchImpl` omitted — **exactly what production does** — the `??` allocates a fresh arrow every render, so `refresh` changes identity every render, so the effect re-fires every render, and its own `setState` renders again. An **unbounded fetch/render loop** that flips the panel header's `Loading…`/`Refresh` label continuously. `SnapshotsPanel` has the identical defect. | `components/PairedDevicesPanel.tsx:156-179,230-232` (pre-fix), `components/SnapshotsPanel.tsx:173-196,243-245` (pre-fix), rendered propless at `App.tsx:2758` / `:2749` | **PROVEN — fixed** |

### The false-safety that hid 3b

All **26** existing tests across `PairedDevicesPanel.test.tsx` / `SnapshotsPanel.test.tsx`
pass `fetchImpl` as a prop, which pins the identity and makes the loop impossible.
Production passes nothing. The suite was green because it never rendered the shape that
ships — the "testing the source tree when the artifact is what ships" family in
`docs/false-safety-guards.md`. The new tests render the **production shape (no props)**
and are StrictMode-honest, since `main.tsx` mounts under `<StrictMode>`.

## What is NOT proven — the jump to Devices

Two independent sweeps of every `viewMode` writer found **no path that can select the
Devices tab except the Devices button itself** (`components/ViewSwitcher.tsx:152`).
Ruled out: keyboard shortcuts (`Cmd+1..9` switches *session* tabs; the only view-tab
shortcut toggles chat↔terminal, `useShortcutDispatch.ts:279`), the command palette
(`store/commands.ts` sets only chat/terminal/files), `openFileInBrowser` (files), the
StreamStallChip "View logs" action (system), the Tauri tray menu (console), the
ErrorBoundary (`window.location.reload()` only), and every handler in
`store/message-handler.ts` — which contains **zero** occurrences of `viewMode`.

Note one thing that surprised me and kills the most attractive alternative: the
localStorage rehydration of `viewMode` at `store/connection.ts:2347` is **dead code in
this package**. It lives inside `loadSavedConnection` (`connection.ts:2311`), whose only
caller in the monorepo is the *mobile app's* separate store
(`packages/app/src/screens/ConnectScreen.tsx:162`). The dashboard never restores
`viewMode` — not on reconnect, not even on boot. The two post-boot
`loadPersistedState()` calls (`switchServer` `:5327`, `connectLocal` `:5369`) apply only
`activeSessionId`. There is also no zustand `persist` middleware and no `storage` event
listener, so no cross-tab sync. So "the click triggered a reconnect that restored a
previously-persisted 'devices'" is not merely unproven — it is impossible.

So the click did not *navigate* to Devices through any code path I can name. The
remaining hypothesis is the reporter's own: a **physical mis-click caused by layout
shift**. `NotificationBanners` returns `null` when the last unread banner goes
(`NotificationBanners.tsx:45`), and `.notification-banners` is a normal-flow,
`flex-shrink: 0` block sitting **immediately above** `.view-switch-wrapper`
(`App.tsx:2567` → `:2581`, `theme/components.css:4999`). Answering the banner therefore
pulls the tab strip **up into the pointer's position**.

Quantified, because "roughly one banner height" is not a claim anyone can check:
`.notification-banner` is `padding: 6px 12px` at `--text-sm: 12px` with a body
`line-height: 1.5` → **~30px** tall. `.view-tab` is `padding: 6px 16px` at
`--text-base: 13px` plus a 2px bottom border → the strip is **~36px** tall. So the
collapse moves the tab strip up by roughly *five sixths of a tab row* — a pointer
resting on the banner's action row ends up squarely inside the strip, not merely near
it. Horizontally it is weaker, and the honest version is worth stating: the banner's
Allow/Deny sit at the far RIGHT (`.notification-banner-actions` under
`justify-content: space-between`), but in the DEFAULT layout the tabs at the right edge
are Checkpoints and Diff, not Devices — `.view-switch-spacer { flex: 1 }`
(`ViewSwitcher.tsx:153`) sits *after* Devices and pushes that tail group over. Devices
lands under the Allow button only when the strip overflows AND has been partially
drag-scrolled (`.view-switch` is `overflow-x: auto`; the spacer's `flex: 1` and the tail
group's `margin-left: auto` both collapse to 0 on overflow, so all 13-15 tabs pack in DOM
order and which tab occupies a given x is a pure function of `scrollLeft`).

And the same click cannot be retargeted at all: `mousedown` / `mouseup` / `click` are all
dispatched before React commits the dismissal. A **second** click is required — which is
precisely why fix 4 matters. Before it, clicking Allow on a stale banner over a dropped
socket did nothing except make the banner vanish, and an operator whose control just
"didn't work" clicks it again, now over the tab strip.

I can prove the adjacency and the collapse; I cannot prove that a single click
retargets onto a specific tab, and jsdom has no layout with which to test it. So the
fix here removes the *precondition* — a stale banner no longer offers a button to click
at all — rather than inventing a mechanism. The issue stays open with a comment naming
exactly what remains and how to instrument it.

## Fixes

1. **`fix(dashboard): stop the Devices and Snapshots panels refetching forever`** — memoize
   `resolvedFetch` on the prop in both panels. `resolvedGetToken` deliberately gets **no**
   memo: `getAuthToken` is a module import and the ternary changes exactly when the prop
   does, so `useMemo(..., [getToken])` is a provable no-op. It was written,
   mutation-tested, **survived its own mutant**, and was removed rather than shipped as a
   guard with no behaviour.
2. **`fix(dashboard): never make a session that no longer exists the active one`** —
   membership-check the auto-switch target against `sessions`. The legitimate
   cross-session jump is preserved and pinned as a positive control; the
   `permission_response` itself still goes to the server, which stays the authority on
   whether the request is pending.
3. **`fix(dashboard): a permission banner that is no longer pending loses its buttons`** —
   gate Allow/Deny on `isPermissionNotificationActionable`, which reads the prompt out of
   `sessionStates` and applies `isLivePermissionPrompt` from `@chroxy/store-core` — the
   **same** signal that already drives the tab badge and jump-to-pending, so no second
   notion of "still pending" is introduced (#7390's one-signal rule). **Conservative on
   absence**: a notification whose prompt the store has never seen keeps its buttons. The
   row survives with a "No longer pending" marker and a Dismiss, so the record of what was
   asked is not erased (#7353). The prop is **required with no default** — defaulting to
   "actionable" is the hole being closed. Re-checked inside `onClick` as well as at
   render, because the render gate holds the `Date.now()` of the *last* render and nothing
   re-renders on the mere passage of a deadline.
4. **`fix(dashboard): a permission banner whose answer never sent must not vanish`** —
   dismiss only when `respondToPermission` reports the answer went on the wire. `'queued'`
   is not a failure, so only an explicit `false` holds the row; the over-strict
   `!== 'sent'` variant has its own mutant.

## Red-first + mutation evidence

Every guard was proven red before the fix and then attacked.

| Guard | Red before fix | Mutant | Result |
|---|---|---|---|
| `resolvedFetch` memo (both panels) | `expected 21 to be 1` (and 14/16/21 across the four cases) — the loop never settles; the first shape of the test hit a 30s `act()` timeout because React never quiesced | **A** revert to the inline `??` in `PairedDevicesPanel` | **killed** — 4 tests, `expected 13 to be 1` |
| `resolvedGetToken` memo | — | **B** revert to the bare expression | **SURVIVED** → the refinement has no behaviour; **deleted** rather than shipped |
| `resolvedFetch` memo (final files, re-run after the B deletion) | — | **A2** revert both panels | **killed** — all 6 tests, `expected 28 to be 1` |
| auto-switch membership check | `expected 'sess-dead' to be 'sess-live'` ×2 | **C** drop the check (`targetIsLive = !!targetSid`) | **killed** — 2 tests |
| ↳ positive control not vacuous | — | **D** invert the check (`!sessions.some(...)`) | **killed** — 3 tests, incl. `expected 'sess-live' to be 'sess-other'` |
| banner render gate | Allow/Deny still rendered; `expected [ …2 buttons ] to have a length of 1` | **E** drop `&& isPermissionActionable(n)` | **killed** — 3 tests |
| `isPermissionNotificationActionable` negatives | `TypeError: isPermissionNotificationActionable is not a function` (×7) | **F** `return true` unconditionally | **killed** — 4 tests |
| ↳ conservative-on-absence branch | — | **G** flip the absence fallback to `return false` | **killed** — 1 test (the CONSERVATIVE case) |
| click-time re-check | — | **H** drop the `onClick` guard | **killed** — 1 test (predicate flipped without a re-render) |
| dismiss-only-on-send | `expected "vi.fn()" to not be called at all, but actually been called 1 times` ×2 | **I** revert the Approve guard | **killed** — 1 test |
| ↳ `'queued'` is not a failure | — | **J** tighten to `!== 'sent'` | **killed** — 1 test (the queued positive control) |

The A2 re-run matters: the fix changed after mutant A (the B deletion), so the original
mutation was re-applied to the *final* file rather than trusting the earlier kill.

## Suites (bare exit codes, captured without a pipe)

| Command | Exit |
|---|---|
| `npx tsc --noEmit` | `0` |
| `npx vitest run src/store/` | `0` — 81 files, **1175** tests |
| `npx vitest run` (whole dashboard) | `0` — 309 files, **5367** tests |
| `npx vitest run` (the 5 touched component files) | `0` — 56 tests |
| `npx vitest run src/App.test.tsx` | `0` — 123 tests |
| `npm run build` (vite) | `0` |

`git status --short` is clean; the committed tree is what was verified.

## Notes / follow-ons

- Two pre-existing `#1710` fixtures seeded `sessionStates` **without** a `sessions`
  roster — not a state the server can produce for a live session — and are corrected
  here. The wire-order test's `switchIdx === -1 ? Infinity` also made it pass just as
  happily when **no** switch was sent at all; it now asserts the switch actually occurred
  before checking the ordering.
- **Tap targets, out of scope but recorded:** `.notification-banner-btn` is
  `padding: 2px 10px` at `--text-xs` — well under the 44pt floor. Growing it would change
  every banner's height (and the banner height is itself the layout-shift surface in the
  unproven symptom above), so it is deliberately untouched here rather than folded into a
  bug fix.
