### PR TITLE
fix(server): heal zombie tool chips and stop full-history replay evicting the client

### DIFF
--- a/packages/server/src/handlers/conversation-handlers.js
+++ b/packages/server/src/handlers/conversation-handlers.js
@@ -11,6 +11,7 @@ import { searchConversations as defaultSearchConversations } from '../conversati
 import { resolveJsonlPath, readConversationHistoryAsync as defaultReadConversationHistoryAsync } from '../jsonl-reader.js'
 import { validateCwdAllowed, broadcastFocusChanged, resolveSession, autoSubscribeOtherClients, buildSessionTokenMismatchPayload, sendSessionError } from '../handler-utils.js'
 import { scopeConversationsToClient } from '../conversation-scope.js'
+import { sendChunkedWithBackpressure, sendHistoryEntry } from '../ws-history.js'
 import { createLogger, loggerForSession } from '../logger.js'
 
 const log = createLogger('ws')
@@ -254,32 +255,60 @@ async function handleRequestFullHistory(ws, client, msg, ctx) {
     sendSessionError(ws, ctx, message)
     return
   }
-  const fullHistory = await ctx.sessions.sessionManager.getFullHistoryAsync(targetId)
-  ctx.transport.send(ws, { type: 'history_replay_start', sessionId: targetId, fullHistory: true })
-  for (const entry of fullHistory) {
-    if (entry.type === 'user_input' || entry.type === 'response' || entry.type === 'tool_use') {
-      ctx.transport.send(ws, {
-        type: 'message',
-        messageType: entry.type,
-        content: entry.content,
-        tool: entry.tool,
-        timestamp: entry.timestamp,
-        sessionId: targetId,
-      })
-    } else {
-      // #7454: this is the SECOND replay path (replayHistory is the first), and
-      // the #7420 live-vs-replayed discriminator keys on `historySeq` PRESENCE
-      // — map the internal `_seq` onto the wire exactly as replayHistory does
-      // (ws-history.js), and never leak the raw counter.
-      const { _seq, ...wireEntry } = entry
-      ctx.transport.send(ws, { ...wireEntry, sessionId: targetId, ...(typeof _seq === 'number' ? { historySeq: _seq } : {}) })
-    }
-  }
-  ctx.transport.send(ws, { type: 'history_replay_end', sessionId: targetId })
-  // #7340: same wipe, same repair — `request_full_history` targets a LIVE
-  // session, so its confirmed-backgrounded subagents must be re-asserted after
-  // the replay that cleared them.
-  ctx.transport.reseedActiveAgents(ws, targetId)
+  const sessionManager = ctx.sessions.sessionManager
+  const fullHistory = await sessionManager.getFullHistoryAsync(targetId)
+  // Route through ctx.transport so a method-style sender keeps its receiver;
+  // the shared loop only ever needs a (ws, payload) callable.
+  const send = (target, payload) => ctx.transport.send(target, payload)
+
+  // #7460 — frame parity with replayHistory. `truncated` is how a client learns
+  // the ring buffer overflowed on THIS replay; `latestSeq` is the input
+  // reconcileReplayEnd (store-core/replay-reconcile.ts) uses to finalise the
+  // cursor when the replayed slice carried no seq of its own. Both helpers are
+  // probed the way replayHistory probes getLatestHistorySeq — a legacy manager
+  // must not throw its way out of a replay.
+  const truncated = typeof sessionManager.isHistoryTruncated === 'function'
+    ? sessionManager.isHistoryTruncated(targetId)
+    : false
+  const latestSeq = typeof sessionManager.getLatestHistorySeq === 'function'
+    ? sessionManager.getLatestHistorySeq(targetId)
+    : 0
+
+  send(ws, { type: 'history_replay_start', sessionId: targetId, truncated, fullHistory: true, latestSeq })
+
+  // #7460 — the SAME chunk + bufferedAmount loop replayHistory uses, from the
+  // one implementation of it. Sending a 1000-entry ring buffer synchronously
+  // could push the socket past the 1MB EVICT_THRESHOLD in ws-client-sender.js
+  // and CLOSE the client: "Sync Full History" — the button a user presses
+  // BECAUSE the view looks wrong — was the action that could drop the
+  // connection.
+  sendChunkedWithBackpressure(ws, fullHistory, {
+    emit: (entry) => {
+      if (entry.type === 'user_input' || entry.type === 'response' || entry.type === 'tool_use') {
+        send(ws, {
+          type: 'message',
+          messageType: entry.type,
+          content: entry.content,
+          tool: entry.tool,
+          timestamp: entry.timestamp,
+          sessionId: targetId,
+        })
+      } else {
+        // This is the SECOND replay path, and both per-entry duties — the
+        // `_seq` → `historySeq` map (#7454) and the `result` → `agent_idle`
+        // synthesis (#7459 / #4628) — come from ws-history.js's shared emitter
+        // rather than a copy that can drift away from it again.
+        sendHistoryEntry(send, ws, targetId, entry)
+      }
+    },
+    onDone: () => {
+      send(ws, { type: 'history_replay_end', sessionId: targetId, latestSeq })
+      // #7340: same wipe, same repair — `request_full_history` targets a LIVE
+      // session, so its confirmed-backgrounded subagents must be re-asserted
+      // after the replay that cleared them.
+      ctx.transport.reseedActiveAgents(ws, targetId)
+    },
+  })
 }
 
 async function handleRequestSessionContext(ws, client, msg, ctx) {

--- a/packages/server/src/handlers/conversation-handlers.js
+++ b/packages/server/src/handlers/conversation-handlers.js
@@ -262,19 +262,36 @@ async function handleRequestFullHistory(ws, client, msg, ctx) {
   const send = (target, payload) => ctx.transport.send(target, payload)
 
   // #7460 — frame parity with replayHistory. `truncated` is how a client learns
-  // the ring buffer overflowed on THIS replay; `latestSeq` is the input
-  // reconcileReplayEnd (store-core/replay-reconcile.ts) uses to finalise the
-  // cursor when the replayed slice carried no seq of its own. Both helpers are
-  // probed the way replayHistory probes getLatestHistorySeq — a legacy manager
-  // must not throw its way out of a replay.
+  // the ring buffer overflowed. Probed the way replayHistory probes its seq
+  // helper: a legacy manager must not throw its way out of a replay.
+  //
+  // NOTE (#7484): `truncated` describes the RING BUFFER, so it is not meaningful
+  // on the JSONL-sourced replay below. Left as-is here deliberately — that is
+  // tracked separately rather than folded into this frame's fix.
   const truncated = typeof sessionManager.isHistoryTruncated === 'function'
     ? sessionManager.isHistoryTruncated(targetId)
     : false
-  const latestSeq = typeof sessionManager.getLatestHistorySeq === 'function'
-    ? sessionManager.getLatestHistorySeq(targetId)
-    : 0
+  // `latestSeq` must describe what THIS replay actually DELIVERS, not what the
+  // ring buffer happens to hold. `getFullHistoryAsync` PREFERS the JSONL
+  // transcript whenever `resumeSessionId` is set, and jsonl-reader.js emits only
+  // user_input/response/tool_use — none of which carry `_seq`. Sourcing the
+  // counter from the buffer there advertises a cursor the client never received:
+  // `reconcileReplayEnd` hands it to `recordHistorySeq`, so the NEXT reconnect
+  // resolves as already-current and replays NOTHING, stranding the client on the
+  // lossy JSONL rebuild. Derived from the entries themselves this is unchanged on
+  // the ring-buffer path — that slice is the whole buffer, so its max `_seq` IS
+  // `getLatestHistorySeq()` — and correctly advertises nothing on the JSONL path.
+  let latestSeq
+  for (const entry of fullHistory) {
+    if (entry && typeof entry._seq === 'number' && (latestSeq === undefined || entry._seq > latestSeq)) {
+      latestSeq = entry._seq
+    }
+  }
+  // Omitted, never zeroed: absence means "this replay carried no cursor", while
+  // `latestSeq: 0` is a real seq the client would happily record.
+  const seqFrame = latestSeq === undefined ? {} : { latestSeq }
 
-  send(ws, { type: 'history_replay_start', sessionId: targetId, truncated, fullHistory: true, latestSeq })
+  send(ws, { type: 'history_replay_start', sessionId: targetId, truncated, fullHistory: true, ...seqFrame })
 
   // #7460 — the SAME chunk + bufferedAmount loop replayHistory uses, from the
   // one implementation of it. Sending a 1000-entry ring buffer synchronously
@@ -302,7 +319,7 @@ async function handleRequestFullHistory(ws, client, msg, ctx) {
       }
     },
     onDone: () => {
-      send(ws, { type: 'history_replay_end', sessionId: targetId, latestSeq })
+      send(ws, { type: 'history_replay_end', sessionId: targetId, ...seqFrame })
       // #7340: same wipe, same repair — `request_full_history` targets a LIVE
       // session, so its confirmed-backgrounded subagents must be re-asserted
       // after the replay that cleared them.

--- a/packages/server/src/ws-history.js
+++ b/packages/server/src/ws-history.js
@@ -156,6 +156,103 @@ export function scheduleAfterDrain(ws, fn) {
   setTimeout(poll, BACKPRESSURE_POLL_INTERVAL_MS)
 }
 
+// #7460 — ONE implementation of the #4833 chunk-and-drain loop, shared by both
+// replay paths. `replayHistory` (connect / session-switch) and
+// `handleRequestFullHistory` ("Sync Full History", conversation-handlers.js)
+// were divergent copies, and the second had no bufferedAmount check at all: it
+// pushed the entire history onto the socket in one turn of the event loop and
+// could sail past the 1MB EVICT_THRESHOLD in ws-client-sender.js, which CLOSES
+// the client. A second copy of this loop is how that divergence started, so
+// there is deliberately only one.
+const REPLAY_CHUNK_SIZE = 20
+
+/**
+ * Send `entries` to `ws` in REPLAY_CHUNK_SIZE batches, yielding the event loop
+ * between chunks and pausing whenever `ws.bufferedAmount` climbs past
+ * BACKPRESSURE_PAUSE_THRESHOLD (#4833). Three gates, all load-bearing:
+ *
+ *  - chunk ENTRY — the first chunk can land on a socket that is already
+ *    congested from a preceding burst (post-auth info, session_switched), so
+ *    it is deferred before anything is written. The mid-chunk break only fires
+ *    *after* a send, so without this gate one fat payload still lands on a
+ *    near-eviction buffer.
+ *  - MID-chunk — REPLAY_CHUNK_SIZE was sized for short messages; two 200KB
+ *    tool_results blow past the threshold inside a single chunk, so the loop
+ *    breaks out and resumes from the next UNSENT entry.
+ *  - chunk SCHEDULING — pause before queueing the next chunk.
+ *
+ * `emit(entry, index)` writes one entry; `onDone()` runs once every entry has
+ * been written. Neither runs after `ws.readyState` leaves OPEN — a client that
+ * disconnects mid-replay gets no further frames and no end marker, which is
+ * the behaviour both callers already relied on.
+ *
+ * @param {WebSocket} ws - The client socket.
+ * @param {Array} entries - The full slice to deliver.
+ * @param {{startOffset?: number, emit: (entry: any, index: number) => void, onDone: () => void}} opts
+ */
+export function sendChunkedWithBackpressure(ws, entries, { startOffset = 0, emit, onDone }) {
+  const sendChunk = (offset) => {
+    if (ws.readyState !== 1) return
+    if ((ws.bufferedAmount || 0) > BACKPRESSURE_PAUSE_THRESHOLD) {
+      scheduleAfterDrain(ws, () => sendChunk(offset))
+      return
+    }
+    const end = Math.min(offset + REPLAY_CHUNK_SIZE, entries.length)
+    let nextOffset = end
+    for (let i = offset; i < end; i++) {
+      emit(entries[i], i)
+      if (i + 1 < end && (ws.bufferedAmount || 0) > BACKPRESSURE_PAUSE_THRESHOLD) {
+        nextOffset = i + 1
+        break
+      }
+    }
+    if (nextOffset < entries.length) {
+      scheduleAfterDrain(ws, () => sendChunk(nextOffset))
+    } else {
+      onDone()
+    }
+  }
+  // An already-current client (startOffset === entries.length) still gets
+  // `onDone` — the empty-slice path, and the most common replay of all.
+  if (startOffset >= entries.length) onDone()
+  else sendChunk(startOffset)
+}
+
+/**
+ * Write ONE history entry to a client, the way BOTH replay paths must.
+ *
+ * Two things happen per entry, and both were forgotten by the second copy of
+ * this loop — which is the whole reason this is a function (#7454, #7459):
+ *
+ *  1. #5555.3 — surface the server-internal `_seq` as `historySeq` (and strip
+ *     the underscore-prefixed internal field) so the client can advance its
+ *     per-session cursor as it applies each entry. #7420's live-vs-replayed
+ *     discriminator keys on that field's PRESENCE, so a missing stamp reads as
+ *     a live racer — and a fabricated one is just as wrong.
+ *  2. #4628 — mirror the live `result` → `agent_idle` fan-out from
+ *     event-normalizer.js. The dashboard's handler dispatch table has no
+ *     `result` entry, only `agent_idle`, and both clients' `case 'result'` is
+ *     replay-gated (#4466) precisely so a replayed result cannot wipe the
+ *     activeTools that `history_replay_start` is preserving. That leaves
+ *     `agent_idle` — which is NOT replay-gated — as the only frame that clears
+ *     a zombie "Running X" chip left by an orphan tool_start (a dropped
+ *     PostToolUse hook, the #4628 root cause). The companion `_emitResult`
+ *     sweep in BaseSession stops new orphans being persisted; this heals the
+ *     sessions already wedged, on every replay path a user can reach.
+ *
+ * @param {(ws: WebSocket, payload: object) => void} send
+ * @param {WebSocket} ws
+ * @param {string} sessionId
+ * @param {object} entry - A ring-buffer entry, possibly carrying `_seq`.
+ */
+export function sendHistoryEntry(send, ws, sessionId, entry) {
+  const { _seq, ...wireEntry } = entry
+  send(ws, { ...wireEntry, sessionId, ...(typeof _seq === 'number' ? { historySeq: _seq } : {}) })
+  if (entry && entry.type === 'result') {
+    send(ws, { type: 'agent_idle', sessionId })
+  }
+}
+
 /**
  * Send all post-authentication info to a newly authenticated client.
  * This includes auth_ok, server mode, session list, model/permission state,
@@ -1241,78 +1338,22 @@ export function replayHistory(ctx, ws, sessionId, opts = {}) {
     reseedActiveAgents(ctx, ws, sessionId)
   }
 
-  const CHUNK_SIZE = 20
-  const sendChunk = (offset) => {
-    if (ws.readyState !== 1) return
-    // #4833 follow-up: gate chunk *entry* on bufferedAmount too, not just
-    // chunk *scheduling*. The recursive setImmediate-via-scheduleAfterDrain
-    // path is already gated, but the very first sendChunk(0) call can land
-    // on a socket that's already congested from the preceding
-    // sendPostAuthInfo / session_switched burst. Without this check, the
-    // first history entry would be sent unconditionally and the mid-chunk
-    // break (which only fires *after* a send) wouldn't trip until i=1 —
-    // meaning we still push one fat tool_result onto an already-congested
-    // socket and can trip the 1MB EVICT_THRESHOLD.
-    if ((ws.bufferedAmount || 0) > BACKPRESSURE_PAUSE_THRESHOLD) {
-      scheduleAfterDrain(ws, () => sendChunk(offset))
-      return
-    }
-    const end = Math.min(offset + CHUNK_SIZE, history.length)
-    let nextOffset = end
-    for (let i = offset; i < end; i++) {
-      const entry = history[i]
-      // #5555.3 — surface the server-internal `_seq` to the client as
-      // `historySeq` (and strip the underscore-prefixed internal field) so the
-      // client can advance its per-session cursor as it applies each entry.
-      const { _seq, ...wireEntry } = entry
-      send(ws, { ...wireEntry, sessionId, ...(typeof _seq === 'number' ? { historySeq: _seq } : {}) })
-      // #4628: mirror the live `result → agent_idle` fan-out from
-      // event-normalizer.js. The dashboard's handler dispatch table has
-      // no `result` entry — only `agent_idle` — so a raw `result` in
-      // history-replay is silently dropped, and `handleAgentIdle`
-      // (which clears activeTools as the #4308 safety net) never fires.
-      // Without this, a session that completed cleanly but had an
-      // orphan tool_start in history (e.g. dropped PostToolUse hook,
-      // #4628 root cause) shows a zombie "Running X" chip every time
-      // the dashboard reconnects, until the next chroxy restart. The
-      // companion `_emitResult` sweep in BaseSession prevents new
-      // orphans from being persisted; this heals the existing wedged
-      // sessions on reconnect without requiring a restart.
-      if (entry && entry.type === 'result') {
-        send(ws, { type: 'agent_idle', sessionId })
-      }
-      // #4833: break out of the chunk early if bufferedAmount already
-      // crossed the pause threshold mid-burst. The CHUNK_SIZE=20 cap was
-      // designed for short messages; a session with fat tool_result
-      // payloads (200KB+) can blow past the 1MB EVICT_THRESHOLD inside
-      // a single chunk, before the post-chunk scheduleAfterDrain ever
-      // gets to inspect bufferedAmount. Pause + resume from the next
-      // unsent entry instead.
-      if (i + 1 < end && (ws.bufferedAmount || 0) > BACKPRESSURE_PAUSE_THRESHOLD) {
-        nextOffset = i + 1
-        break
-      }
-    }
-    if (nextOffset < history.length) {
-      // #4833: pause if the socket is already congested before scheduling
-      // the next chunk. Without this, every setImmediate fires another
-      // burst regardless of buffer pressure, blowing past the 1MB
-      // EVICT_THRESHOLD in ws-client-sender.js on sessions with fat
-      // tool_result payloads.
-      scheduleAfterDrain(ws, () => sendChunk(nextOffset))
-    } else {
-      finishReplay()
-    }
-  }
   // #5555.3 — start at the resolved offset: 0 for a full replay, the
   // first-newer-than-cursor index for a delta replay. When the client is
-  // already current (startOffset === history.length) this immediately falls
-  // through to the empty-slice path and emits start+end with nothing between.
-  if (startOffset >= history.length) {
-    finishReplay()
-  } else {
-    sendChunk(startOffset)
-  }
+  // already current (startOffset === history.length) sendChunkedWithBackpressure
+  // falls straight through to the empty-slice path and emits start+end with
+  // nothing between.
+  //
+  // #7460 — the chunk-and-drain machinery and the per-entry wire mapping both
+  // live in ONE place now (above), because `handleRequestFullHistory` is the
+  // second caller of exactly this loop and every hand-copied piece of it has
+  // drifted: the `_seq` map (#7454), the `result` → `agent_idle` synthesis
+  // (#7459), and the bufferedAmount gating (#7460) were each missing there.
+  sendChunkedWithBackpressure(ws, history, {
+    startOffset,
+    emit: (entry) => sendHistoryEntry(send, ws, sessionId, entry),
+    onDone: finishReplay,
+  })
 }
 
 /**

--- a/packages/server/src/ws-history.js
+++ b/packages/server/src/ws-history.js
@@ -162,24 +162,36 @@ export function scheduleAfterDrain(ws, fn) {
 // were divergent copies, and the second had no bufferedAmount check at all: it
 // pushed the entire history onto the socket in one turn of the event loop and
 // could sail past the 1MB EVICT_THRESHOLD in ws-client-sender.js, which CLOSES
-// the client. A second copy of this loop is how that divergence started, so
-// there is deliberately only one.
+// the client. A second copy of this loop is how that divergence started, so the
+// two REPLAY paths now share exactly one.
+//
+// Not the only instance in this file, and the comment should not pretend
+// otherwise: `flushPostAuthQueue` below still carries its own copy of the same
+// chunk-and-drain shape, kept separate here because it also owns the
+// `_flushing` / `_flushOverflow` queue state. Folding it in is tracked as #7485.
 const REPLAY_CHUNK_SIZE = 20
 
 /**
  * Send `entries` to `ws` in REPLAY_CHUNK_SIZE batches, yielding the event loop
  * between chunks and pausing whenever `ws.bufferedAmount` climbs past
- * BACKPRESSURE_PAUSE_THRESHOLD (#4833). Three gates, all load-bearing:
+ * BACKPRESSURE_PAUSE_THRESHOLD (#4833). Three gates, of which TWO carry
+ * behaviour on their own:
  *
- *  - chunk ENTRY — the first chunk can land on a socket that is already
- *    congested from a preceding burst (post-auth info, session_switched), so
- *    it is deferred before anything is written. The mid-chunk break only fires
- *    *after* a send, so without this gate one fat payload still lands on a
- *    near-eviction buffer.
- *  - MID-chunk — REPLAY_CHUNK_SIZE was sized for short messages; two 200KB
- *    tool_results blow past the threshold inside a single chunk, so the loop
- *    breaks out and resumes from the next UNSENT entry.
- *  - chunk SCHEDULING — pause before queueing the next chunk.
+ *  - chunk ENTRY (load-bearing) — the first chunk can land on a socket that is
+ *    already congested from a preceding burst (post-auth info,
+ *    session_switched), so it is deferred before anything is written. The
+ *    mid-chunk break only fires *after* a send, so without this gate one fat
+ *    payload still lands on a near-eviction buffer.
+ *  - MID-chunk (load-bearing) — REPLAY_CHUNK_SIZE was sized for short messages;
+ *    two 200KB tool_results blow past the threshold inside a single chunk, so
+ *    the loop breaks out and resumes from the next UNSENT entry.
+ *  - chunk SCHEDULING — pauses before queueing the next chunk. Retained as the
+ *    inherited #4833 shape, but it is NOT independently load-bearing: replacing
+ *    it with a bare `setImmediate` is an equivalent mutation, because the next
+ *    `sendChunk` re-checks the chunk-ENTRY gate and enters the same drain wait
+ *    (with the same #5328 max-wait cap) one tick later. Established by mutation
+ *    testing and a 48-scenario differential during review of PR #7479; do not
+ *    read this line as a third independent guard.
  *
  * `emit(entry, index)` writes one entry; `onDone()` runs once every entry has
  * been written. Neither runs after `ws.readyState` leaves OPEN — a client that

--- a/packages/server/src/ws-history.js
+++ b/packages/server/src/ws-history.js
@@ -224,6 +224,16 @@ export function sendChunkedWithBackpressure(ws, entries, { startOffset = 0, emit
       onDone()
     }
   }
+  // Both entry paths are gated on OPEN, not just the chunking one. `sendChunk`
+  // re-checks readyState itself (it is also the resume point for every
+  // scheduled continuation), but the EMPTY-slice path below reaches `onDone`
+  // without going through it — so without this check a client that vanished
+  // before an already-current replay still had its `history_replay_end` and
+  // re-seed burst written at a dead socket, contradicting the contract stated
+  // above. That is the comment-stronger-than-code class
+  // (docs/false-safety-guards.md), and it hid in the path taken MOST often:
+  // the already-current reconnect (Copilot review, PR #7479).
+  if (ws.readyState !== 1) return
   // An already-current client (startOffset === entries.length) still gets
   // `onDone` — the empty-slice path, and the most common replay of all.
   if (startOffset >= entries.length) onDone()

--- a/packages/server/tests/conversation-full-history-replay.test.js
+++ b/packages/server/tests/conversation-full-history-replay.test.js
@@ -368,7 +368,38 @@ describe('#7460 — request_full_history sends under the same chunk + bufferedAm
     assert.deepEqual(reseeds, [], 'and no follow-up work is queued against a dead peer')
   })
 
-  it('carries `truncated` + `latestSeq` on history_replay_start and `latestSeq` on history_replay_end', async () => {
+  it('omits latestSeq entirely when NO forwarded entry carried a _seq (the JSONL path)', async () => {
+    // C1 (review of PR #7479). `getFullHistoryAsync` PREFERS the JSONL
+    // transcript whenever `resumeSessionId` is set, and jsonl-reader.js emits
+    // only user_input/response/tool_use — none of which carry `_seq`. Sourcing
+    // `latestSeq` from the RING BUFFER there tells the client it holds entries
+    // this replay never delivered: `reconcileReplayEnd` feeds it straight to
+    // `recordHistorySeq`, so the NEXT reconnect resolves the cursor as
+    // already-current and replays NOTHING — stranding the client on the lossy
+    // JSONL rebuild with no way back to the ring buffer's richer entries.
+    const { ctx, sends, ws } = build([
+      { type: 'user_input', content: 'hi', timestamp: 1 },
+      { type: 'response', content: 'yo', timestamp: 2 },
+      { type: 'tool_use', content: 'ls', tool: 'Bash', timestamp: 3 },
+    ], { managerOverrides: { getLatestHistorySeq: () => 42 } })
+    await handler(ws, client(), { type: 'request_full_history' }, ctx)
+
+    const start = sends.find(m => m.type === 'history_replay_start')
+    const end = sends.find(m => m.type === 'history_replay_end')
+    // Precondition, stated as an assertion so this test cannot pass because the
+    // fixture silently grew a seq: nothing in a JSONL replay is seq-stamped.
+    assert.equal(sends.some(m => 'historySeq' in m), false,
+      'precondition: a JSONL-sourced history stamps historySeq on nothing')
+    assert.ok(!('latestSeq' in end),
+      `the end frame must not advertise a cursor this replay never delivered; got latestSeq=${end.latestSeq}`)
+    assert.ok(!('latestSeq' in start),
+      `nor may the start frame; got latestSeq=${start.latestSeq}`)
+  })
+
+  it('carries `truncated`, and sources `latestSeq` from the entries DELIVERED rather than the buffer', async () => {
+    // The buffer's counter says 42; this replay delivered up to seq 9. Telling
+    // the client 42 would advance its cursor past entries it never received
+    // (C1) — so the frames must carry what was actually sent.
     const { ctx, sends, ws } = build([{ type: 'response', content: 'Hi', timestamp: 1, _seq: 9 }], {
       managerOverrides: { isHistoryTruncated: () => true, getLatestHistorySeq: () => 42 },
     })
@@ -378,11 +409,21 @@ describe('#7460 — request_full_history sends under the same chunk + bufferedAm
     const end = sends.find(m => m.type === 'history_replay_end')
     assert.equal(start.fullHistory, true, 'still an authoritative rebuild')
     assert.equal(start.truncated, true, 'without it a client cannot tell the ring buffer overflowed on this replay')
-    assert.equal(start.latestSeq, 42, 'replayHistory rides latestSeq on the start frame too')
-    assert.equal(end.latestSeq, 42, 'reconcileReplayEnd finalises the cursor from the END frame\'s latestSeq')
+    assert.equal(start.latestSeq, 9, 'replayHistory rides latestSeq on the start frame too — but only the delivered one')
+    assert.equal(end.latestSeq, 9, 'reconcileReplayEnd finalises the cursor from the END frame\'s latestSeq')
   })
 
-  it('degrades to truncated:false / latestSeq:0 on a legacy manager missing the helpers', async () => {
+  it('takes the HIGHEST delivered _seq, not the last entry\'s', async () => {
+    const { ctx, sends, ws } = build([
+      { type: 'tool_start', tool: 'Bash', timestamp: 1, _seq: 12 },
+      { type: 'response', content: 'Hi', timestamp: 2 },
+    ])
+    await handler(ws, client(), { type: 'request_full_history' }, ctx)
+    const end = sends.find(m => m.type === 'history_replay_end')
+    assert.equal(end.latestSeq, 12, 'a trailing seq-less entry must not erase the cursor the replay did deliver')
+  })
+
+  it('degrades to truncated:false and NO latestSeq on a legacy manager missing the helpers', async () => {
     // Same defensive posture replayHistory takes for getLatestHistorySeq —
     // an older ctx fixture must not throw its way out of a replay.
     const { ctx, sends, ws } = build([{ type: 'response', content: 'Hi', timestamp: 1 }], {
@@ -391,7 +432,7 @@ describe('#7460 — request_full_history sends under the same chunk + bufferedAm
     await handler(ws, client(), { type: 'request_full_history' }, ctx)
     const start = sends.find(m => m.type === 'history_replay_start')
     assert.equal(start.truncated, false)
-    assert.equal(start.latestSeq, 0)
+    assert.ok(!('latestSeq' in start), 'no entry carried a _seq, so no cursor is advertised — never a fabricated 0')
     assert.ok(sends.some(m => m.type === 'history_replay_end'), 'the replay still completes')
   })
 })

--- a/packages/server/tests/conversation-full-history-replay.test.js
+++ b/packages/server/tests/conversation-full-history-replay.test.js
@@ -3,6 +3,73 @@ import assert from 'node:assert/strict'
 import { conversationHandlers } from '../src/handlers/conversation-handlers.js'
 import { createMockSessionManager, nsCtx } from './test-helpers.js'
 
+const handler = conversationHandlers.request_full_history
+
+/** An OPEN, never-congested socket — the common case. */
+function makeOpenWs() {
+  return { readyState: 1, bufferedAmount: 0 }
+}
+
+/**
+ * A ws stub whose `bufferedAmount` grows by the wire size of every payload
+ * written and only falls when the simulated peer acknowledges — i.e. what the
+ * real socket reports between event-loop turns. Mirrors the fixture the #4833
+ * `replayHistory` tests use in ws-history.test.js, because this handler is the
+ * SECOND replay path and must behave identically under the same pressure.
+ */
+function makeBackpressuredWs(readyState = 1) {
+  const ws = {
+    readyState,
+    bufferedAmount: 0,
+    send(data) {
+      ws.bufferedAmount += Buffer.byteLength(typeof data === 'string' ? data : JSON.stringify(data))
+    },
+    close() { ws._closed = true },
+    drain(bytes) { ws.bufferedAmount = Math.max(0, ws.bufferedAmount - bytes) },
+    drainAll() { ws.bufferedAmount = 0 },
+  }
+  return ws
+}
+
+function build(historyEntries, { ws = makeOpenWs(), managerOverrides = {} } = {}) {
+  const sends = []
+  const reseeds = []
+  const { manager } = createMockSessionManager([{ id: 'sess-1', name: 'Work', cwd: '/repo' }])
+  manager.getFullHistoryAsync = async () => historyEntries
+  Object.assign(manager, managerOverrides)
+  const ctx = nsCtx({
+    send: (target, msg) => {
+      sends.push(msg)
+      // Feed the byte stream back into the stub so the back-pressure gate sees
+      // a real, growing bufferedAmount. A no-op on the plain open-ws stub,
+      // which has no send() — that one models a socket that never congests.
+      if (target && typeof target.send === 'function' && target.readyState === 1) {
+        target.send(JSON.stringify(msg))
+      }
+    },
+    sessionManager: manager,
+    reseedActiveAgents: (_ws, sid) => reseeds.push(sid),
+  })
+  return { ctx, sends, ws, reseeds }
+}
+
+const client = () => ({ id: 'c1', activeSessionId: 'sess-1' })
+
+/** Yield the event loop `n` times so setImmediate-scheduled chunks can run. */
+async function turn(n = 5) {
+  for (let i = 0; i < n; i++) await new Promise(r => setImmediate(r))
+}
+
+function fatHistory(count = 30, payloadBytes = 200 * 1024) {
+  const bigText = 'x'.repeat(payloadBytes)
+  return Array.from({ length: count }, (_, i) => ({
+    type: 'tool_result',
+    toolUseId: `toolu_${i}`,
+    content: bigText,
+    _seq: i + 1,
+  }))
+}
+
 /**
  * #7454 — `request_full_history` is the SECOND replay path (the first is
  * ws-history.js's `replayHistory`), and the #7420 live-vs-replayed
@@ -12,26 +79,12 @@ import { createMockSessionManager, nsCtx } from './test-helpers.js'
  * leaking onto the wire besides.
  */
 describe('#7454 — request_full_history maps _seq onto the wire like replayHistory does', () => {
-  const handler = conversationHandlers.request_full_history
-
-  function build(historyEntries) {
-    const sends = []
-    const { manager } = createMockSessionManager([{ id: 'sess-1', name: 'Work', cwd: '/repo' }])
-    manager.getFullHistoryAsync = async () => historyEntries
-    const ctx = nsCtx({
-      send: (ws, msg) => sends.push(msg),
-      sessionManager: manager,
-      reseedActiveAgents: () => {},
-    })
-    return { ctx, sends }
-  }
-
   it('stamps historySeq on a ring-buffer user_question and never leaks the raw _seq', async () => {
-    const { ctx, sends } = build([
+    const { ctx, sends, ws } = build([
       { type: 'user_question', toolUseId: 't1', questions: [], timestamp: 123, _seq: 7 },
       { type: 'response', content: 'Hi', timestamp: 124 },
     ])
-    await handler({}, { id: 'c1', activeSessionId: 'sess-1' }, { type: 'request_full_history' }, ctx)
+    await handler(ws, client(), { type: 'request_full_history' }, ctx)
     const q = sends.find(m => m.type === 'user_question')
     assert.ok(q, 'the user_question entry is forwarded')
     assert.equal(q.historySeq, 7, 'the internal _seq must surface as historySeq — the #7420 discriminator keys on it')
@@ -41,10 +94,10 @@ describe('#7454 — request_full_history maps _seq onto the wire like replayHist
   it('POSITIVE CONTROL: an entry with no _seq goes out with NO historySeq key', async () => {
     // Absence is the live signal — manufacturing a historySeq here would be
     // as wrong as omitting a real one.
-    const { ctx, sends } = build([
+    const { ctx, sends, ws } = build([
       { type: 'user_question', toolUseId: 't2', questions: [], timestamp: 125 },
     ])
-    await handler({}, { id: 'c1', activeSessionId: 'sess-1' }, { type: 'request_full_history' }, ctx)
+    await handler(ws, client(), { type: 'request_full_history' }, ctx)
     const q = sends.find(m => m.type === 'user_question')
     assert.ok(q)
     assert.ok(!('historySeq' in q), 'no _seq means no historySeq — never null, never fabricated')
@@ -54,11 +107,11 @@ describe('#7454 — request_full_history maps _seq onto the wire like replayHist
     // Review on #7458: narrowing the mapping to user_question survived every
     // test. The clients read historySeq off `message` and `tool_start` too
     // (the #5555.3 delta-replay cursor), so the breadth is load-bearing.
-    const { ctx, sends } = build([
+    const { ctx, sends, ws } = build([
       { type: 'tool_start', tool: 'Bash', timestamp: 1, _seq: 11 },
       { type: 'tool_result', tool: 'Bash', timestamp: 2, _seq: 12 },
     ])
-    await handler({}, { id: 'c1', activeSessionId: 'sess-1' }, { type: 'request_full_history' }, ctx)
+    await handler(ws, client(), { type: 'request_full_history' }, ctx)
     const ts = sends.find(m => m.type === 'tool_start')
     const tr = sends.find(m => m.type === 'tool_result')
     assert.equal(ts.historySeq, 11, 'tool_start must carry historySeq — the delta-replay cursor reads it')
@@ -67,16 +120,278 @@ describe('#7454 — request_full_history maps _seq onto the wire like replayHist
   })
 
   it('still brackets the forward with history_replay_start/end and rebuilds message-branch entries', async () => {
-    const { ctx, sends } = build([
+    const { ctx, sends, ws } = build([
       { type: 'response', content: 'Hi', timestamp: 1, _seq: 3 },
       { type: 'user_question', toolUseId: 't3', questions: [], timestamp: 2, _seq: 4 },
     ])
-    await handler({}, { id: 'c1', activeSessionId: 'sess-1' }, { type: 'request_full_history' }, ctx)
+    await handler(ws, client(), { type: 'request_full_history' }, ctx)
     assert.equal(sends[0].type, 'history_replay_start')
     assert.equal(sends[sends.length - 1].type, 'history_replay_end')
     const rebuilt = sends.find(m => m.type === 'message')
     assert.equal(rebuilt.messageType, 'response')
     assert.ok(!('_seq' in rebuilt), 'the message branch never carried _seq and must not start')
     assert.ok(!('historySeq' in rebuilt), 'nor may it grow a historySeq — the rebuild enumerates its fields')
+  })
+})
+
+/**
+ * #7459 — the same family, a different mechanism. `replayHistory` synthesises
+ * an `agent_idle` after every replayed `result` (#4628); this handler did not.
+ *
+ * The raw `result` is not a substitute: both clients DO have a `case 'result'`
+ * that clears `activeTools` as the #4308 turn-boundary net, but #4466 gated it
+ * behind "not replaying" so a replayed result can't wipe the activeTools that
+ * `history_replay_start` is trying to preserve. During a replay the clear comes
+ * from `agent_idle`, which is NOT replay-gated — and only replayHistory
+ * synthesised it. Net effect: reconnect/session-switch healed a zombie
+ * "Running X" chip, but "Sync Full History" — the button a user presses
+ * BECAUSE the view looks wrong — could not.
+ */
+describe('#7459 — request_full_history mirrors replayHistory result → agent_idle synthesis (#4628)', () => {
+  it('emits agent_idle immediately after a ring-buffer result entry', async () => {
+    const { ctx, sends, ws } = build([
+      { type: 'tool_start', tool: 'Bash', toolUseId: 'toolu_1', timestamp: 1, _seq: 1 },
+      { type: 'result', durationMs: 12, timestamp: 2, _seq: 2 },
+    ])
+    await handler(ws, client(), { type: 'request_full_history' }, ctx)
+
+    const types = sends.map(m => m.type)
+    const resultIdx = types.indexOf('result')
+    const idleIdx = types.indexOf('agent_idle')
+    assert.ok(resultIdx >= 0, 'the result entry itself is still forwarded')
+    assert.ok(
+      idleIdx >= 0,
+      'a replayed result must be followed by a synthesized agent_idle — the clients\' case \'result\' is replay-gated (#4466), so agent_idle is the ONLY thing that clears the zombie tool chip',
+    )
+    assert.equal(idleIdx, resultIdx + 1, 'the synthesis must come IMMEDIATELY after its result, in the same order replayHistory emits it')
+  })
+
+  it('emits the SAME shape replayHistory does — { type, sessionId } and nothing else', async () => {
+    const { ctx, sends, ws } = build([
+      { type: 'result', durationMs: 5, timestamp: 1, _seq: 4 },
+    ])
+    await handler(ws, client(), { type: 'request_full_history' }, ctx)
+    const idle = sends.find(m => m.type === 'agent_idle')
+    assert.ok(idle, 'agent_idle must be synthesized')
+    assert.equal(idle.sessionId, 'sess-1', 'the synthesis targets the replayed session')
+    assert.deepEqual(
+      Object.keys(idle).sort(),
+      ['sessionId', 'type'],
+      'ws-history.js emits exactly { type, sessionId }; a divergent shape would hit different client branches',
+    )
+    assert.ok(!('historySeq' in idle), 'the synthesis is a fresh frame, not a replayed entry — it carries no seq')
+  })
+
+  it('brackets the synthesis INSIDE the replay window', async () => {
+    // Outside the window the client would treat it as a live idle and the
+    // #4466 gate reasoning no longer holds.
+    const { ctx, sends, ws } = build([
+      { type: 'result', durationMs: 5, timestamp: 1, _seq: 4 },
+    ])
+    await handler(ws, client(), { type: 'request_full_history' }, ctx)
+    const types = sends.map(m => m.type)
+    const idleIdx = types.indexOf('agent_idle')
+    assert.equal(types[0], 'history_replay_start')
+    assert.equal(types[types.length - 1], 'history_replay_end')
+    assert.ok(idleIdx > 0 && idleIdx < types.length - 1, `agent_idle must sit between the replay brackets; got order ${types.join(',')}`)
+  })
+
+  it('synthesizes ONE agent_idle per result, not one per replay', async () => {
+    const { ctx, sends, ws } = build([
+      { type: 'result', durationMs: 1, timestamp: 1, _seq: 1 },
+      { type: 'tool_start', tool: 'Bash', timestamp: 2, _seq: 2 },
+      { type: 'result', durationMs: 2, timestamp: 3, _seq: 3 },
+    ])
+    await handler(ws, client(), { type: 'request_full_history' }, ctx)
+    const idles = sends.filter(m => m.type === 'agent_idle')
+    assert.equal(idles.length, 2, 'each replayed result carries its own turn boundary')
+  })
+
+  it('POSITIVE CONTROL: a history with no result entry synthesizes nothing', async () => {
+    const { ctx, sends, ws } = build([
+      { type: 'tool_start', tool: 'Bash', timestamp: 1, _seq: 1 },
+      { type: 'user_question', toolUseId: 't1', questions: [], timestamp: 2, _seq: 2 },
+    ])
+    await handler(ws, client(), { type: 'request_full_history' }, ctx)
+    assert.equal(sends.filter(m => m.type === 'agent_idle').length, 0,
+      'agent_idle is synthesized FROM a result — an unconditional emit would clear activeTools on every sync')
+  })
+
+  it('POSITIVE CONTROL: a JSONL-sourced history leaves the message branch untouched', async () => {
+    // jsonl-reader.js only ever emits user_input/response/tool_use, so a
+    // JSONL history has no `result` to synthesize from and the rebuilt
+    // `message` frames must not grow one.
+    const { ctx, sends, ws } = build([
+      { type: 'user_input', content: 'hi', timestamp: 1 },
+      { type: 'response', content: 'yo', timestamp: 2 },
+      { type: 'tool_use', content: 'ls', tool: 'Bash', timestamp: 3 },
+    ])
+    await handler(ws, client(), { type: 'request_full_history' }, ctx)
+    assert.equal(sends.filter(m => m.type === 'agent_idle').length, 0)
+    assert.equal(sends.filter(m => m.type === 'message').length, 3, 'all three JSONL types still rebuild as `message`')
+  })
+})
+
+/**
+ * #7460 — the #4833 back-pressure discipline never reached this path. The
+ * handler sent the entire history synchronously in one turn of the event loop
+ * with no `bufferedAmount` check anywhere, so a session with fat tool_result
+ * payloads could push the socket past the 1MB EVICT_THRESHOLD in
+ * ws-client-sender.js — and crossing it CLOSES the client. The action a user
+ * takes to repair a view was the one that could break the connection.
+ */
+describe('#7460 — request_full_history sends under the same chunk + bufferedAmount gate replayHistory uses (#4833)', () => {
+  it('pauses mid-chunk once bufferedAmount crosses the threshold instead of draining the whole history', async () => {
+    // 30 × 200KB = 6MB. Pre-fix the loop pushed all of it onto the socket in
+    // one synchronous burst, blowing far past the 1MB eviction line.
+    const ENTRY_COUNT = 30
+    const ws = makeBackpressuredWs()
+    const { ctx, sends, reseeds } = build(fatHistory(ENTRY_COUNT), { ws })
+
+    await handler(ws, client(), { type: 'request_full_history' }, ctx)
+    // The peer never acknowledges, so the loop must stay parked.
+    await turn(5)
+
+    assert.ok(sends.some(m => m.type === 'history_replay_start'), 'the start frame precedes the gate, as in replayHistory')
+    const replayed = sends.filter(m => m.type === 'tool_result').length
+    assert.ok(
+      replayed > 0 && replayed < ENTRY_COUNT,
+      `expected the loop to stall part-way while bufferedAmount stays above the pause threshold; got ${replayed}/${ENTRY_COUNT}`,
+    )
+    assert.equal(sends.find(m => m.type === 'history_replay_end'), undefined,
+      'history_replay_end must not be sent while the socket is congested')
+    assert.equal(reseeds.length, 0, 'the re-seed follows the end frame, so a stalled replay has not re-seeded either')
+
+    ws.readyState = 3 // stop the pending drain poll leaking into later tests
+  })
+
+  it('defers the whole chunk when bufferedAmount is ALREADY over the threshold at entry', async () => {
+    // Carry-over congestion from a preceding burst. The chunk-entry gate must
+    // send zero history payload — the mid-chunk break only fires after a send,
+    // so without it one fat tool_result still lands on a near-eviction buffer.
+    const ENTRY_COUNT = 30
+    const ws = makeBackpressuredWs()
+    const { ctx, sends } = build(fatHistory(ENTRY_COUNT), { ws })
+    ws.bufferedAmount = 512 * 1024
+
+    await handler(ws, client(), { type: 'request_full_history' }, ctx)
+    await turn(5)
+
+    assert.ok(sends.some(m => m.type === 'history_replay_start'))
+    const replayed = sends.filter(m => m.type === 'tool_result').length
+    assert.equal(replayed, 0, `chunk-entry gate must defer every history send while bufferedAmount > threshold; got ${replayed}`)
+    assert.equal(sends.find(m => m.type === 'history_replay_end'), undefined, 'the replay must not complete while gated')
+
+    ws.readyState = 3
+  })
+
+  it('resumes from the NEXT unsent entry and completes once the peer drains', async () => {
+    const ENTRY_COUNT = 30
+    const EVICT_THRESHOLD = 1024 * 1024
+    const ws = makeBackpressuredWs()
+    const { ctx, sends, reseeds } = build(fatHistory(ENTRY_COUNT), { ws })
+
+    let maxObserved = 0
+    const drainTimer = setInterval(() => {
+      if (ws.bufferedAmount > maxObserved) maxObserved = ws.bufferedAmount
+      ws.drain(512 * 1024)
+    }, 5)
+
+    try {
+      await handler(ws, client(), { type: 'request_full_history' }, ctx)
+      const deadline = Date.now() + 3000
+      while (Date.now() < deadline) {
+        if (ws.bufferedAmount > maxObserved) maxObserved = ws.bufferedAmount
+        if (sends.some(m => m.type === 'history_replay_end')) break
+        await new Promise(r => setTimeout(r, 10))
+      }
+
+      assert.ok(sends.some(m => m.type === 'history_replay_end'), 'the replay must eventually complete when the peer drains')
+      assert.equal(sends.filter(m => m.type === 'tool_result').length, ENTRY_COUNT,
+        'every entry must be delivered exactly once — a pause resumes, it does not drop')
+      assert.deepEqual(sends.filter(m => m.type === 'tool_result').map(m => m.toolUseId),
+        fatHistory(ENTRY_COUNT).map(e => e.toolUseId),
+        'and in the original order, resuming from the next UNSENT entry')
+      assert.ok(maxObserved < EVICT_THRESHOLD,
+        `bufferedAmount peaked at ${maxObserved}; must stay under the ${EVICT_THRESHOLD}-byte eviction line that CLOSES the client`)
+      assert.deepEqual(reseeds, ['sess-1'], 'the #7340 re-seed still runs, exactly once, after the end frame')
+    } finally {
+      clearInterval(drainTimer)
+    }
+  })
+
+  it('POSITIVE CONTROL: an uncongested socket is never paused — the whole history drains', async () => {
+    // Arms the other direction of the gate: below the threshold it must not
+    // pause, or a gate that always paused would pass the tests above.
+    const ENTRY_COUNT = 50 // > CHUNK_SIZE(20), so it genuinely spans 3 chunks
+    const history = Array.from({ length: ENTRY_COUNT }, (_, i) => ({
+      type: 'tool_result', toolUseId: `toolu_${i}`, content: 'small', _seq: i + 1,
+    }))
+    const { ctx, sends, ws, reseeds } = build(history)
+
+    await handler(ws, client(), { type: 'request_full_history' }, ctx)
+    await turn(10)
+
+    assert.equal(sends.filter(m => m.type === 'tool_result').length, ENTRY_COUNT,
+      'nothing may be withheld when bufferedAmount never crosses the threshold')
+    assert.equal(sends[sends.length - 1].type, 'history_replay_end')
+    assert.deepEqual(reseeds, ['sess-1'])
+  })
+
+  it('stops sending when the socket closes while parked on back-pressure', async () => {
+    const ws = makeBackpressuredWs()
+    const { ctx, sends } = build(fatHistory(30), { ws })
+
+    await handler(ws, client(), { type: 'request_full_history' }, ctx)
+    await turn(2)
+
+    const sentBeforeClose = sends.length
+    ws.readyState = 3
+    ws.drainAll()
+    await new Promise(r => setTimeout(r, 60)) // past the 20ms drain poll
+
+    assert.equal(sends.length, sentBeforeClose, 'nothing may be written to a closed socket')
+    assert.equal(sends.find(m => m.type === 'history_replay_end'), undefined, 'and the replay does not "finish" against a dead peer')
+  })
+
+  it('writes no history to a socket that is already CLOSED', async () => {
+    // The shared loop gates on readyState the way replayHistory always has.
+    // Pre-#7460 this handler wrote the whole ring buffer to a dead peer.
+    const ws = makeBackpressuredWs(3)
+    const { ctx, sends, reseeds } = build(fatHistory(5, 1024), { ws })
+
+    await handler(ws, client(), { type: 'request_full_history' }, ctx)
+    await turn(3)
+
+    assert.equal(sends.filter(m => m.type === 'tool_result').length, 0)
+    assert.equal(sends.find(m => m.type === 'history_replay_end'), undefined)
+    assert.deepEqual(reseeds, [], 'and no follow-up work is queued against a dead peer')
+  })
+
+  it('carries `truncated` + `latestSeq` on history_replay_start and `latestSeq` on history_replay_end', async () => {
+    const { ctx, sends, ws } = build([{ type: 'response', content: 'Hi', timestamp: 1, _seq: 9 }], {
+      managerOverrides: { isHistoryTruncated: () => true, getLatestHistorySeq: () => 42 },
+    })
+    await handler(ws, client(), { type: 'request_full_history' }, ctx)
+
+    const start = sends.find(m => m.type === 'history_replay_start')
+    const end = sends.find(m => m.type === 'history_replay_end')
+    assert.equal(start.fullHistory, true, 'still an authoritative rebuild')
+    assert.equal(start.truncated, true, 'without it a client cannot tell the ring buffer overflowed on this replay')
+    assert.equal(start.latestSeq, 42, 'replayHistory rides latestSeq on the start frame too')
+    assert.equal(end.latestSeq, 42, 'reconcileReplayEnd finalises the cursor from the END frame\'s latestSeq')
+  })
+
+  it('degrades to truncated:false / latestSeq:0 on a legacy manager missing the helpers', async () => {
+    // Same defensive posture replayHistory takes for getLatestHistorySeq —
+    // an older ctx fixture must not throw its way out of a replay.
+    const { ctx, sends, ws } = build([{ type: 'response', content: 'Hi', timestamp: 1 }], {
+      managerOverrides: { isHistoryTruncated: undefined, getLatestHistorySeq: undefined },
+    })
+    await handler(ws, client(), { type: 'request_full_history' }, ctx)
+    const start = sends.find(m => m.type === 'history_replay_start')
+    assert.equal(start.truncated, false)
+    assert.equal(start.latestSeq, 0)
+    assert.ok(sends.some(m => m.type === 'history_replay_end'), 'the replay still completes')
   })
 })

--- a/packages/server/tests/conversation-full-history-replay.test.js
+++ b/packages/server/tests/conversation-full-history-replay.test.js
@@ -396,6 +396,34 @@ describe('#7460 — request_full_history sends under the same chunk + bufferedAm
       `nor may the start frame; got latestSeq=${start.latestSeq}`)
   })
 
+  it('sends no end frame and no re-seed for an EMPTY history when the socket is CLOSED', async () => {
+    // Copilot review: the empty-slice path ran onDone() unconditionally, so a
+    // client that vanished before an empty replay still got a
+    // history_replay_end plus a re-seed burst written at a dead socket —
+    // contradicting the shared helper's own stated contract.
+    const ws = makeBackpressuredWs(3)
+    const { ctx, sends, reseeds } = build([], { ws })
+
+    await handler(ws, client(), { type: 'request_full_history' }, ctx)
+    await turn(3)
+
+    assert.equal(sends.find(m => m.type === 'history_replay_end'), undefined,
+      'no end frame may be written to a socket that is already gone')
+    assert.deepEqual(reseeds, [], 'and no re-seed burst behind it')
+  })
+
+  it('POSITIVE CONTROL: an EMPTY history on an OPEN socket still brackets start+end', async () => {
+    // The empty replay must keep working — gating the dead-socket case must not
+    // turn "nothing to replay" into "no reply at all".
+    const { ctx, sends, ws, reseeds } = build([])
+    await handler(ws, client(), { type: 'request_full_history' }, ctx)
+    await turn(3)
+
+    assert.equal(sends[0].type, 'history_replay_start')
+    assert.equal(sends[sends.length - 1].type, 'history_replay_end')
+    assert.deepEqual(reseeds, ['sess-1'], 'the #7340 re-seed still follows an empty replay')
+  })
+
   it('carries `truncated`, and sources `latestSeq` from the entries DELIVERED rather than the buffer', async () => {
     // The buffer's counter says 42; this replay delivered up to seq 9. Telling
     // the client 42 would advance its cursor past entries it never received

--- a/packages/server/tests/handlers/conversation-handlers.test.js
+++ b/packages/server/tests/handlers/conversation-handlers.test.js
@@ -55,7 +55,10 @@ function makeClient(overrides = {}) {
   }
 }
 
-function makeWs() { return {} }
+// An OPEN, uncongested socket. `readyState` is load-bearing since #7460: the
+// full-history replay runs through ws-history.js's shared chunk loop, which
+// refuses to write to a non-OPEN peer exactly as replayHistory always has.
+function makeWs() { return { readyState: 1, bufferedAmount: 0 } }
 
 describe('conversation-handlers', () => {
   describe('list_conversations', () => {

--- a/packages/server/tests/ws-handler-coverage.test.js
+++ b/packages/server/tests/ws-handler-coverage.test.js
@@ -365,7 +365,9 @@ describe('request_full_history handler', () => {
     ]
     ctx = createMockCtx(manager)
     client = { id: 'client-A', activeSessionId: 'sess-1' }
-    ws = {}
+    // OPEN socket: the replay loop refuses to write to a non-OPEN peer (#7460),
+    // exactly as replayHistory always has.
+    ws = { readyState: 1, bufferedAmount: 0 }
   })
 
   it('replays full history with start/end markers', async () => {

--- a/packages/server/tests/ws-history.test.js
+++ b/packages/server/tests/ws-history.test.js
@@ -12,6 +12,7 @@ import {
   resolveReplayPlan,
   flushPostAuthQueue,
   scheduleAfterDrain,
+  sendChunkedWithBackpressure,
   scheduleProviderModelsRefresh,
   _reserveEagerDerivationSlot,
   _resetEagerDerivationBudgetForTests,
@@ -3500,5 +3501,81 @@ describe('scheduleProviderModelsRefresh (#5421 / #5450)', () => {
     const totalPushes = ctx._sends.filter(m => m.type === 'available_models').length
     assert.equal(totalPushes, syncPushes + 1,
       'exactly one async re-push on top of the single synchronous snapshot')
+  })
+})
+
+
+// Copilot review of PR #7479 — the empty-slice path called onDone()
+// unconditionally while the function's own contract says neither emit nor
+// onDone runs once the socket leaves OPEN. That is the
+// comment-stronger-than-code class (docs/false-safety-guards.md): the
+// non-empty path is gated by sendChunk's readyState check, the empty one was
+// not, so a client that vanished before an already-current replay still got a
+// history_replay_end and a re-seed burst written at it.
+describe('sendChunkedWithBackpressure — the OPEN gate covers the empty-slice path too', () => {
+  function ws(readyState) { return { readyState, bufferedAmount: 0 } }
+
+  it('does NOT run onDone for an empty slice when the socket is CLOSED', () => {
+    const calls = []
+    sendChunkedWithBackpressure(ws(3), [], {
+      emit: () => calls.push('emit'),
+      onDone: () => calls.push('onDone'),
+    })
+    assert.deepEqual(calls, [],
+      'the contract says neither emit nor onDone runs after readyState leaves OPEN — the empty slice is not an exception')
+  })
+
+  it('does NOT run onDone for an already-current slice (startOffset === length) when CLOSED', () => {
+    // The real empty-slice shape: a non-empty history the client is already
+    // current with. This is the most common replay of all, so an ungated
+    // onDone here is the most frequently reached instance of the bug.
+    const calls = []
+    sendChunkedWithBackpressure(ws(3), [{ type: 'response' }, { type: 'result' }], {
+      startOffset: 2,
+      emit: () => calls.push('emit'),
+      onDone: () => calls.push('onDone'),
+    })
+    assert.deepEqual(calls, [], 'an already-current cursor against a dead socket must send nothing')
+  })
+
+  it('POSITIVE CONTROL: an empty slice on an OPEN socket still runs onDone', () => {
+    // The empty-slice path must keep working — an already-current reconnect
+    // still needs its history_replay_end and re-seed. Gating must not become
+    // "never fires".
+    const calls = []
+    sendChunkedWithBackpressure(ws(1), [], {
+      emit: () => calls.push('emit'),
+      onDone: () => calls.push('onDone'),
+    })
+    assert.deepEqual(calls, ['onDone'],
+      'start+end with nothing between is the whole point of the empty-slice path')
+  })
+
+  it('POSITIVE CONTROL: an already-current slice on an OPEN socket still runs onDone', () => {
+    const calls = []
+    sendChunkedWithBackpressure(ws(1), [{ type: 'response' }], {
+      startOffset: 1,
+      emit: () => calls.push('emit'),
+      onDone: () => calls.push('onDone'),
+    })
+    assert.deepEqual(calls, ['onDone'])
+  })
+
+  it('matches the NON-empty path, which has always been gated', () => {
+    // Equivalence is the actual claim: both entry paths must treat a dead
+    // socket identically. Same fixture, one entry to send instead of none.
+    const closed = []
+    sendChunkedWithBackpressure(ws(3), [{ type: 'response' }], {
+      emit: () => closed.push('emit'),
+      onDone: () => closed.push('onDone'),
+    })
+    assert.deepEqual(closed, [], 'non-empty + closed sends nothing (pre-existing behaviour)')
+
+    const empty = []
+    sendChunkedWithBackpressure(ws(3), [], {
+      emit: () => empty.push('emit'),
+      onDone: () => empty.push('onDone'),
+    })
+    assert.deepEqual(empty, closed, 'and the empty slice must behave the same way')
   })
 })


### PR DESCRIPTION
`handleRequestFullHistory` is the SECOND replay path (`replayHistory` in
`ws-history.js` is the first), and it did neither of the things that one does
per entry. Both defects were filed from the review of #7458, and both are fixed
by the same change, so they land together.

Closes #7459
Closes #7460

## The defects

**#7459 — no `result` → `agent_idle` synthesis (#4628).** The **dashboard**'s
`case 'result'` clears `activeTools` as the #4308 turn-boundary net, but #4466
gated that clear behind "not replaying", precisely so a replayed `result` cannot
wipe the `activeTools` that `history_replay_start` is trying to preserve
(otherwise every session switch resets the "Running X · 1s" clock). The **mobile
app's** `case 'result'` does not touch `activeTools` at all.

So on both clients the replay-time clear comes from `agent_idle` — which routes
through store-core's shared dispatch (`handlers/session-config.ts`, returning
`activeTools: []`) and is *not* replay-gated — and only `replayHistory`
synthesised it. On mobile that is the only path to the clear in any
circumstance.

Net effect: a session with an orphan `tool_start` in its ring buffer (dropped
PostToolUse hook — the #4628 root cause) shows a zombie "Running X" chip.
Reconnecting or switching sessions healed it; pressing **Sync Full History** —
the one action a user takes *because* the view looks wrong — could not.

**#7460 — no back-pressure (#4833).** The handler sent the whole history
synchronously, in one turn of the event loop, with no `bufferedAmount` check
anywhere. The ring buffer caps at 1000 entries and fat `tool_result` payloads
run 200KB+, so the burst can sail past the 1MB `EVICT_THRESHOLD` in
`ws-client-sender.js` — and crossing it **closes the client**. Same direction of
irony: the action taken to repair a view was the one that could drop the
connection.

## The fix shape

Rather than a third copy of the loop, the two pieces `replayHistory` owned are
now exported from `ws-history.js` and both callers share them:

- **`sendChunkedWithBackpressure(ws, entries, { startOffset, emit, onDone })`** —
  20-entry chunks with all three #4833 gates (chunk *entry*, mid-chunk break
  resuming from the next unsent entry, chunk *scheduling*), plus the empty-slice
  path.
- **`sendHistoryEntry(send, ws, sessionId, entry)`** — the `_seq` → `historySeq`
  mapping (#5555.3/#7454) **and** the `result` → `agent_idle` synthesis (#4628).

This is the extraction #7460's acceptance criteria asked for ("prefer extracting
the existing `sendChunk` machinery over a second copy of it — a second
implementation of the backpressure loop is how this class of divergence
started"). It also makes the #7459 mirror *structural* rather than a promise:
the condition and emitted shape cannot drift, because the two replay paths now
share one of each. Scope of that claim, stated precisely: `flushPostAuthQueue`
in the same file still carries its own copy of the chunk-and-drain shape, kept
separate because it also owns the `_flushing`/`_flushOverflow` queue state —
tracked as #7485, not silently claimed as unified. The
mutation table below shows this directly — disarming the synthesis kills tests in
**both** suites.

`replayHistory` is rewired through the same helpers with everything moved
verbatim; commit 1 is behaviour-preserving and ws-history's 164 tests (the whole
#4833 set included) stay green on it.

Also taken, per #7460's acceptance criteria — both were named as in-scope
one-liners:

- `history_replay_start` now carries **`truncated`**, so a client can tell the
  ring buffer overflowed on this replay.
- `history_replay_start`/`history_replay_end` now carry **`latestSeq`**, the
  input `reconcileReplayEnd` (`store-core/src/replay-reconcile.ts`) uses to
  finalise the cursor when the replayed slice carried no seq of its own.

Both manager helpers are probed with `typeof === 'function'` the way
`replayHistory` probes `getLatestHistorySeq`, so a legacy ctx fixture cannot
throw its way out of a replay.

## Red-first evidence

Every assertion below was run against the unmodified handler first.
`tests/conversation-full-history-replay.test.js` (extended, not replaced — the
four #7458 tests are unchanged and still pass): re-measured against `main`
(990a9322e) with the final suite, **12 failed / 8 passed**, and **20/20 after**.

(The body first said 10/7. That was the count for the suite as it stood when I
took the measurement, before two further tests were added — review correctly
flagged it as 11/7 for the 18-test file; the C1 work below then took it to
12/8. Re-measured rather than incremented.)

| Issue | Red-first observation on `main` |
|---|---|
| #7459 | `agent_idle must be synthesized` — absent. Frame order was `history_replay_start, result, history_replay_end`, with nothing to clear the chip. |
| #7460 | `expected the loop to stall part-way …; got 30/30` — the whole history drained in one burst, and `bufferedAmount peaked at 6146952` bytes against the 1,048,576-byte eviction line (**5.9x over**). |

The 7 that passed pre-fix are the four #7458 tests plus the three positive
controls (no `result` → no synthesis; a JSONL history → no synthesis; an
uncongested socket → drains fully), which is the correct split: a positive
control that went red pre-fix would be testing the wrong thing.

## Mutation evidence

Each mutant was applied with an assertion that it landed exactly once (a
silently no-op'd `str.replace` is a false green), run, then restored from a
byte-exact `/tmp` copy and `cmp`-verified.

| # | Mutation | full-history | ws-history |
|---|---|---|---|
| M1 | `entry.type === 'result'` → never matches | RED | RED |
| M2 | mid-chunk break disarmed | RED | RED |
| M3 | chunk-**entry** gate disarmed | RED | RED |
| M4 | chunk-**scheduling** gate → bare `setImmediate` | GREEN (equivalent; upheld in review) | GREEN |
| M5 | a pause **abandons** the remainder instead of resuming | RED | RED |
| M6 | gate **always** pauses (arms the positive control) | RED (hung) | — |
| M7 | `truncated` dropped from `history_replay_start` | RED | — |
| M8 | `latestSeq` dropped from `history_replay_end` | RED | — |
| M9 | handler bypasses the shared emitter (raw forward) | RED | — |

M1/M2/M3/M5 dying in **both** suites is the load-bearing result: it is what
proves the two replay paths now run one implementation rather than two that
merely agree today.

**M4 survived, and it is an equivalent mutant — not a coverage gap.** With the
post-chunk `scheduleAfterDrain` replaced by a bare `setImmediate`, the next
`sendChunk` immediately re-checks the **chunk-entry** gate and calls
`scheduleAfterDrain` itself, so the drain wait (and the #5328 30s max-wait →
1013 close) still happens, one `setImmediate` later. There is no input that
distinguishes them. This is pre-existing in `replayHistory` — the entry gate
arrived later, as the #4845 follow-up, and subsumed the scheduling gate — and
the extraction preserved it faithfully rather than introducing it. Not removed
here: deleting a #4833 guard is its own change with its own risk, and this PR's
job was to stop the two paths diverging.

M6 kills by hanging rather than asserting: an always-pausing gate makes
`scheduleAfterDrain` → `setImmediate` → pause spin forever, so the suite never
completes (bounded by a hard kill in the harness). A hang is a legitimate red
for "this gate must let uncongested traffic through", and it confirms the
positive control is armed rather than passing for free.

## Suites

Run individually, bare exit codes. The full `npm test` was deliberately not run
(it prompts against the real Keychain).

| Suite | Result |
|---|---|
| `conversation-full-history-replay` (extended) | 20/20 |
| `ws-history` | 164/164 |
| `ws-server` | 124/124 |
| `ws-server-backpressure` | 5/5 |
| `ws-handler-coverage` | 36/36 |
| `handlers/conversation-handlers` | 41/41 |
| `ws-schemas` | 173/173 |
| `session-manager` | 204/204 |
| `ws-outbound-coverage` / `ws-schema-coverage` / `ws-exposure` / `ws-client-sender` | 16 / 4 / 8 / 23 |
| `lint-ws-index-mutations` + 7 other dependents | all green |
| all 9 `scripts/lint-*.sh` | rc=0 each |
| `npm run lint` (eslint) | rc=0 (10 pre-existing warnings, untouched files) |

## Behaviour change worth naming in review

The shared loop **refuses to write to a non-OPEN socket**, exactly as
`replayHistory` always has; previously this handler wrote the whole ring buffer
to a dead peer. Two fixtures modelled a `ws` with no `readyState` at all
(`ws = {}` / `makeWs() { return {} }`) and were the only casualties — they now
model a real OPEN socket, and the guard has its own test rather than being an
untested side effect.

## Review round 1 — C1 (a regression this PR introduced)

`getFullHistoryAsync` **prefers the JSONL transcript** whenever `resumeSessionId`
is set, and jsonl-reader.js emits only `user_input`/`response`/`tool_use` — none
of which carry `_seq`. Sourcing `latestSeq` from the ring buffer's
`getLatestHistorySeq` therefore advertised a cursor the replay never delivered:
the client feeds it to `recordHistorySeq` via `reconcileReplayEnd`, so the next
reconnect resolves as already-current and replays **nothing**, stranding the
client on the lossy JSONL rebuild.

`latestSeq` is now derived from the highest `_seq` actually forwarded, and
**omitted** when none was — omitted rather than zeroed, because `latestSeq: 0`
is a real seq a client will happily record. Unchanged on the ring-buffer path:
that slice is the whole buffer, so its max `_seq` *is* `getLatestHistorySeq()`.

Red-first is against this PR's own intermediate commit rather than `main`, since
the defect was PR-introduced — the reviewer's probe shape reproduced exactly:
`end.latestSeq: 42` while `any historySeq? false`. Mutation: re-sourcing
`latestSeq` from the buffer kills 4 tests, the JSONL one first.

Two comments that claimed more than the code delivers were corrected in the same
pass (the "three load-bearing gates" docstring, given M4; and "deliberately only
one", given `flushPostAuthQueue`).

`truncated` still describes the ring buffer and so is not meaningful on the JSONL
replay — noted at the call site and left to #7484 rather than folded in.

## Not taken

`handleRequestConversationTranscript` in the same file is a **third** unchunked
send loop with the same eviction exposure (bounded only by
`MAX_TRANSCRIPT_BYTES`). Out of scope for both issues, which name
`request_full_history` specifically; filed separately rather than folded in
silently.

