### PR TITLE
fix(dashboard): prune the per-session PR/CI maps when a session goes away

### DIFF
--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -3247,6 +3247,19 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       // #5163: drop the Control Room tree on disconnect/forget — a fresh
       // connection re-seeds it from activity_snapshot on subscribe.
       activity: createEmptyActivityState(),
+      // #7470 forget-reset-start — the per-session PR/CI maps go with the
+      // session state they describe. They are keyed by SESSION ID, and session
+      // ids are minted per daemon, so an entry that outlived its server can be
+      // read against a DIFFERENT server's session of the same id — one
+      // machine's CI state rendered on another machine's chip. That is a wrong
+      // answer, not just retained memory, which is why these are cleared here
+      // and not only pruned on the session_list removal path (message-handler.ts).
+      sessionPrStatus: {},
+      sessionPrStatusLoading: {},
+      sessionPrStatusRequestedAt: {},
+      sessionPrThreads: {},
+      sessionPrThreadsLoading: {},
+      // #7470 forget-reset-end
       cancellingActivityIds: new Set<string>(),
       // #5500: drop reindex pending/result state with the rest of the
       // connection-scoped Control Room state.
@@ -3302,6 +3315,17 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       // #5163: drop the Control Room tree on disconnect/forget — a fresh
       // connection re-seeds it from activity_snapshot on subscribe.
       activity: createEmptyActivityState(),
+      // #7470 switch-reset-start — same reasoning as forgetSession above, and
+      // this is the path where the cross-server read is REACHABLE rather than
+      // theoretical: switchServer keeps the old server's persisted data on
+      // purpose, so without this the new server's session ids can collide with
+      // the old server's PR/CI entries.
+      sessionPrStatus: {},
+      sessionPrStatusLoading: {},
+      sessionPrStatusRequestedAt: {},
+      sessionPrThreads: {},
+      sessionPrThreadsLoading: {},
+      // #7470 switch-reset-end
       cancellingActivityIds: new Set<string>(),
       // #5500: drop reindex pending/result state with the rest of the
       // connection-scoped Control Room state.

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -3248,12 +3248,22 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       // connection re-seeds it from activity_snapshot on subscribe.
       activity: createEmptyActivityState(),
       // #7470 forget-reset-start — the per-session PR/CI maps go with the
-      // session state they describe. They are keyed by SESSION ID, and session
-      // ids are minted per daemon, so an entry that outlived its server can be
-      // read against a DIFFERENT server's session of the same id — one
-      // machine's CI state rendered on another machine's chip. That is a wrong
-      // answer, not just retained memory, which is why these are cleared here
-      // and not only pruned on the session_list removal path (message-handler.ts).
+      // session roster this action empties.
+      //
+      // Clearing them HERE is not belt-and-braces over the `session_list`
+      // removedIds prune (message-handler.ts): it is the only thing that can
+      // reach them. `removedIds` is a diff against `Object.keys(sessionStates)`,
+      // and this block empties `sessionStates` in the same patch — so from the
+      // next snapshot onwards there is nothing to diff, `removedIds` is `[]`,
+      // and any entry left behind is permanently unprunable for the life of the
+      // tab. Same mechanism at `_resetSessionMemory` below and at `auth_ok`'s
+      // non-reconnect branch (message-handler.ts).
+      //
+      // Session ids carry no daemon namespace — they are 16 random bytes
+      // (server/session-manager.js), so entropy is the ONLY thing separating
+      // two servers' id spaces. That is ample (128 bits) and a collision is not
+      // the hazard here; it is simply not a property worth leaning on when the
+      // correct lifetime for these entries is "this connection".
       sessionPrStatus: {},
       sessionPrStatusLoading: {},
       sessionPrStatusRequestedAt: {},
@@ -3315,11 +3325,12 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       // #5163: drop the Control Room tree on disconnect/forget — a fresh
       // connection re-seeds it from activity_snapshot on subscribe.
       activity: createEmptyActivityState(),
-      // #7470 switch-reset-start — same reasoning as forgetSession above, and
-      // this is the path where the cross-server read is REACHABLE rather than
-      // theoretical: switchServer keeps the old server's persisted data on
-      // purpose, so without this the new server's session ids can collide with
-      // the old server's PR/CI entries.
+      // #7470 switch-reset-start — same mechanism as forgetSession above: this
+      // block empties `sessionStates`, which is the set `removedIds` diffs
+      // against, so anything left behind here can never be pruned by a later
+      // `session_list`. switchServer additionally KEEPS the old server's
+      // persisted data on purpose, so leaving these would carry one server's
+      // PR/CI readings into a session list drawn from another.
       sessionPrStatus: {},
       sessionPrStatusLoading: {},
       sessionPrStatusRequestedAt: {},

--- a/packages/dashboard/src/store/dispatch-control-room-activity.test.ts
+++ b/packages/dashboard/src/store/dispatch-control-room-activity.test.ts
@@ -79,6 +79,15 @@ function baseState(): Partial<ConnectionState> {
     sessionStates: { [SESSION_ID]: createEmptySessionState() },
     activity: createEmptyActivityState(),
     messages: [],
+    // #7470 — the `session_list` removedIds block now prunes the per-session
+    // PR/CI maps alongside the activity tree. They are non-optional on
+    // `ConnectionState` and always `{}` in the real store, so a partial mock
+    // that omits them is a fixture gap, not a production shape.
+    sessionPrStatus: {},
+    sessionPrStatusLoading: {},
+    sessionPrStatusRequestedAt: {},
+    sessionPrThreads: {},
+    sessionPrThreadsLoading: {},
   }
 }
 

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -4447,6 +4447,29 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
           sessions: [],
           activeSessionId: null,
           sessionStates: {},
+          // #7470 authok-reset-start — the per-session PR/CI maps go with the
+          // roster this branch empties, and this is a SITE rather than a case
+          // the removedIds prune below covers. `removedIds` is a diff against
+          // `Object.keys(sessionStates)` (store-core `buildSessionListPatches`),
+          // so once the roster is empty there is nothing to diff: the next
+          // `session_list` yields `removedIds = []`, the `removedIds.length > 0`
+          // guard skips the prune block, and anything left here is permanently
+          // unprunable for the life of the tab.
+          //
+          // Reached by Disconnect → Connect to the same server: `disconnect()`
+          // clears `lastConnectedUrl` while preserving the session roster, so
+          // `isReconnect = (lastConnectedUrl === url)` is false and this branch
+          // runs. `scheduleRetry` re-entering `connect()` with `_retryCount > 0`
+          // is a second route to it. Only the NON-reconnect branch clears — a
+          // silent reconnect keeps `sessionStates`, so the snapshots it
+          // describes are still true and blanking them would wipe a chip the
+          // user is reading on every transient drop.
+          sessionPrStatus: {},
+          sessionPrStatusLoading: {},
+          sessionPrStatusRequestedAt: {},
+          sessionPrThreads: {},
+          sessionPrThreadsLoading: {},
+          // #7470 authok-reset-end
           customAgents: [],
         });
       }
@@ -4726,9 +4749,19 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         // session it had ever surveyed, for the life of the connection.
         //
         // Pruned HERE, beside `sessionStates` and `activity` above, because
-        // this removedIds block is the store's one session-went-away path —
-        // `destroySession` only puts a frame on the wire; the server's next
-        // `session_list` is what tells this tab the session is gone.
+        // this is where ONE session going away is observed — `destroySession`
+        // only puts a frame on the wire; the server's next `session_list` is
+        // what tells this tab the session is gone.
+        //
+        // It is NOT the only such path, and reading it as one is how PR #7481's
+        // review found a fourth. `removedIds` is a diff against
+        // `Object.keys(sessionStates)`, so this block only ever sees sessions
+        // that are still in the roster when the snapshot lands. The three sites
+        // that empty the roster WHOLESALE — `auth_ok`'s non-reconnect branch
+        // above, and `forgetSession` / `_resetSessionMemory` in connection.ts —
+        // leave nothing to diff, so each must clear these maps itself. All four
+        // are held by the SITES table in
+        // `session-destroy-prunes-pr-maps.test.ts`.
         //
         // Each map is assigned EXPLICITLY rather than looped over a list of
         // field names: a name list is the same hardcoded roster with the

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -196,7 +196,7 @@ import type {
   MCPResourceItem,
   McpServerOpResult,
 } from './types';
-import { createEmptySessionState } from './utils';
+import { createEmptySessionState, pruneSessionKeyedMap } from './utils';
 import { clearPersistedSession } from './persistence';
 
 // ---------------------------------------------------------------------------
@@ -4716,6 +4716,36 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
           nextActivity = clearSessionActivity(nextActivity, id);
         }
         if (nextActivity !== get().activity) patch.activity = nextActivity;
