### PR TITLE
test(scripts): pin the four pre-existing exit paths of assert-test-count (#7462)

### DIFF
--- a/scripts/__tests__/assert-test-count.test.mjs
+++ b/scripts/__tests__/assert-test-count.test.mjs
@@ -85,12 +85,17 @@ await test('an INVALID env override falls back to --min, not to the server defau
 // --- #7462: the four pre-existing exit paths, each mutation-demonstrated ----
 
 await test('a signal death fails even with a clean summary above the floor', async () => {
+  // Kill only after the summary write's flush callback: with piped stdout, a
+  // timed kill can lose the summary under load, and the mutant would then die
+  // via the missing-summary branch instead of the signal branch (Copilot
+  // review on #7476) — red for the wrong reason proves nothing.
   eq(await run(['--min', '5', process.execPath, '-e',
-    "console.log('# tests 9');console.log('# fail 0');setTimeout(()=>process.kill(process.pid,'SIGKILL'),150)"]), 1, 'exit')
+    "process.stdout.write('# tests 9\\n# fail 0\\n',()=>setTimeout(()=>process.kill(process.pid,'SIGKILL'),20))"]), 1, 'exit')
 })
 await test('a non-zero child exit is preserved even when the summary is clean', async () => {
+  // Same flush discipline: process.exit can truncate queued pipe writes.
   eq(await run(['--min', '5', process.execPath, '-e',
-    "console.log('# tests 9');console.log('# fail 0');process.exit(3)"]), 3, 'exit')
+    "process.stdout.write('# tests 9\\n# fail 0\\n',()=>process.exit(3))"]), 3, 'exit')
 })
 await test('a spawn failure is exit 2 (the guard broke), not exit 1 (the code is dirty)', async () => {
   eq(await run(['--min', '5', 'definitely-not-a-real-binary-xyz']), 2, 'exit')

--- a/scripts/__tests__/assert-test-count.test.mjs
+++ b/scripts/__tests__/assert-test-count.test.mjs
@@ -82,6 +82,25 @@ await test('an INVALID env override falls back to --min, not to the server defau
   // (13500) would fail it — so exit 0 pins the fallback target.
   eq(await run(['--min', '3', ...tap(5, 0)], { CHROXY_MIN_TEST_COUNT: 'abc' }), 0, 'exit')
 })
+// --- #7462: the four pre-existing exit paths, each mutation-demonstrated ----
+
+await test('a signal death fails even with a clean summary above the floor', async () => {
+  eq(await run(['--min', '5', process.execPath, '-e',
+    "console.log('# tests 9');console.log('# fail 0');setTimeout(()=>process.kill(process.pid,'SIGKILL'),150)"]), 1, 'exit')
+})
+await test('a non-zero child exit is preserved even when the summary is clean', async () => {
+  eq(await run(['--min', '5', process.execPath, '-e',
+    "console.log('# tests 9');console.log('# fail 0');process.exit(3)"]), 3, 'exit')
+})
+await test('a spawn failure is exit 2 (the guard broke), not exit 1 (the code is dirty)', async () => {
+  eq(await run(['--min', '5', 'definitely-not-a-real-binary-xyz']), 2, 'exit')
+})
+await test('a PARTIAL TAP summary (tests line, no fail line) fails', async () => {
+  // The existing missing-summary case emits NEITHER line, so the floor branch
+  // catches its mutant anyway (#7462) — this one distinguishes the null-check.
+  eq(await run(['--min', '5', process.execPath, '-e', "console.log('# tests 5')"]), 1, 'exit')
+})
+
 await test('no command at all is a usage error', async () => {
   eq(await run(['--min', '5']), 2, 'exit')
 })


### PR DESCRIPTION
Closes #7462.

Adds the four harness cases the issue prescribed (its measurements were taken at `272e51bda` and reproduce at current main): signal-death-after-clean-summary → 1, non-zero-child-exit-with-clean-summary → 3, spawn-failure → 2 (guard-broke, not code-dirty — the distinction `run-windows-tests.mjs` documents as load-bearing), and the partial-TAP case that the existing missing-summary case cannot distinguish (its mutant is caught by the floor branch instead — noted in a comment). `MIN_CASES` 53 → 57.

## Verification

Each of the issue's four documented mutations applied one at a time (occurrence-asserted, byte-backup restores): each fails **exactly its paired case** (12 passed / 1 failed × 4), restored → 13/13. Test-only change; the guarded script is byte-identical.