+        // #7470 prune-block-start — the per-session PR/CI maps.
+        //
+        // Five maps, all keyed by session id, and until now nothing removed an
+        // entry when the session it describes went away: connection.ts's #6153
+        // sweep resets the LOADING-shaped ones on a socket drop, but that is a
+        // reconnect reset for a stranded control, not a lifecycle prune. A
+        // long-lived tab therefore accumulated one full PR/CI snapshot per
+        // session it had ever surveyed, for the life of the connection.
+        //
+        // Pruned HERE, beside `sessionStates` and `activity` above, because
+        // this removedIds block is the store's one session-went-away path —
+        // `destroySession` only puts a frame on the wire; the server's next
+        // `session_list` is what tells this tab the session is gone.
+        //
+        // Each map is assigned EXPLICITLY rather than looped over a list of
+        // field names: a name list is the same hardcoded roster with the
+        // compiler switched off, and a dropped entry in one reads as a missing
+        // string instead of a missing statement. The roster is held honest by
+        // `session-destroy-prunes-pr-maps.test.ts`, which extracts the family
+        // from types.ts and asserts each member appears between these markers.
+        //
+        // `pruneSessionKeyedMap` returns the SAME reference when the map held
+        // none of the removed ids, so this cannot churn `useShallow` consumers
+        // on a snapshot that only removed a session they don't track.
+        patch.sessionPrStatus = pruneSessionKeyedMap(get().sessionPrStatus, removedIds);
+        patch.sessionPrStatusLoading = pruneSessionKeyedMap(get().sessionPrStatusLoading, removedIds);
+        patch.sessionPrStatusRequestedAt = pruneSessionKeyedMap(get().sessionPrStatusRequestedAt, removedIds);
+        patch.sessionPrThreads = pruneSessionKeyedMap(get().sessionPrThreads, removedIds);
+        patch.sessionPrThreadsLoading = pruneSessionKeyedMap(get().sessionPrThreadsLoading, removedIds);
+        // #7470 prune-block-end
         // If the active session was removed, switch to next available
         if (initialActiveId && removedIds.includes(initialActiveId)) {
           const remaining = Object.keys(newStates);

--- a/packages/dashboard/src/store/session-destroy-prunes-pr-maps.test.ts
+++ b/packages/dashboard/src/store/session-destroy-prunes-pr-maps.test.ts
@@ -16,24 +16,39 @@
  * went away, so a long-lived tab accumulated one snapshot per ever-surveyed
  * session id for the life of the connection.
  *
- * The store's one session-went-away path is the `session_list` handler's
- * `removedIds` block, where `sessionStates` and the Control Room `activity`
- * tree are already pruned. The fix lives there.
+ * ## Four sites, one mechanism
+ *
+ * "The session went away" has FOUR spellings here. The obvious one is the
+ * `session_list` handler's `removedIds` block, where `sessionStates` and the
+ * Control Room `activity` tree are already pruned. The other three empty the
+ * roster WHOLESALE — `auth_ok`'s non-reconnect branch, `forgetSession`,
+ * `_resetSessionMemory` — and because `removedIds` is a diff against
+ * `Object.keys(sessionStates)`, emptying the roster leaves nothing to diff:
+ * anything not cleared in the same patch is PERMANENTLY unprunable for the life
+ * of the tab. So each of the four clears these maps itself.
+ *
+ * The fourth (`auth_ok`) was missed by the first version of this file and found
+ * in review of PR #7481. It is the most ordinary gesture of the four —
+ * Disconnect, then Connect to the same server — which is worth remembering
+ * before the next "surely the removedIds prune covers this" simplification.
  *
  * ## What these tests are shaped to catch
  *
- * A per-map assertion for EACH of the five, never one blanket "the maps no
- * longer mention sess-dead" check: a blanket assertion is satisfied by pruning
- * four of five, which is exactly the adjacent-field failure this issue is an
- * instance of. Mutating away any single prune call must turn exactly one
- * assertion red, and the message must name the map.
+ * A per-map assertion for EACH of the five at EACH site, never one blanket "the
+ * maps no longer mention sess-dead" check: a blanket assertion is satisfied by
+ * pruning four of five, which is exactly the adjacent-field failure this issue
+ * is an instance of. Mutating away any single clear must turn exactly one
+ * assertion red, and the message must name the map AND the site.
  *
  * Plus a POSITIVE CONTROL in every case: the surviving session's entries must
- * come through byte-identical. Without it, `set({ sessionPrStatus: {} })` —
- * clearing everything — would pass every "dead key is gone" assertion.
+ * come through byte-identical, and a silent RECONNECT must keep all five. Both
+ * exist so that `set({ sessionPrStatus: {} })` — clearing everything, always —
+ * cannot pass.
  *
- * Plus a roster guard derived from `types.ts` rather than from a list written
- * here, so a SIXTH map added to the family without a prune goes red.
+ * Plus a roster guard that classifies every session-keyed-shaped collection on
+ * `ConnectionState`, so a new one is red until someone says how it is keyed.
+ * See its own docstring below for why the first version of that guard did not
+ * work.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { readFileSync } from 'fs'
@@ -49,7 +64,7 @@ vi.mock('./crypto', () => ({
 vi.mock('./persistence', () => ({ clearPersistedSession: vi.fn() }))
 
 import { handleMessage, setStore, clearDeltaBuffers, clearPermissionSplits, stopHeartbeat, resetReplayFlags } from './message-handler'
-import { createEmptySessionState } from './utils'
+import { createEmptySessionState, pruneSessionKeyedMap } from './utils'
 import type { ConnectionState } from './types'
 import { createEmptyActivityState } from '@chroxy/store-core'
 import type { ServerSessionPrStatusMessage, ServerSessionPrThreadsMessage } from '@chroxy/protocol'
@@ -275,25 +290,212 @@ describe('#7470 session destroy prunes the per-session PR/CI maps', () => {
 })
 
 /**
+ * #7470 (fourth site, PR #7481 review Critical 1) — a FRESH `auth_ok`.
+ *
+ * `auth_ok`'s non-reconnect branch empties `sessions` / `activeSessionId` /
+ * `sessionStates` before any `session_list` arrives. That ordering is what makes
+ * this its own site rather than a case the removedIds prune covers:
+ * `removedIds` is a diff against `Object.keys(sessionStates)`
+ * (store-core `buildSessionListPatches`), so once the roster has been emptied
+ * there is nothing to diff and `removedIds` is `[]` — the
+ * `removedIds.length > 0` guard skips the prune block entirely and the entries
+ * are beyond the reach of the only prune path for the life of the tab.
+ *
+ * Reachable by the most ordinary gesture in the dashboard: Disconnect, then
+ * Connect to the same server. `disconnect()` clears `lastConnectedUrl` while
+ * PRESERVING the session roster, so the next `connect()` computes
+ * `isReconnect = (lastConnectedUrl === url)` as `null === url` → false and takes
+ * the wipe branch. The auto-retry ladder reaches it a second way, via
+ * `scheduleRetry` re-entering `connect()` with `_retryCount > 0`.
+ */
+describe('#7470 a fresh auth_ok clears the per-session PR/CI maps', () => {
+  let store: ReturnType<typeof createMockStore>
+  let mockSocket: WebSocket
+
+  /** The minimal auth_ok the dashboard's handler needs. */
+  function authOk(): Record<string, unknown> {
+    return {
+      type: 'auth_ok',
+      serverMode: 'cli',
+      cwd: '/home/user/project',
+      defaultCwd: '/home/user',
+      serverVersion: '0.11.0',
+      protocolVersion: 3,
+      clientId: 'client-1',
+      connectedClients: [{ clientId: 'client-1', deviceName: 'Dashboard', deviceType: 'desktop', platform: 'macos' }],
+    }
+  }
+  const freshCtx = () => ({ url: 'wss://t', token: 'tok', socket: mockSocket, isReconnect: false, silent: false })
+  const reconnectCtx = () => ({ url: 'wss://t', token: 'tok', socket: mockSocket, isReconnect: true, silent: false })
+
+  beforeEach(() => {
+    vi.clearAllMocks(); localStorage.clear(); clearDeltaBuffers(); clearPermissionSplits(); resetReplayFlags()
+    mockSocket = createMockSocket(); store = createMockStore(baseState()); setStore(store)
+  })
+  afterEach(() => { stopHeartbeat() })
+
+  it('control: the fixture holds entries for both sessions before the connect', () => {
+    // Without this, every "is empty afterwards" assertion below could be
+    // passing because the seed never landed.
+    const s = store.getState()
+    expect(Object.keys(s.sessionPrStatus)).toEqual([DEAD, LIVE])
+    expect(Object.keys(s.sessionPrThreads)).toEqual([DEAD, LIVE])
+  })
+
+  it('clears sessionPrStatus', () => {
+    handleMessage(authOk(), freshCtx() as never)
+    expect(store.getState().sessionPrStatus).toEqual({})
+  })
+  it('clears sessionPrStatusLoading', () => {
+    handleMessage(authOk(), freshCtx() as never)
+    expect(store.getState().sessionPrStatusLoading).toEqual({})
+  })
+  it('clears sessionPrStatusRequestedAt', () => {
+    handleMessage(authOk(), freshCtx() as never)
+    expect(store.getState().sessionPrStatusRequestedAt).toEqual({})
+  })
+  it('clears sessionPrThreads', () => {
+    handleMessage(authOk(), freshCtx() as never)
+    expect(store.getState().sessionPrThreads).toEqual({})
+  })
+  it('clears sessionPrThreadsLoading', () => {
+    handleMessage(authOk(), freshCtx() as never)
+    expect(store.getState().sessionPrThreadsLoading).toEqual({})
+  })
+
+  it('clears them in the same patch that empties sessionStates', () => {
+    handleMessage(authOk(), freshCtx() as never)
+    const s = store.getState()
+    expect(s.sessionStates).toEqual({})
+    expect(s.sessions).toEqual([])
+  })
+
+  it('POSITIVE CONTROL: a silent RECONNECT keeps them, because it keeps sessionStates', () => {
+    // The reconnect branch preserves the roster, so the snapshots it describes
+    // stay valid — and clearing here would blank a chip the user is looking at
+    // on every transient drop. This is what stops the fix degenerating into
+    // "clear on every auth_ok", which would pass all five assertions above.
+    handleMessage(authOk(), reconnectCtx() as never)
+    const s = store.getState()
+    expect(Object.keys(s.sessionStates)).toEqual([DEAD, LIVE])
+    expect(Object.keys(s.sessionPrStatus)).toEqual([DEAD, LIVE])
+    expect(Object.keys(s.sessionPrStatusLoading)).toEqual([DEAD, LIVE])
+    expect(Object.keys(s.sessionPrStatusRequestedAt)).toEqual([DEAD, LIVE])
+    expect(Object.keys(s.sessionPrThreads)).toEqual([DEAD, LIVE])
+    expect(Object.keys(s.sessionPrThreadsLoading)).toEqual([DEAD, LIVE])
+  })
+
+  /**
+   * Pins the MECHANISM, not the fix — this passes both before and after, and
+   * that is the point. It is the reason the fourth site cannot be folded into
+   * the removedIds block: after a roster wipe there is nothing left to diff, so
+   * no `session_list` can ever produce a `removedIds` containing the stale ids.
+   * If someone later "simplifies" the auth_ok clear away on the theory that the
+   * removedIds prune covers it, this test states in one place why it does not.
+   */
+  it('MECHANISM: after a roster wipe, no session_list can ever prune the stale ids', () => {
+    // Exactly the state auth_ok's else-branch leaves behind, minus the fix.
+    store.setState({ sessions: [], activeSessionId: null, sessionStates: {} })
+    handleMessage({ type: 'session_list', sessions: [{ sessionId: 'brand-new', isBusy: false }] }, freshCtx() as never)
+    const s = store.getState()
+    // removedIds was [] — the prune block never ran, so the dead ids are still
+    // here. This is the defect Critical 1 named, reproduced as a property.
+    expect(s.sessionPrStatus[DEAD]).toBeDefined()
+    expect(s.sessionPrStatus[LIVE]).toBeDefined()
+  })
+})
+
+/**
+ * `pruneSessionKeyedMap`'s reference contract, tested directly (PR #7481 N1).
+ *
+ * The docstring calls the same-reference return "load-bearing, not an
+ * optimisation detail", so the membership test has to be own-property. `in`
+ * walks the prototype chain, which made the guarantee true only by luck about
+ * the session-id alphabet.
+ */
+describe('#7470 pruneSessionKeyedMap reference contract', () => {
+  it('returns the SAME reference when no id is an own key', () => {
+    const map = { 'sess-a': 1 }
+    expect(pruneSessionKeyedMap(map, ['sess-b'])).toBe(map)
+  })
+
+  it('is not fooled by inherited keys (`in` would clone here)', () => {
+    const map = { 'sess-a': 1 }
+    // Every one of these answers true to `id in map` via Object.prototype, so
+    // the pre-fix helper cloned and returned a NEW object with identical
+    // contents — silently breaking the reference guarantee for every
+    // `useShallow` consumer.
+    for (const inherited of ['toString', 'constructor', 'hasOwnProperty', 'valueOf']) {
+      expect(pruneSessionKeyedMap(map, [inherited]), `${inherited} must not clone`).toBe(map)
+    }
+  })
+
+  it('still returns a new object, without the id, for a real own key', () => {
+    // Positive control: the two assertions above are satisfiable by a helper
+    // that never prunes anything at all.
+    const map = { 'sess-a': 1, 'sess-b': 2 }
+    const out = pruneSessionKeyedMap(map, ['sess-a'])
+    expect(out).not.toBe(map)
+    expect(out).toEqual({ 'sess-b': 2 })
+    expect(map).toEqual({ 'sess-a': 1, 'sess-b': 2 })
+  })
+})
+
+/**
  * Roster coverage — the adjacent-field guard.
  *
- * Each of the three cleanup sites names its maps explicitly (a loop over a
- * string list would be the same hardcoded roster, just less visible). That is
- * only safe if something notices when the family grows, so this derives the
- * roster from the PRODUCER — the `ConnectionState` declaration in `types.ts` —
- * and asserts every session-keyed PR/CI map appears at EVERY site. A sixth map
- * added without cleanup goes red here, naming both the field and the site it
- * was missed at.
+ * ## What the first version of this got wrong (PR #7481 review, Critical 2)
  *
- * Three sites, because "the session went away" has three spellings in this
- * store and covering only the one the issue named is the same adjacent-field
- * mistake one level up:
+ * It extracted `/^\s{2}(sessionPr\w*): Record<string,/` and its docstring
+ * claimed it covered "every session-keyed PR/CI map". It did not: it covered a
+ * NAME PREFIX. The mutant offered as proof was named `sessionPrMutantSixth` —
+ * derived from the guard's own pattern rather than from the defect — and the
+ * reviewer killed the claim by running the identical mutant renamed
+ * `sessionCiChecks`: same declaration point, same shape, genuinely session-keyed,
+ * and it survived 38/38 in silence. `pendingServerSeed` was the live proof: a
+ * real session-keyed map in the same file that the guard could not see.
  *
- *   1. `session_list` removedIds        — one session closed  (message-handler.ts)
- *   2. `forgetSession`                  — disconnect + forget (connection.ts)
- *   3. `_resetSessionMemory`            — switchServer        (connection.ts)
+ * That is docs/false-safety-guards.md's "guard whose comment describes a
+ * stronger check than its code performs", committed inside the guard written to
+ * prevent its cousin. A guard certified by a mutant named after its own pattern
+ * is testing itself.
+ *
+ * ## What it does now: classify-or-fail, red by default
+ *
+ * The extraction is now STRUCTURAL — every `Record<string, …>` and
+ * `Set<string>` field declared on the `ConnectionState` interface, which is the
+ * shape a session-keyed collection actually has, with no reliance on what it is
+ * called. Each one must appear in exactly one of four buckets below. A field in
+ * NONE of them fails `classification`, so a newly-added collection is RED until
+ * someone states how it is keyed — `sessionCiChecks` included, whatever it is
+ * named.
+ *
+ * The buckets are visible rather than inferred, because the deferred ones are
+ * the point: `pendingServerSeed` (#7478) and `cancellingActivityIds` (#7483) are
+ * session-scoped and NOT yet cleaned, and a reader has to be able to see that
+ * they were considered. An exclusion list that names them beats a pattern that
+ * cannot see them.
+ *
+ * Every "keyed by" reason below is quoted from the field's OWN declaration in
+ * types.ts, not inferred from its name — the naming inference is what produced
+ * the defect this guard now exists to catch.
+ *
+ * ## Four sites
+ *
+ * "The session went away" has four spellings in this store. Covering only the
+ * one the issue named is the same adjacent-field mistake one level up, and the
+ * review found the fourth after this table already had three:
+ *
+ *   1. `session_list` removedIds  — one session closed        (message-handler.ts)
+ *   2. `auth_ok` non-reconnect    — fresh connect, roster wipe (message-handler.ts)
+ *   3. `forgetSession`            — disconnect + forget        (connection.ts)
+ *   4. `_resetSessionMemory`      — switchServer               (connection.ts)
+ *
+ * 2/3/4 empty `sessionStates` wholesale, and `removedIds` is a diff against
+ * `sessionStates` — so each must clear these maps itself or they are permanently
+ * unprunable. That is one mechanism, not four coincidences.
  */
-describe('#7470 roster coverage: every session-keyed PR/CI map is cleaned up', () => {
+describe('#7470 roster coverage: every session-keyed collection is classified and cleaned', () => {
   const typesSrc = readFileSync(resolve(__dirname, 'types.ts'), 'utf8')
   const handlerSrc = readFileSync(resolve(__dirname, 'message-handler.ts'), 'utf8')
   const connectionSrc = readFileSync(resolve(__dirname, 'connection.ts'), 'utf8')
@@ -301,44 +503,129 @@ describe('#7470 roster coverage: every session-keyed PR/CI map is cleaned up', (
   /** `[site label, source text, start marker, end marker]`. */
   const SITES: [string, string, string, string][] = [
     ['session_list removedIds', handlerSrc, '#7470 prune-block-start', '#7470 prune-block-end'],
+    ['auth_ok fresh connect', handlerSrc, '#7470 authok-reset-start', '#7470 authok-reset-end'],
     ['forgetSession', connectionSrc, '#7470 forget-reset-start', '#7470 forget-reset-end'],
     ['_resetSessionMemory', connectionSrc, '#7470 switch-reset-start', '#7470 switch-reset-end'],
   ]
 
+  // -- Bucket 1: session-id-keyed, cleaned at every site by this PR. ----------
+  const CLEANED = [
+    'sessionPrStatus',
+    'sessionPrStatusLoading',
+    'sessionPrStatusRequestedAt',
+    'sessionPrThreads',
+    'sessionPrThreadsLoading',
+  ]
+
+  // -- Bucket 2: session-id-keyed, cleaned by its own code at all four sites. -
+  // `sessionStates` IS the roster the other three sites empty and the set
+  // `removedIds` diffs against; the five above follow it rather than duplicate
+  // it, so it is classified, not asserted against the markers.
+  const SESSION_KEYED_ELSEWHERE = ['sessionStates']
+
+  // -- Bucket 3: session-scoped and NOT yet cleaned — tracked, not hidden. ----
+  const SESSION_KEYED_DEFERRED: Record<string, string> = {
+    pendingServerSeed: '#7478 — keyed by sessionId; different feature family (#5553 presets)',
+    cancellingActivityIds: '#7483 — keyed `${sessionId}:${activityId}`; missing from the removedIds site only',
+  }
+
+  // -- Bucket 4: keyed by something that is not a session id. ----------------
+  // Reason quoted from each field's own declaration in types.ts.
+  const NOT_SESSION_KEYED: Record<string, string> = {
+    sessionPresetSnapshots: 'keyed by cwd (#5553)',
+    reindexingRepoPaths: 'keyed by the repoPath the dashboard sent',
+    reindexResults: 'per repo path',
+    relayRerunningRepoPaths: 'repo paths with an in-flight relay re-run',
+    relayRerunResults: 'per repo path',
+    permissionInputs: 'keyed by requestId',
+    resolvedPermissions: 'keyed by requestId',
+    orchestrationPendingActions: 'keyed by requestId',
+    orchestrationActionResults: 'keyed by requestId',
+    scheduledTaskPendingActions: 'keyed by requestId',
+    scheduledTaskActionResults: 'keyed by requestId',
+    orchestrationRunDetails: 'per run (runId)',
+    orchestrationRunDetailErrors: 'keyed by runId',
+    orchestrationRunDetailStale: 'runIds whose held detail hit a seq gap',
+    orchestrationRunDetailLoading: 'runIds with an in-flight detail request',
+    containerActioningIds: 'keyed by environmentId',
+    containerActionResults: 'per environment id',
+    byokPoolActioningIds: 'keyed by the action target',
+    byokPoolActionResults: 'per target id',
+    hostPruneActioningIds: 'keyed by kind',
+    hostPruneActionResults: 'per kind',
+    simulatorActioningIds: 'keyed by udid',
+    simulatorActionResults: 'per udid',
+    emulatorActioningIds: 'keyed by avd / serial',
+    emulatorActionResults: 'per target id',
+    wslActioningIds: 'keyed by distro',
+    wslActionResults: 'per distro name',
+    serverCapabilities: 'keyed by feature name',
+    credentialTestResults: 'keyed by credential key',
+  }
+
   /**
-   * `sessionPresetSnapshots` matches the `sessionPr` prefix by accident and is
-   * keyed by CWD, not by session id (#5553) — so it has no business in a
-   * session-lifecycle prune. Excluded BY NAME with the reason, rather than by
-   * narrowing the pattern until only today's five fields match: a pattern
-   * tightened around the current answer stops being a guard.
+   * Every `Record<string, …>` / `Set<string>` declared on `ConnectionState`.
+   *
+   * Sliced to the interface first: types.ts declares other interfaces with
+   * two-space members (`env?: Record<string, string>` on the MCP shapes), and a
+   * file-wide match would silently widen the roster with fields that are not
+   * store state at all.
    */
-  const NOT_SESSION_KEYED = new Set(['sessionPresetSnapshots'])
+  const interfaceBody = (() => {
+    const m = /^export interface ConnectionState[\s\S]*?^\}/m.exec(typesSrc)
+    return m ? m[0] : ''
+  })()
+  const declared = [...interfaceBody.matchAll(/^ {2}(\w+)\??: (?:Record<string,|Set<string>)/gm)].map((m) => m[1]!)
 
-  const declared = [...typesSrc.matchAll(/^\s{2}(sessionPr\w*):\s*Record<string,/gm)]
-    .map((m) => m[1]!)
-    .filter((name) => !NOT_SESSION_KEYED.has(name))
-
-  it('finds the known PR/CI maps in types.ts (control: the extraction actually matched)', () => {
-    // Guards the guard: if the declaration style in types.ts changes and the
-    // regex stops matching, `declared` goes empty and the per-field loop below
-    // passes vacuously — the "cannot check this treated as nothing to check"
-    // entry in docs/false-safety-guards.md.
+  it('control: the structural extraction is non-vacuous and sees the known fields', () => {
+    // Guards the guard. If the interface slice or the member pattern stops
+    // matching, `declared` goes empty and every loop below passes vacuously —
+    // "cannot check this" silently becoming "nothing to check".
     //
-    // Deliberately a CONTAINMENT check, not an exact list. An exact list is a
-    // hardcoded roster beside a growing set — the same defect the loop below
-    // exists to catch — and would make a legitimately-added sixth map fail
-    // HERE, in the control, instead of on the prune assertion that is the
-    // actual finding.
+    // The floor is deliberately loose (the roster grows) but the named members
+    // are exact: the five under test, one from each other bucket, and one
+    // `Set<string>` so a regression to Records-only is caught. A `Set` matters
+    // because #7483 is one — the shape the first version of this guard could
+    // not express at all.
+    expect(declared.length).toBeGreaterThanOrEqual(30)
     expect(declared).toEqual(expect.arrayContaining([
-      'sessionPrStatus',
-      'sessionPrStatusLoading',
-      'sessionPrStatusRequestedAt',
-      'sessionPrThreads',
-      'sessionPrThreadsLoading',
+      ...CLEANED,
+      'sessionStates',
+      'pendingServerSeed',
+      'cancellingActivityIds',
+      'sessionPresetSnapshots',
+      'resolvedPermissions',
     ]))
   })
 
-  const CASES: [string, string][] = SITES.flatMap(([site]) => declared.map((f) => [site, f] as [string, string]))
+  it('classification: every session-keyed-shaped collection is in exactly one bucket', () => {
+    // THE test Critical 2 asked for. A new collection on ConnectionState is RED
+    // until it is classified, whatever it is called — so `sessionCiChecks`, the
+    // mutant that survived the name-prefix version, fails here by name.
+    const classified = new Set([
+      ...CLEANED,
+      ...SESSION_KEYED_ELSEWHERE,
+      ...Object.keys(SESSION_KEYED_DEFERRED),
+      ...Object.keys(NOT_SESSION_KEYED),
+    ])
+    const unclassified = declared.filter((f) => !classified.has(f))
+    expect(
+      unclassified,
+      'new session-keyed-shaped field(s) on ConnectionState. Add each to CLEANED (and to all four ' +
+      'site blocks), to SESSION_KEYED_DEFERRED with a tracking issue, or to NOT_SESSION_KEYED with ' +
+      'the key it is actually keyed by — quoted from its declaration, not inferred from its name.',
+    ).toEqual([])
+
+    // And the reverse: a bucket entry for a field that no longer exists is a
+    // stale allowlist, which is how an exclusion outlives its reason.
+    const declaredSet = new Set(declared)
+    expect(
+      [...classified].filter((f) => !declaredSet.has(f)),
+      'bucket entries for fields no longer declared on ConnectionState — stale allowlist',
+    ).toEqual([])
+  })
+
+  const CASES: [string, string][] = SITES.flatMap(([site]) => CLEANED.map((f) => [site, f] as [string, string]))
 
   it.each(CASES)('[%s] cleans up %s', (site, field) => {
     const entry = SITES.find(([name]) => name === site)!
@@ -356,8 +643,6 @@ describe('#7470 roster coverage: every session-keyed PR/CI map is cleaned up', (
     // `sessionPrStatus`, so a site that dropped `sessionPrStatus` entirely
     // still satisfied it — measured, not theorised (the mutation matrix showed
     // exactly two of ten mutants surviving this guard before it was tightened).
-    // That is docs/false-safety-guards.md's substring-standing-in-for-a-token
-    // entry, reproduced inside the guard written to prevent its cousin.
     //
     // Requiring the field to be followed by `:` or `=` pins it to an actual
     // assignment (`sessionPrStatus: {}` / `patch.sessionPrStatus = ...`) and

--- a/packages/dashboard/src/store/session-destroy-prunes-pr-maps.test.ts
+++ b/packages/dashboard/src/store/session-destroy-prunes-pr-maps.test.ts
@@ -1,0 +1,368 @@
+/**
+ * #7470 — destroying a session must prune its entry from EVERY per-session
+ * PR/CI map in the connection store.
+ *
+ * The store keeps five session-keyed maps for the PR/CI surface:
+ *
+ *   sessionPrStatus            (#7344)  full PR + check-rollup snapshot
+ *   sessionPrStatusLoading     (#7344)  in-flight flag
+ *   sessionPrStatusRequestedAt (#7344)  client-clock auto-pull throttle stamp
+ *   sessionPrThreads           (#7430)  unresolved review-thread reading
+ *   sessionPrThreadsLoading    (#7430)  in-flight flag
+ *
+ * `connection.ts` resets the three LOADING-shaped maps on a socket drop, which
+ * is a reconnect reset (a control stranded by a reply that will never arrive) —
+ * NOT a lifecycle prune. Nothing removed an entry when the session it describes
+ * went away, so a long-lived tab accumulated one snapshot per ever-surveyed
+ * session id for the life of the connection.
+ *
+ * The store's one session-went-away path is the `session_list` handler's
+ * `removedIds` block, where `sessionStates` and the Control Room `activity`
+ * tree are already pruned. The fix lives there.
+ *
+ * ## What these tests are shaped to catch
+ *
+ * A per-map assertion for EACH of the five, never one blanket "the maps no
+ * longer mention sess-dead" check: a blanket assertion is satisfied by pruning
+ * four of five, which is exactly the adjacent-field failure this issue is an
+ * instance of. Mutating away any single prune call must turn exactly one
+ * assertion red, and the message must name the map.
+ *
+ * Plus a POSITIVE CONTROL in every case: the surviving session's entries must
+ * come through byte-identical. Without it, `set({ sessionPrStatus: {} })` —
+ * clearing everything — would pass every "dead key is gone" assertion.
+ *
+ * Plus a roster guard derived from `types.ts` rather than from a list written
+ * here, so a SIXTH map added to the family without a prune goes red.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+vi.mock('./crypto', () => ({
+  createKeyPair: vi.fn(() => ({ publicKey: 'mock-pub', secretKey: 'mock-sec' })),
+  deriveSharedKey: vi.fn(), encrypt: vi.fn(), decrypt: vi.fn(),
+  generateConnectionSalt: vi.fn(() => 'mock-salt'),
+  deriveConnectionKey: vi.fn(() => new Uint8Array(32)),
+  DIRECTION_CLIENT: 0, DIRECTION_SERVER: 1,
+}))
+vi.mock('./persistence', () => ({ clearPersistedSession: vi.fn() }))
+
+import { handleMessage, setStore, clearDeltaBuffers, clearPermissionSplits, stopHeartbeat, resetReplayFlags } from './message-handler'
+import { createEmptySessionState } from './utils'
+import type { ConnectionState } from './types'
+import { createEmptyActivityState } from '@chroxy/store-core'
+import type { ServerSessionPrStatusMessage, ServerSessionPrThreadsMessage } from '@chroxy/protocol'
+
+const DEAD = 'sess-dead'
+const LIVE = 'sess-live'
+
+function createMockStore(initial: Partial<ConnectionState>) {
+  let state = initial as ConnectionState
+  return {
+    getState: () => state,
+    setState: (s: Partial<ConnectionState> | ((prev: ConnectionState) => Partial<ConnectionState>)) => {
+      state = { ...state, ...(typeof s === 'function' ? s(state) : s) }
+    },
+  }
+}
+function createMockSocket(): WebSocket {
+  return { send: vi.fn(), close: vi.fn(), readyState: WebSocket.OPEN, addEventListener: vi.fn(), removeEventListener: vi.fn() } as unknown as WebSocket
+}
+
+/**
+ * A realistic `session_pr_status` snapshot. Built to the REAL schema shape
+ * (nested `repo` / `pr` / `checks` / `merge`) and typed WITHOUT a cast, so a
+ * fixture that drifts from the wire contract fails the typecheck instead of
+ * type-checking as whatever the test happens to assert on.
+ */
+function prStatus(sessionId: string, prNumber: number): ServerSessionPrStatusMessage {
+  return {
+    type: 'session_pr_status',
+    requestId: `req-status-${sessionId}`,
+    sessionId,
+    generatedAt: '2026-08-28T00:00:00.000Z',
+    branch: `feat/${sessionId}`,
+    repo: { owner: 'blamechris', name: 'chroxy' },
+    pr: {
+      number: prNumber,
+      title: `PR for ${sessionId}`,
+      url: `https://github.com/blamechris/chroxy/pull/${prNumber}`,
+      headRefOid: 'deadbeef',
+      isDraft: false,
+    },
+    checks: {
+      state: 'success',
+      counts: { total: 3, passed: 3, failed: 0, pending: 0, skipped: 0, unknown: 0 },
+    },
+    merge: { mergeable: 'MERGEABLE', mergeStateStatus: 'CLEAN', reviewDecision: 'APPROVED' },
+    reason: null,
+  }
+}
+
+function prThreads(sessionId: string, unresolvedCount: number): ServerSessionPrThreadsMessage {
+  return {
+    type: 'session_pr_threads',
+    requestId: `req-${sessionId}`,
+    sessionId,
+    countedAt: '2026-08-28T00:00:00.000Z',
+    prNumber: 7470,
+    unresolvedCount,
+    totalCount: unresolvedCount,
+    truncated: false,
+    reason: null,
+  }
+}
+
+/**
+ * Both sessions are known to the store (they have `sessionStates` entries —
+ * that is what `removedIds` is computed against) and both carry an entry in
+ * every one of the five maps.
+ */
+function baseState(): Partial<ConnectionState> {
+  return {
+    connectionPhase: 'connected',
+    socket: null,
+    activeSessionId: LIVE,
+    sessions: [
+      { sessionId: DEAD, name: 'dead' },
+      { sessionId: LIVE, name: 'live' },
+    ] as ConnectionState['sessions'],
+    sessionStates: {
+      [DEAD]: createEmptySessionState(),
+      [LIVE]: createEmptySessionState(),
+    },
+    messages: [],
+    availableModels: [],
+    // #5163 activity tree — the removedIds block calls `clearSessionActivity`
+    // on it, so an undefined value throws there and the PR/CI assertions below
+    // would never run (a crash is not a red assertion).
+    activity: createEmptyActivityState(),
+    sessionPrStatus: { [DEAD]: prStatus(DEAD, 1), [LIVE]: prStatus(LIVE, 2) },
+    sessionPrStatusLoading: { [DEAD]: true, [LIVE]: true },
+    sessionPrStatusRequestedAt: { [DEAD]: 1000, [LIVE]: 2000 },
+    sessionPrThreads: { [DEAD]: prThreads(DEAD, 3), [LIVE]: prThreads(LIVE, 4) },
+    sessionPrThreadsLoading: { [DEAD]: true, [LIVE]: true },
+  }
+}
+
+/** A `session_list` snapshot that no longer contains `sess-dead`. */
+function listWithoutDead(): Record<string, unknown> {
+  return {
+    type: 'session_list',
+    sessions: [{ sessionId: LIVE, name: 'live', isBusy: false }],
+  }
+}
+
+describe('#7470 session destroy prunes the per-session PR/CI maps', () => {
+  let store: ReturnType<typeof createMockStore>
+  let mockSocket: WebSocket
+  const ctx = () => ({ url: 'wss://t', token: 'tok', socket: mockSocket, isReconnect: false, silent: false })
+
+  beforeEach(() => {
+    vi.clearAllMocks(); localStorage.clear(); clearDeltaBuffers(); clearPermissionSplits(); resetReplayFlags()
+    mockSocket = createMockSocket(); store = createMockStore(baseState()); setStore(store)
+  })
+  afterEach(() => { stopHeartbeat() })
+
+  // ---- Per-map prune assertions. One `it` per map, so a partial fix fails
+  // ---- with the name of the map that was missed.
+
+  it('prunes sessionPrStatus for the destroyed session and leaves the survivor', () => {
+    const before = store.getState().sessionPrStatus[LIVE]
+    handleMessage(listWithoutDead(), ctx() as never)
+    const after = store.getState().sessionPrStatus
+    expect(after[DEAD]).toBeUndefined()
+    expect(Object.keys(after)).toEqual([LIVE])
+    // Positive control: the survivor's snapshot is untouched, so a blanket
+    // `sessionPrStatus: {}` cannot satisfy the assertion above.
+    expect(after[LIVE]).toBe(before)
+    expect(after[LIVE]?.pr?.number).toBe(2)
+  })
+
+  it('prunes sessionPrStatusLoading for the destroyed session and leaves the survivor', () => {
+    handleMessage(listWithoutDead(), ctx() as never)
+    const after = store.getState().sessionPrStatusLoading
+    expect(after[DEAD]).toBeUndefined()
+    expect(Object.keys(after)).toEqual([LIVE])
+    expect(after[LIVE]).toBe(true)
+  })
+
+  it('prunes sessionPrStatusRequestedAt for the destroyed session and leaves the survivor', () => {
+    handleMessage(listWithoutDead(), ctx() as never)
+    const after = store.getState().sessionPrStatusRequestedAt
+    expect(after[DEAD]).toBeUndefined()
+    expect(Object.keys(after)).toEqual([LIVE])
+    // The survivor's auto-pull stamp must survive intact — clearing it would
+    // silently re-open the #7344 request-rate hole for every other tab.
+    expect(after[LIVE]).toBe(2000)
+  })
+
+  it('prunes sessionPrThreads for the destroyed session and leaves the survivor', () => {
+    const before = store.getState().sessionPrThreads[LIVE]
+    handleMessage(listWithoutDead(), ctx() as never)
+    const after = store.getState().sessionPrThreads
+    expect(after[DEAD]).toBeUndefined()
+    expect(Object.keys(after)).toEqual([LIVE])
+    expect(after[LIVE]).toBe(before)
+    expect(after[LIVE]?.unresolvedCount).toBe(4)
+  })
+
+  it('prunes sessionPrThreadsLoading for the destroyed session and leaves the survivor', () => {
+    handleMessage(listWithoutDead(), ctx() as never)
+    const after = store.getState().sessionPrThreadsLoading
+    expect(after[DEAD]).toBeUndefined()
+    expect(Object.keys(after)).toEqual([LIVE])
+    expect(after[LIVE]).toBe(true)
+  })
+
+  // ---- Shape / no-op properties.
+
+  it('leaves every map untouched (same reference) when no session was removed', () => {
+    const before = store.getState()
+    const refs = {
+      sessionPrStatus: before.sessionPrStatus,
+      sessionPrStatusLoading: before.sessionPrStatusLoading,
+      sessionPrStatusRequestedAt: before.sessionPrStatusRequestedAt,
+      sessionPrThreads: before.sessionPrThreads,
+      sessionPrThreadsLoading: before.sessionPrThreadsLoading,
+    }
+    handleMessage({
+      type: 'session_list',
+      sessions: [{ sessionId: DEAD, isBusy: false }, { sessionId: LIVE, isBusy: false }],
+    }, ctx() as never)
+    const after = store.getState()
+    // NOTE what this does and does NOT prove: with no removals the handler's
+    // `removedIds.length > 0` guard skips the whole block, so this pins the
+    // GUARD and says nothing about the prune helper. The helper's own no-op
+    // path is pinned by the next test, which drives a real removal.
+    for (const key of Object.keys(refs) as (keyof typeof refs)[]) {
+      expect(after[key], `${key} must keep its reference when nothing was removed`).toBe(refs[key])
+    }
+  })
+
+  it('keeps a map\'s reference when the removed session was never in THAT map', () => {
+    // The reachable case: a tab has a PR status for both sessions but has only
+    // ever counted threads for the survivor. Removing `sess-dead` must not hand
+    // `sessionPrThreads` a fresh object — every `useShallow` consumer of it
+    // would re-render for a value that did not change, on every session close.
+    //
+    // This is the test that actually exercises `pruneSessionKeyedMap`'s
+    // same-reference return: the previous test's precondition
+    // (`removedIds.length > 0`) is false, so the helper never runs there.
+    store.setState({ sessionPrThreads: { [LIVE]: prThreads(LIVE, 4) } })
+    const untrackedBefore = store.getState().sessionPrThreads
+    const trackedBefore = store.getState().sessionPrStatus
+    handleMessage(listWithoutDead(), ctx() as never)
+    const after = store.getState()
+    expect(after.sessionPrThreads).toBe(untrackedBefore)
+    // Positive control for THIS test: a map that did hold the removed id is
+    // rebuilt, so the assertion above cannot be passing because the prune
+    // never ran at all.
+    expect(after.sessionPrStatus).not.toBe(trackedBefore)
+    expect(after.sessionPrStatus[DEAD]).toBeUndefined()
+  })
+
+  it('prunes every removed session when several disappear at once', () => {
+    handleMessage({ type: 'session_list', sessions: [] }, ctx() as never)
+    const s = store.getState()
+    expect(s.sessionPrStatus).toEqual({})
+    expect(s.sessionPrStatusLoading).toEqual({})
+    expect(s.sessionPrStatusRequestedAt).toEqual({})
+    expect(s.sessionPrThreads).toEqual({})
+    expect(s.sessionPrThreadsLoading).toEqual({})
+  })
+})
+
+/**
+ * Roster coverage — the adjacent-field guard.
+ *
+ * Each of the three cleanup sites names its maps explicitly (a loop over a
+ * string list would be the same hardcoded roster, just less visible). That is
+ * only safe if something notices when the family grows, so this derives the
+ * roster from the PRODUCER — the `ConnectionState` declaration in `types.ts` —
+ * and asserts every session-keyed PR/CI map appears at EVERY site. A sixth map
+ * added without cleanup goes red here, naming both the field and the site it
+ * was missed at.
+ *
+ * Three sites, because "the session went away" has three spellings in this
+ * store and covering only the one the issue named is the same adjacent-field
+ * mistake one level up:
+ *
+ *   1. `session_list` removedIds        — one session closed  (message-handler.ts)
+ *   2. `forgetSession`                  — disconnect + forget (connection.ts)
+ *   3. `_resetSessionMemory`            — switchServer        (connection.ts)
+ */
+describe('#7470 roster coverage: every session-keyed PR/CI map is cleaned up', () => {
+  const typesSrc = readFileSync(resolve(__dirname, 'types.ts'), 'utf8')
+  const handlerSrc = readFileSync(resolve(__dirname, 'message-handler.ts'), 'utf8')
+  const connectionSrc = readFileSync(resolve(__dirname, 'connection.ts'), 'utf8')
+
+  /** `[site label, source text, start marker, end marker]`. */
+  const SITES: [string, string, string, string][] = [
+    ['session_list removedIds', handlerSrc, '#7470 prune-block-start', '#7470 prune-block-end'],
+    ['forgetSession', connectionSrc, '#7470 forget-reset-start', '#7470 forget-reset-end'],
+    ['_resetSessionMemory', connectionSrc, '#7470 switch-reset-start', '#7470 switch-reset-end'],
+  ]
+
+  /**
+   * `sessionPresetSnapshots` matches the `sessionPr` prefix by accident and is
+   * keyed by CWD, not by session id (#5553) — so it has no business in a
+   * session-lifecycle prune. Excluded BY NAME with the reason, rather than by
+   * narrowing the pattern until only today's five fields match: a pattern
+   * tightened around the current answer stops being a guard.
+   */
+  const NOT_SESSION_KEYED = new Set(['sessionPresetSnapshots'])
+
+  const declared = [...typesSrc.matchAll(/^\s{2}(sessionPr\w*):\s*Record<string,/gm)]
+    .map((m) => m[1]!)
+    .filter((name) => !NOT_SESSION_KEYED.has(name))
+
+  it('finds the known PR/CI maps in types.ts (control: the extraction actually matched)', () => {
+    // Guards the guard: if the declaration style in types.ts changes and the
+    // regex stops matching, `declared` goes empty and the per-field loop below
+    // passes vacuously — the "cannot check this treated as nothing to check"
+    // entry in docs/false-safety-guards.md.
+    //
+    // Deliberately a CONTAINMENT check, not an exact list. An exact list is a
+    // hardcoded roster beside a growing set — the same defect the loop below
+    // exists to catch — and would make a legitimately-added sixth map fail
+    // HERE, in the control, instead of on the prune assertion that is the
+    // actual finding.
+    expect(declared).toEqual(expect.arrayContaining([
+      'sessionPrStatus',
+      'sessionPrStatusLoading',
+      'sessionPrStatusRequestedAt',
+      'sessionPrThreads',
+      'sessionPrThreadsLoading',
+    ]))
+  })
+
+  const CASES: [string, string][] = SITES.flatMap(([site]) => declared.map((f) => [site, f] as [string, string]))
+
+  it.each(CASES)('[%s] cleans up %s', (site, field) => {
+    const entry = SITES.find(([name]) => name === site)!
+    const [, src, startMarker, endMarker] = entry
+    // Slice to the marked block. A file-wide grep would be satisfied by any of
+    // the dozens of other mentions of these fields in the same file — the
+    // "source-level guards must be anchored" failure.
+    const start = src.indexOf(startMarker)
+    const end = src.indexOf(endMarker)
+    expect(start, `${startMarker} must exist`).toBeGreaterThan(-1)
+    expect(end, `${endMarker} must exist and follow its start`).toBeGreaterThan(start)
+    const block = src.slice(start, end)
+    // TOKEN match, not a substring match. `toContain(field)` looks right and is
+    // not: `sessionPrStatusLoading: {}` contains the substring
+    // `sessionPrStatus`, so a site that dropped `sessionPrStatus` entirely
+    // still satisfied it — measured, not theorised (the mutation matrix showed
+    // exactly two of ten mutants surviving this guard before it was tightened).
+    // That is docs/false-safety-guards.md's substring-standing-in-for-a-token
+    // entry, reproduced inside the guard written to prevent its cousin.
+    //
+    // Requiring the field to be followed by `:` or `=` pins it to an actual
+    // assignment (`sessionPrStatus: {}` / `patch.sessionPrStatus = ...`) and
+    // rejects a longer identifier that merely starts with it.
+    const assigned = new RegExp(`(^|[^A-Za-z0-9_$])${field}\\s*[:=][^=]`)
+    expect(assigned.test(block), `${site} must assign ${field} (token match, not substring)`).toBe(true)
+  })
+})

--- a/packages/dashboard/src/store/session-reset-clears-pr-maps.test.ts
+++ b/packages/dashboard/src/store/session-reset-clears-pr-maps.test.ts
@@ -1,0 +1,118 @@
+/**
+ * #7470 (second site) — the two FULL-RESET actions must drop the per-session
+ * PR/CI maps along with everything else session-scoped.
+ *
+ * `forgetSession()` (disconnect + forget this server) and `_resetSessionMemory()`
+ * (switchServer, which preserves the old server's PERSISTED data but must not
+ * carry its in-memory session state to the new one) both already clear
+ * `sessions`, `sessionStates` and the Control Room `activity` tree. Leaving the
+ * five PR/CI maps behind is worse than the unbounded growth #7470 was filed for:
+ * these maps are keyed by SESSION ID, and session ids are minted per daemon —
+ * so a surviving entry can be read against a DIFFERENT server's session of the
+ * same id and render one machine's CI state on another machine's chip.
+ *
+ * Driven through the REAL store rather than a mock, because the thing under
+ * test is the action's `set({ ... })` payload itself.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mock localStorage before importing the store (same idiom as
+// server-registry-store.test.ts — connection.ts reads persisted settings at
+// module scope).
+const lsStore: Record<string, string> = {}
+const localStorageMock = {
+  getItem: vi.fn((key: string) => lsStore[key] ?? null),
+  setItem: vi.fn((key: string, value: string) => { lsStore[key] = value }),
+  removeItem: vi.fn((key: string) => { delete lsStore[key] }),
+  clear: vi.fn(() => { for (const k of Object.keys(lsStore)) delete lsStore[k] }),
+  get length() { return Object.keys(lsStore).length },
+  key: vi.fn((i: number) => Object.keys(lsStore)[i] ?? null),
+}
+Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock, writable: true })
+
+vi.mock('../utils/auth', () => ({ getAuthToken: () => null }))
+
+const { useConnectionStore } = await import('./connection')
+const { createEmptySessionState } = await import('./utils')
+
+const A = 'sess-A'
+const B = 'sess-B'
+
+/** The five maps, populated for two sessions. */
+function seedPrMaps() {
+  useConnectionStore.setState({
+    sessions: [{ sessionId: A }, { sessionId: B }] as never,
+    activeSessionId: A,
+    sessionStates: { [A]: createEmptySessionState(), [B]: createEmptySessionState() },
+    sessionPrStatus: { [A]: { type: 'session_pr_status' } as never, [B]: { type: 'session_pr_status' } as never },
+    sessionPrStatusLoading: { [A]: true, [B]: true },
+    sessionPrStatusRequestedAt: { [A]: 1000, [B]: 2000 },
+    sessionPrThreads: { [A]: { type: 'session_pr_threads' } as never, [B]: { type: 'session_pr_threads' } as never },
+    sessionPrThreadsLoading: { [A]: true, [B]: true },
+  })
+}
+
+/** Restore the store's PR/CI slice so this file cannot leak into another. */
+function clearPrMaps() {
+  useConnectionStore.setState({
+    sessionPrStatus: {},
+    sessionPrStatusLoading: {},
+    sessionPrStatusRequestedAt: {},
+    sessionPrThreads: {},
+    sessionPrThreadsLoading: {},
+  })
+}
+
+describe.each([
+  ['forgetSession', () => useConnectionStore.getState().forgetSession()],
+  ['_resetSessionMemory', () => useConnectionStore.getState()._resetSessionMemory()],
+])('#7470 %s clears the per-session PR/CI maps', (_name, run) => {
+  beforeEach(() => {
+    clearPrMaps()
+    seedPrMaps()
+  })
+
+  // A positive control for the whole block: the seed actually landed, so an
+  // "everything is empty afterwards" assertion cannot pass because the fixture
+  // was never applied.
+  it('control: the seed populated all five maps for two sessions', () => {
+    const s = useConnectionStore.getState()
+    expect(Object.keys(s.sessionPrStatus)).toEqual([A, B])
+    expect(Object.keys(s.sessionPrStatusLoading)).toEqual([A, B])
+    expect(Object.keys(s.sessionPrStatusRequestedAt)).toEqual([A, B])
+    expect(Object.keys(s.sessionPrThreads)).toEqual([A, B])
+    expect(Object.keys(s.sessionPrThreadsLoading)).toEqual([A, B])
+  })
+
+  // One assertion per map: a reset that clears four of five must name the fifth.
+  it('clears sessionPrStatus', () => {
+    run()
+    expect(useConnectionStore.getState().sessionPrStatus).toEqual({})
+  })
+  it('clears sessionPrStatusLoading', () => {
+    run()
+    expect(useConnectionStore.getState().sessionPrStatusLoading).toEqual({})
+  })
+  it('clears sessionPrStatusRequestedAt', () => {
+    run()
+    expect(useConnectionStore.getState().sessionPrStatusRequestedAt).toEqual({})
+  })
+  it('clears sessionPrThreads', () => {
+    run()
+    expect(useConnectionStore.getState().sessionPrThreads).toEqual({})
+  })
+  it('clears sessionPrThreadsLoading', () => {
+    run()
+    expect(useConnectionStore.getState().sessionPrThreadsLoading).toEqual({})
+  })
+
+  it('clears them as part of the same reset that drops sessionStates', () => {
+    run()
+    const s = useConnectionStore.getState()
+    // Co-location check: these maps go with the session state they describe.
+    // If sessionStates survived here the test above would be asserting the
+    // wrong thing entirely.
+    expect(s.sessionStates).toEqual({})
+    expect(s.sessions).toEqual([])
+  })
+})

--- a/packages/dashboard/src/store/utils.ts
+++ b/packages/dashboard/src/store/utils.ts
@@ -31,3 +31,28 @@ export function createEmptySessionState(): SessionState {
     pendingEvaluatorClarify: null,
   };
 }
+
+/**
+ * #7470 — drop every id in `removedIds` from a session-keyed map, returning a
+ * NEW object only when something was actually removed.
+ *
+ * The same-reference return on a no-op is load-bearing, not an optimisation
+ * detail: these maps are read through `useShallow` selectors, and rebuilding
+ * them on every `session_list` snapshot (one per session lifecycle event, plus
+ * every reconnect) would re-render each consumer for a value that did not
+ * change.
+ *
+ * Inputs are treated as immutable — the source map is never mutated.
+ */
+export function pruneSessionKeyedMap<T>(
+  map: Record<string, T>,
+  removedIds: readonly string[],
+): Record<string, T> {
+  let next: Record<string, T> | null = null;
+  for (const id of removedIds) {
+    if (!(id in map)) continue;
+    if (!next) next = { ...map };
+    delete next[id];
+  }
+  return next ?? map;
+}

--- a/packages/dashboard/src/store/utils.ts
+++ b/packages/dashboard/src/store/utils.ts
@@ -43,6 +43,18 @@ export function createEmptySessionState(): SessionState {
  * change.
  *
  * Inputs are treated as immutable — the source map is never mutated.
+ *
+ * Membership is an OWN-property test, deliberately not `in`. `in` walks the
+ * prototype chain, so `prune({ a: 1 }, ['toString'])` would find a "match",
+ * clone, and return a NEW object with identical contents — defeating the
+ * same-reference guarantee above. Unreachable with today's session ids
+ * (`[a-f0-9]{32}`), but this helper is generic and exported, and its contract
+ * is reference identity: `__proto__` / `constructor` / `hasOwnProperty` must
+ * not be able to break it (PR #7481 review N1).
+ *
+ * Spelled `Object.prototype.hasOwnProperty.call` rather than `Object.hasOwn`:
+ * the latter is ES2022 and this package's `lib` predates it, so it fails
+ * `tsc --noEmit`. Caught by running the typecheck for its bare exit code.
  */
 export function pruneSessionKeyedMap<T>(
   map: Record<string, T>,
@@ -50,7 +62,7 @@ export function pruneSessionKeyedMap<T>(
 ): Record<string, T> {
   let next: Record<string, T> | null = null;
   for (const id of removedIds) {
-    if (!(id in map)) continue;
+    if (!Object.prototype.hasOwnProperty.call(map, id)) continue;
     if (!next) next = { ...map };
     delete next[id];
   }


### PR DESCRIPTION
Closes #7470

## The map roster (enumerated first)

Every `Record<sessionId, …>`-shaped map in the dashboard connection store,
audited in full rather than fixing only the two the issue named:

| Map | Issue | Keyed by | Before | Now |
|---|---|---|---|---|
| `sessionPrStatus` | #7344 | session id | never removed | pruned at all 3 sites |
| `sessionPrStatusLoading` | #7344 | session id | reset on socket drop only | pruned at all 3 sites |
| `sessionPrStatusRequestedAt` | #7344 | session id | reset on socket drop only | pruned at all 3 sites |
| `sessionPrThreads` | #7430 | session id | never removed | pruned at all 3 sites |
| `sessionPrThreadsLoading` | #7430 | session id | reset on socket drop only | pruned at all 3 sites |

Audited and deliberately **out**:

| Map | Why |
|---|---|
| `sessionStates` | already pruned on `session_list` removal + both resets |
| `activity` (Control Room tree) | already pruned, via `clearSessionActivity` (#5163) |
| `sessionNotifications` | an array, and deliberately retained on close — the #7466 comment in `connection.ts` depends on that retention |
| `sessionPresetSnapshots` | matches the `sessionPr` prefix by accident; keyed by **cwd**, not session id (#5553) |
| `pendingServerSeed` | genuinely session-keyed and genuinely unpruned, but a different feature family (#5553) — filed as **#7478** rather than folded in silently |

## Three sites, not one

The issue asked for "the `session_destroyed` / session-removal path". There is
no `session_destroyed` in the dashboard — `destroySession` only puts a frame on
the wire, and the server's next `session_list` is what tells this tab a session
is gone. Auditing for that turned up three spellings of "the session went away",
and covering only the first would have been the same adjacent-field mistake one
level up:

1. **`session_list` removedIds** (`message-handler.ts`) — one session closed.
   Pruned beside `sessionStates` and `activity`, which is where the store
   already does this.
2. **`forgetSession`** (`connection.ts`) — disconnect + forget.
3. **`_resetSessionMemory`** (`connection.ts`) — `switchServer`.

(2) and (3) are worse than unbounded growth. These maps are keyed by session id,
session ids are minted per daemon, and `switchServer` keeps the old server's
persisted data on purpose — so a surviving entry can be read against a
**different** server's session of the same id, rendering one machine's CI state
on another machine's chip. That is a wrong answer, not just retained memory.

`sessionStates` is pruned rather than retained on all three paths, so no
retain/prune split was needed — the PR/CI maps go exactly where it goes.

## Evidence

### Red first

`handleMessage` takes an **object**, not a JSON string, and my first fixture
passed `JSON.stringify(...)` — the handler returned at its `typeof raw !== 'object'`
guard and every test "failed" without reaching the code under test. The second
red run crashed inside `clearSessionActivity` because the fixture omitted
`activity`. Both were discarded: **a crash and an early return are not a red
assertion.** The recorded red is the third run.

`session_list` prune site — fix reverted, fixture correct:

```
Tests  11 failed | 2 passed (13)
AssertionError: expected { type: 'session_pr_status', …(10) } to be undefined
AssertionError: expected true to be undefined
AssertionError: expected 1000 to be undefined
AssertionError: expected { type: 'session_pr_threads', …(8) } to be undefined
AssertionError: expected true to be undefined
```

The 2 passing pre-fix are both controls by design: the roster-extraction control
and the no-removal no-op.

Reset sites, before the `connection.ts` change:

```
Tests  10 failed | 4 passed (14)
AssertionError: expected { 'sess-A': 1000, 'sess-B': 2000 } to deeply equal {}
```

After: **38 passed (38)** across both new files.

### Mutation matrix

Twelve single-map mutants — drop exactly one map's cleanup at one site — each
killed by an assertion that **names that map**, so no blanket assertion is
satisfiable by partial pruning:

| Mutant | Killed by |
|---|---|
| drop `sessionPrStatus` @ session_list | `prunes sessionPrStatus …` + `[session_list removedIds] cleans up sessionPrStatus` |
| drop `sessionPrThreads` @ session_list | `prunes sessionPrThreads …` + roster |
| drop each of 5 @ `forgetSession` | `clears <map>` + `[forgetSession] cleans up <map>` |
| drop each of 5 @ `_resetSessionMemory` | `clears <map>` + `[_resetSessionMemory] cleans up <map>` |

Three further mutants:

- **Blanket clear** — replace all five prunes with `= {}`: **5 failed**, one per
  map, caught by the positive controls (the survivor's snapshot must come through
  by reference, its `prNumber` must still be 2, its throttle stamp still 2000). A
  fix that wipes everything cannot pass.
- **Sixth family map** — add `sessionPrMutantSixth: Record<string, number>` to
  `types.ts` with no cleanup: **3 failed**, one per site, each naming the field.
- **Reference churn** — make `pruneSessionKeyedMap` always return a new object:
  killed by `keeps a map's reference when the removed session was never in THAT map`.

Two guards I had to fix because a mutant **survived** them, both recorded here
because a mutation matrix that only reports kills is not evidence:

1. The first reference-stability test drove a `session_list` with **no**
   removals, so the handler's `removedIds.length > 0` guard skipped the block
   entirely and the helper never ran — a false precondition, green for the wrong
   reason. Replaced with a removal the map does not track.
2. Generalising the roster guard to three sites weakened its assertion from
   `toContain('patch.<field> =')` to `toContain(field)` — and
   `sessionPrStatusLoading: {}` **contains the substring** `sessionPrStatus`, so
   2 of 10 mutants survived it. Now a token match
   (`(^|[^A-Za-z0-9_$])<field>\s*[:=][^=]`); the matrix above is the re-run after
   tightening, with all 12 killed.

### Adjacent-field guard

The roster test derives the family from the **producer** — the `ConnectionState`
declaration in `types.ts` — not from a list written in the test, and asserts each
member is assigned inside each site's marked block. `sessionPresetSnapshots` is
excluded **by name with its reason** rather than by narrowing the regex until
only today's five match. The extraction has its own control (a containment check,
so a legitimate sixth map fails the prune assertion rather than the control).

Blocks are sliced by marker before matching — a file-wide grep for
`sessionPrStatus` in `message-handler.ts` is satisfied by dozens of unrelated
lines.

## Suites

| Suite | Command | Result |
|---|---|---|
| Dashboard typecheck | `npx tsc --noEmit` (bare exit code) | **exit 0** |
| Dashboard store | `npx vitest run src/store/` | **85 files, 1230 tests passed** |
| Full dashboard | `npx vitest run` | **313 files, 5460 tests passed** |
| `session-destroy-prunes-pr-maps.test.ts` | individually | **24 passed** |
| `session-reset-clears-pr-maps.test.ts` | individually | **14 passed** |
| `dispatch-control-room-activity.test.ts` | individually | **14 passed** |

The worktree has no `packages/dashboard/node_modules`, so `tsc` initially
reported 251 errors — all `Cannot find module '@testing-library/react'` /
`react-dom` / `react-resizable-panels` and their implicit-any cascade. Confirmed
environmental by diffing against the **pristine** tree: byte-identical error
lists, so the change adds zero. Re-run with those four packages resolvable, the
typecheck exits **0**.

## Note on the touched existing test

`dispatch-control-room-activity.test.ts`'s partial mock state omitted the five
maps, so the new prune hit `undefined`. The maps are non-optional on
`ConnectionState` and always `{}` in the real store, so this is a fixture gap,
not a production shape — filled in rather than making `pruneSessionKeyedMap`
undefined-tolerant, which would have written `undefined` into the store to hide
a test's omission.

## Not in this PR

- #7478 — `pendingServerSeed`, the one session-keyed map left uncleaned. Same
  defect, different feature; the three `#7470` markers this PR adds are where its
  fix lands.
- #7450 remains the server-side half of the same shape and is untouched here.