### PR TITLE
fix(store-core): refcount the replay window, and give its live-question ledger a lifetime

### DIFF
--- a/packages/app/src/__tests__/store/connection-replay-teardown.test.ts
+++ b/packages/app/src/__tests__/store/connection-replay-teardown.test.ts
@@ -1,0 +1,178 @@
+/**
+ * #7456 — the replay window and its live-arrival ledger are per-CONNECTION
+ * state, and until now nothing released them on a transport drop.
+ *
+ * `resetReplayReconcile()` was called from exactly one production path on each
+ * client — `auth_ok` — so a socket that dropped mid-replay left the session's
+ * window open and its ledger populated until the NEXT successful auth, which on
+ * a backgrounded app may never come.
+ *
+ * Since #7455 the window is a REFCOUNT, which makes this load-bearing rather
+ * than merely untidy: a `history_replay_start` with no matching `_end` strands
+ * a +1, so every later end decrements from a too-high base and the window never
+ * closes again for that session — the ledger is never released and every later
+ * prompt is protected forever.
+ *
+ * Cursors are deliberately NOT cleared here: they are what makes the reconnect
+ * a delta replay instead of a full rebuild (#5555.3).
+ *
+ * Harness mirrors connection-reconnect-backoff.test.ts.
+ */
+jest.mock('expo-secure-store', () => ({
+  getItemAsync: jest.fn(() => Promise.resolve('dev-id-123')),
+  setItemAsync: jest.fn(() => Promise.resolve()),
+}));
+
+import * as SecureStore from 'expo-secure-store';
+import {
+  reconcileReplayStart,
+  recordHistorySeq,
+  resetReplayReconcile,
+  noteLivePromptDuringReplay,
+  wasPromptLiveDuringReplay,
+  getReplayWindowDepth,
+  getLiveReplayLedgerSessionIds,
+  getHistoryCursor,
+  isRebuildInProgress,
+} from '@chroxy/store-core';
+import { useConnectionStore, __resetDeviceIdCacheForTests } from '../../store/connection';
+import { useConnectionLifecycleStore } from '../../store/connection-lifecycle';
+import { resetReconnectAttempt } from '../../store/message-handler';
+import { clearAllCallbacks } from '../../store/imperative-callbacks';
+
+function flushPromises(): Promise<void> {
+  return new Promise((resolve) =>
+    jest.requireActual<typeof globalThis>('timers').setImmediate(resolve),
+  );
+}
+
+function mockResponse(status: number, body?: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body ?? {}),
+    text: () => Promise.resolve(JSON.stringify(body ?? {})),
+  } as unknown as Response;
+}
+
+interface FakeSocket {
+  url: string;
+  readyState: number;
+  onopen: (() => void) | null;
+  onclose: ((event?: unknown) => void) | null;
+  onerror: ((event?: unknown) => void) | null;
+  onmessage: ((event: unknown) => void) | null;
+  send: jest.Mock;
+  close: jest.Mock;
+}
+
+function installMockWebSocket(): FakeSocket[] {
+  const instances: FakeSocket[] = [];
+  // @ts-expect-error — mock WebSocket constructor
+  global.WebSocket = class MockWebSocket {
+    static OPEN = 1;
+    url: string;
+    readyState = 0;
+    onopen: (() => void) | null = null;
+    onclose: ((event?: unknown) => void) | null = null;
+    onerror: ((event?: unknown) => void) | null = null;
+    onmessage: ((event: unknown) => void) | null = null;
+    send = jest.fn();
+    close = jest.fn();
+    constructor(url: string) {
+      this.url = url;
+      instances.push(this as unknown as FakeSocket);
+    }
+  };
+  return instances;
+}
+
+const originalFetch = global.fetch;
+const originalWebSocket = global.WebSocket;
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  clearAllCallbacks();
+  __resetDeviceIdCacheForTests();
+  resetReconnectAttempt();
+  resetReplayReconcile({ clearCursors: true });
+  (SecureStore.getItemAsync as jest.Mock).mockReset();
+  (SecureStore.getItemAsync as jest.Mock).mockResolvedValue('dev-id-123');
+  (SecureStore.setItemAsync as jest.Mock).mockResolvedValue(undefined);
+  useConnectionStore.setState({ sessionStates: {}, activeSessionId: null, socket: null });
+  useConnectionLifecycleStore.setState({
+    connectionPhase: 'disconnected',
+    connectionError: null,
+    connectionRetryCount: 0,
+    wsUrl: null,
+  });
+});
+
+afterEach(() => {
+  useConnectionStore.getState().disconnect();
+  resetReplayReconcile({ clearCursors: true });
+  global.fetch = originalFetch;
+  global.WebSocket = originalWebSocket;
+  jest.useRealTimers();
+});
+
+/** Open a connection and return the freshly constructed (current-attempt) socket. */
+async function openConnectedSocket(): Promise<FakeSocket> {
+  global.fetch = jest.fn().mockResolvedValue(mockResponse(200, { status: 'ok' }));
+  const instances = installMockWebSocket();
+  useConnectionStore.getState().connect('wss://tunnel.example.com', 'tok', { silent: true });
+  await flushPromises();
+  useConnectionLifecycleStore.setState({ connectionPhase: 'connected' });
+  return instances[instances.length - 1]!;
+}
+
+/** Open a replay window for `s1` with one live question inside it. */
+function openReplayWindowWithRacer(): void {
+  reconcileReplayStart('s1', true, 0);
+  noteLivePromptDuringReplay('s1', 'live-q');
+  recordHistorySeq('s1', 42);
+  // Positive controls — the fixture took effect, so the assertions below are
+  // about the teardown and not about state that was never there.
+  expect(getReplayWindowDepth('s1')).toBe(1);
+  expect(wasPromptLiveDuringReplay('s1', 'live-q')).toBe(true);
+  expect(isRebuildInProgress('s1')).toBe(true);
+}
+
+describe('transport teardown releases the replay window + live-arrival ledger (#7456)', () => {
+  it('socket.onclose releases the window and ledger but keeps the history cursor', async () => {
+    const socket = await openConnectedSocket();
+    openReplayWindowWithRacer();
+
+    socket.onclose?.({ code: 1006 });
+
+    expect(getReplayWindowDepth('s1')).toBe(0);
+    expect(getLiveReplayLedgerSessionIds()).toEqual([]);
+    expect(wasPromptLiveDuringReplay('s1', 'live-q')).toBe(false);
+    expect(isRebuildInProgress('s1')).toBe(false);
+    expect(getHistoryCursor('s1')).toBe(42);
+  });
+
+  it('socket.onerror releases the window and ledger but keeps the history cursor', async () => {
+    const socket = await openConnectedSocket();
+    openReplayWindowWithRacer();
+
+    socket.onerror?.({ message: 'boom' });
+
+    expect(getReplayWindowDepth('s1')).toBe(0);
+    expect(getLiveReplayLedgerSessionIds()).toEqual([]);
+    expect(wasPromptLiveDuringReplay('s1', 'live-q')).toBe(false);
+    expect(getHistoryCursor('s1')).toBe(42);
+  });
+
+  it('a stale socket close does not tear down the CURRENT attempt state', async () => {
+    const stale = await openConnectedSocket();
+    // A new attempt supersedes it (bumps the module-level attempt id).
+    await openConnectedSocket();
+    openReplayWindowWithRacer();
+
+    stale.onclose?.({ code: 1006 });
+
+    expect(getReplayWindowDepth('s1')).toBe(1);
+    expect(wasPromptLiveDuringReplay('s1', 'live-q')).toBe(true);
+  });
+});

--- a/packages/app/src/__tests__/store/message-handler.test.ts
+++ b/packages/app/src/__tests__/store/message-handler.test.ts
@@ -26,6 +26,9 @@ import {
   PERMISSION_DECISION_TOKENS,
   isLivePermissionPrompt,
   resetReplayReconcile,
+  wasPromptLiveDuringReplay,
+  getReplayWindowDepth,
+  getLiveReplayLedgerSessionIds,
 } from '@chroxy/store-core';
 import { clearPersistedSession } from '../../store/persistence';
 import { setCallback, clearAllCallbacks } from '../../store/imperative-callbacks';
@@ -975,6 +978,88 @@ describe("history_replay_end: '(resolved)' sweep vs a racing live AskUserQuestio
     _testMessageHandler.handle({ type: 'history_replay_end', sessionId: 's1' });
 
     expect((store.getState().sessionStates.s1.messages[0] as any).answered).toBe('(resolved)');
+  });
+
+  // #7455 — the server can have two replays of ONE session in flight at once:
+  // `subscribe_sessions` replays every newly-subscribed background session and
+  // `switch_session` calls `replayHistory(..., { forceFull: true })`
+  // unconditionally, so the wire order is start start end end. Before the
+  // window became a refcount the FIRST end closed it while replay #2 was still
+  // streaming, and every live question in that tail was stamped '(resolved)'.
+  it('protects a racer that arrives between the two ends of overlapping replays (#7455)', () => {
+    const store = seedOne();
+    _testMessageHandler.handle({ type: 'history_replay_start', sessionId: 's1', fullHistory: true });
+    _testMessageHandler.handle({ type: 'history_replay_start', sessionId: 's1', fullHistory: true });
+    // A racer inside the OVERLAP...
+    _testMessageHandler.handle(question({ toolUseId: 'q-use-1' }));
+    _testMessageHandler.handle({ type: 'history_replay_end', sessionId: 's1' });
+    // ...and one in the TAIL, after end#1, while replay #2 is still streaming.
+    // The tail racer is the one the pre-#7455 Set lost.
+    _testMessageHandler.handle(question({ toolUseId: 'q-use-2' }));
+    _testMessageHandler.handle({ type: 'history_replay_end', sessionId: 's1' });
+
+    // A racer arriving BEFORE the second start is deliberately not covered
+    // here: `_rebuildBaseline` has the same non-refcount shape and the second
+    // start overwrites it, so end#1's atomic swap slices that racer out of
+    // `messages` entirely. That is a separate defect in the same file, filed
+    // as #7477 — the ledger protects the message, the swap then drops it.
+    //
+    // Positive control: both questions really are in the store, so the
+    // `undefined` assertions below are about the sweep and not a missing fixture.
+    expect(store.getState().sessionStates.s1.messages).toHaveLength(2);
+    expect(answeredOf(store, 0)).toBeUndefined();
+    expect(answeredOf(store, 1)).toBeUndefined();
+    // Balanced pairs ⇒ the window is closed again.
+    expect(getReplayWindowDepth('s1')).toBe(0);
+  });
+
+  // #7456 — the store drops a session's messages wholesale on prune and on
+  // timeout; module state here used to survive both with nothing left to
+  // correspond to.
+  it('session_timeout drops the session live-arrival ledger (#7456)', () => {
+    const store = seedOne();
+    _testMessageHandler.handle({ type: 'history_replay_start', sessionId: 's1', fullHistory: false });
+    _testMessageHandler.handle(question());
+    const liveId = (store.getState().sessionStates.s1.messages[0] as any).id;
+    expect(wasPromptLiveDuringReplay('s1', liveId)).toBe(true);
+
+    _testMessageHandler.handle({
+      type: 'session_timeout',
+      sessionId: 's1',
+      name: 'S1',
+      idleMs: 600000,
+    });
+
+    expect(wasPromptLiveDuringReplay('s1', liveId)).toBe(false);
+    expect(getReplayWindowDepth('s1')).toBe(0);
+    expect(getLiveReplayLedgerSessionIds()).not.toContain('s1');
+  });
+
+  it('a session_list prune drops the pruned session live-arrival ledger (#7456)', () => {
+    const store = createMockStore({
+      activeSessionId: 's1',
+      sessions: [
+        { sessionId: 's1', name: 'S1' } as any,
+        { sessionId: 's2', name: 'S2' } as any,
+      ],
+      sessionStates: { s1: createEmptySessionState(), s2: createEmptySessionState() },
+      sessionNotifications: [],
+    });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockConnectionContext());
+
+    _testMessageHandler.handle({ type: 'history_replay_start', sessionId: 's1', fullHistory: false });
+    _testMessageHandler.handle(question());
+    const liveId = (store.getState().sessionStates.s1.messages[0] as any).id;
+    expect(wasPromptLiveDuringReplay('s1', liveId)).toBe(true);
+
+    // s1 dropped out of the authoritative list.
+    _testMessageHandler.handle({ type: 'session_list', sessions: [{ sessionId: 's2', name: 'S2' }] });
+
+    expect(store.getState().sessionStates).not.toHaveProperty('s1');
+    expect(wasPromptLiveDuringReplay('s1', liveId)).toBe(false);
+    expect(getReplayWindowDepth('s1')).toBe(0);
+    expect(getLiveReplayLedgerSessionIds()).not.toContain('s1');
   });
 });
 

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -1398,6 +1398,16 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       const wasConnected = useConnectionLifecycleStore.getState().connectionPhase === 'connected';
       set({ socket: null });
 
+      // #7456 — the replay window and its live-arrival ledger are
+      // per-CONNECTION state, like the rebuild baseline: release them on the
+      // transport drop rather than waiting for the next `auth_ok`, which on a
+      // backgrounded app may never arrive. Load-bearing since #7455 made the
+      // window a refcount — a `history_replay_start` with no matching `_end`
+      // would otherwise strand a +1 and the window would never close again for
+      // that session. Cursors are deliberately KEPT (they are what makes the
+      // reconnect a delta replay, #5555.3).
+      resetReplayReconcile();
+
       // Clear transient streaming/plan state so stale UI doesn't persist
       clearPermissionSplits();
       updateActiveSession((ss) => {
@@ -1467,6 +1477,16 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       clearHandshakeTimer();
 
       set({ socket: null });
+
+      // #7456 — the replay window and its live-arrival ledger are
+      // per-CONNECTION state, like the rebuild baseline: release them on the
+      // transport drop rather than waiting for the next `auth_ok`, which on a
+      // backgrounded app may never arrive. Load-bearing since #7455 made the
+      // window a refcount — a `history_replay_start` with no matching `_end`
+      // would otherwise strand a +1 and the window would never close again for
+      // that session. Cursors are deliberately KEPT (they are what makes the
+      // reconnect a delta replay, #5555.3).
+      resetReplayReconcile();
 
       // UX landmine #8: extract whatever detail we can from the error
       // event. React Native's WebSocket implementation exposes a

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -65,6 +65,10 @@ import {
   recordHistorySeq,
   reconcileReplayStart,
   reconcileReplayEnd,
+  // #7456 — per-session teardown for the two paths that drop a session's store
+  // state wholesale; without it this module's per-session entries outlive
+  // everything they correspond to.
+  dropReplaySessionState,
   // #7420 — the shared `history_replay_end` unanswered-prompt sweep. Both
   // clients carried byte-identical copies of the predicate through #7410/#7419;
   // it now has one implementation, which is also where the live-arrival ledger
@@ -2200,6 +2204,11 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       // GC persisted messages for sessions that dropped out of the list
       for (const prevId of removedIds) {
         void clearPersistedSession(prevId);
+        // #7456 — and the store-core replay state keyed to the same id. The
+        // prune drops `sessionStates[prevId]` and its persisted messages just
+        // below, so a retained replay window / live-arrival ledger would refer
+        // to nothing at all.
+        dropReplaySessionState(prevId);
       }
       // Batch in-memory cleanup into a single state update
       if (removedIds.length > 0) {
@@ -3700,6 +3709,8 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         set(patch);
         // Garbage-collect persisted messages for the deleted session (#797)
         void clearPersistedSession(timeoutSessionId);
+        // #7456 — same for the store-core replay window / live-arrival ledger.
+        dropReplaySessionState(timeoutSessionId);
       }
       break;
     }

--- a/packages/dashboard/src/store/connection-replay-teardown.test.ts
+++ b/packages/dashboard/src/store/connection-replay-teardown.test.ts
@@ -1,0 +1,145 @@
+/**
+ * #7456 — the replay window and its live-arrival ledger are per-CONNECTION
+ * state, and until now nothing released them on a transport drop.
+ *
+ * `resetReplayReconcile()` was called from exactly one production path on each
+ * client — `auth_ok` — so a socket that dropped mid-replay left the session's
+ * window open and its ledger populated until the NEXT successful auth, which
+ * for a tab left open on a dead tunnel may never come.
+ *
+ * Since #7455 the window is a REFCOUNT, which makes this load-bearing rather
+ * than merely untidy: a `history_replay_start` with no matching `_end` strands
+ * a +1, so every later end decrements from a too-high base and the window never
+ * closes again for that session — the ledger is never released and every later
+ * prompt is protected forever.
+ *
+ * Cursors are deliberately NOT cleared here: they are what makes the reconnect
+ * a delta replay instead of a full rebuild (#5555.3).
+ *
+ * Harness mirrors connection-reconnect-backoff.test.ts.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const store: Record<string, string> = {}
+const localStorageMock = {
+  getItem: (k: string) => store[k] ?? null,
+  setItem: (k: string, v: string) => { store[k] = v },
+  removeItem: (k: string) => { delete store[k] },
+  clear: () => { for (const k of Object.keys(store)) delete store[k] },
+  get length() { return Object.keys(store).length },
+  key: (i: number) => Object.keys(store)[i] ?? null,
+}
+Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock, writable: true })
+vi.mock('../utils/auth', () => ({ getAuthToken: () => null }))
+
+class MockWebSocket {
+  static OPEN = 1
+  static instances: MockWebSocket[] = []
+  url: string
+  readyState = 1
+  sent: string[] = []
+  onopen: (() => void) | null = null
+  onmessage: ((e: unknown) => void) | null = null
+  onclose: ((e?: unknown) => void) | null = null
+  onerror: ((e?: unknown) => void) | null = null
+  constructor(url: string) { this.url = url; MockWebSocket.instances.push(this) }
+  send(d: string) { this.sent.push(d) }
+  close() { this.readyState = 3 }
+}
+;(globalThis as unknown as { WebSocket: unknown }).WebSocket = MockWebSocket
+;(globalThis as unknown as { fetch: unknown }).fetch = vi.fn(async () => ({
+  ok: true,
+  status: 200,
+  json: async () => ({ status: 'ok' }),
+}))
+
+const {
+  reconcileReplayStart,
+  recordHistorySeq,
+  resetReplayReconcile,
+  noteLivePromptDuringReplay,
+  wasPromptLiveDuringReplay,
+  getReplayWindowDepth,
+  getLiveReplayLedgerSessionIds,
+  getHistoryCursor,
+  isRebuildInProgress,
+} = await import('@chroxy/store-core')
+const { useConnectionStore } = await import('./connection')
+const { resetReconnectAttempt } = await import('./message-handler')
+
+/** Open a connection and return the freshly constructed (current-attempt) socket. */
+async function openConnected(): Promise<MockWebSocket> {
+  const before = MockWebSocket.instances.length
+  useConnectionStore.getState().connect('wss://tunnel.example.com/ws', 'tok')
+  await vi.advanceTimersByTimeAsync(0)
+  const ws = MockWebSocket.instances[before]!
+  ws.readyState = 1
+  ws.onopen?.()
+  await vi.advanceTimersByTimeAsync(0)
+  useConnectionStore.setState({ connectionPhase: 'connected', userDisconnected: false })
+  return ws
+}
+
+/** Open a replay window for `s1` with one live question inside it. */
+function openReplayWindowWithRacer(): void {
+  reconcileReplayStart('s1', true, 0)
+  noteLivePromptDuringReplay('s1', 'live-q')
+  recordHistorySeq('s1', 42)
+  // Positive controls — the fixture took effect, so the assertions below are
+  // about the teardown and not about state that was never there.
+  expect(getReplayWindowDepth('s1')).toBe(1)
+  expect(wasPromptLiveDuringReplay('s1', 'live-q')).toBe(true)
+  expect(isRebuildInProgress('s1')).toBe(true)
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  MockWebSocket.instances = []
+  resetReconnectAttempt()
+  resetReplayReconcile({ clearCursors: true })
+  useConnectionStore.setState({ socket: null, connectionPhase: 'disconnected', userDisconnected: false })
+})
+
+afterEach(() => {
+  resetReplayReconcile({ clearCursors: true })
+  vi.useRealTimers()
+})
+
+describe('transport teardown releases the replay window + live-arrival ledger (#7456)', () => {
+  it('socket.onclose releases the window and ledger but keeps the history cursor', async () => {
+    const socket = await openConnected()
+    openReplayWindowWithRacer()
+
+    socket.onclose?.({ code: 1006 })
+
+    expect(getReplayWindowDepth('s1')).toBe(0)
+    expect(getLiveReplayLedgerSessionIds()).toEqual([])
+    expect(wasPromptLiveDuringReplay('s1', 'live-q')).toBe(false)
+    expect(isRebuildInProgress('s1')).toBe(false)
+    expect(getHistoryCursor('s1')).toBe(42)
+  })
+
+  it('socket.onerror releases the window and ledger but keeps the history cursor', async () => {
+    const socket = await openConnected()
+    openReplayWindowWithRacer()
+
+    socket.onerror?.()
+
+    expect(getReplayWindowDepth('s1')).toBe(0)
+    expect(getLiveReplayLedgerSessionIds()).toEqual([])
+    expect(wasPromptLiveDuringReplay('s1', 'live-q')).toBe(false)
+    expect(getHistoryCursor('s1')).toBe(42)
+  })
+
+  it('a stale socket close does not tear down the CURRENT attempt state', async () => {
+    const stale = await openConnected()
+    // A new attempt supersedes it (bumps the module-level attempt id).
+    await openConnected()
+    openReplayWindowWithRacer()
+
+    stale.onclose?.({ code: 1006 })
+
+    expect(getReplayWindowDepth('s1')).toBe(1)
+    expect(wasPromptLiveDuringReplay('s1', 'live-q')).toBe(true)
+  })
+})

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -2790,6 +2790,17 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       // CURRENT attempt's timer. (Idempotent if the handshake already completed.)
       clearHandshakeTimer();
 
+      // #7456 — the replay window and its live-arrival ledger are
+      // per-CONNECTION state, like the rebuild baseline: release them on the
+      // transport drop rather than waiting for the next `auth_ok`, which for a
+      // tab left open on a dead tunnel may never arrive. Load-bearing since
+      // #7455 made the window a refcount — a `history_replay_start` with no
+      // matching `_end` would otherwise strand a +1 and the window would never
+      // close again for that session. Cursors are deliberately KEPT (they are
+      // what makes the reconnect a delta replay, #5555.3).
+      resetReplayReconcile();
+
+
       // #3068: any in-flight evaluator request is now a guaranteed no-op —
       // reject them so awaiters get a fast error instead of waiting 60s for
       // the timeout to fire.
@@ -3021,6 +3032,17 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       // handshake timer so it can't also fire (scheduleReconnect's per-socket
       // dedupe would no-op the second one, but clearing keeps it tidy).
       clearHandshakeTimer();
+
+      // #7456 — the replay window and its live-arrival ledger are
+      // per-CONNECTION state, like the rebuild baseline: release them on the
+      // transport drop rather than waiting for the next `auth_ok`, which for a
+      // tab left open on a dead tunnel may never arrive. Load-bearing since
+      // #7455 made the window a refcount — a `history_replay_start` with no
+      // matching `_end` would otherwise strand a +1 and the window would never
+      // close again for that session. Cursors are deliberately KEPT (they are
+      // what makes the reconnect a delta replay, #5555.3).
+      resetReplayReconcile();
+
 
       // #3605: an unexpected error means any in-flight skill_trust_grant
       // request will never be acked. Clear both the Map-based correlation

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -2800,7 +2800,6 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       // what makes the reconnect a delta replay, #5555.3).
       resetReplayReconcile();
 
-
       // #3068: any in-flight evaluator request is now a guaranteed no-op —
       // reject them so awaiters get a fast error instead of waiting 60s for
       // the timeout to fire.
@@ -3042,7 +3041,6 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       // close again for that session. Cursors are deliberately KEPT (they are
       // what makes the reconnect a delta replay, #5555.3).
       resetReplayReconcile();
-
 
       // #3605: an unexpected error means any in-flight skill_trust_grant
       // request will never be acked. Clear both the Map-based correlation

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -57,7 +57,14 @@ import {
   MCP_SERVER_OP_PENDING_CAP,
 } from './message-handler'
 import { createEmptySessionState } from './utils'
-import { isLivePermissionPrompt, resetReplayReconcile } from '@chroxy/store-core'
+import {
+  isLivePermissionPrompt,
+  resetReplayReconcile,
+  wasPromptLiveDuringReplay,
+  getReplayWindowDepth,
+  getLiveReplayLedgerSessionIds,
+  createEmptyActivityState,
+} from '@chroxy/store-core'
 import type { ConnectionState } from './types'
 
 function createMockStore(initial: Partial<ConnectionState>) {
@@ -3919,6 +3926,87 @@ describe('dashboard message-handler dispatch', () => {
       handleMessage({ type: 'history_replay_end', sessionId: 's1' }, ctx() as any)
 
       expect(answeredOf()).toBe('(resolved)')
+    })
+
+    // #7455 — the server can have two replays of ONE session in flight at once:
+    // `subscribe_sessions` replays every newly-subscribed background session and
+    // `switch_session` calls `replayHistory(..., { forceFull: true })`
+    // unconditionally, so the wire order is start start end end. Before the
+    // window became a refcount the FIRST end closed it while replay #2 was
+    // still streaming, and every live question in that tail was stamped
+    // '(resolved)'.
+    it('protects a racer that arrives between the two ends of overlapping replays (#7455)', () => {
+      seedOne()
+      handleMessage({ type: 'history_replay_start', sessionId: 's1', fullHistory: true }, ctx() as any)
+      handleMessage({ type: 'history_replay_start', sessionId: 's1', fullHistory: true }, ctx() as any)
+      // A racer inside the OVERLAP...
+      handleMessage(question({ toolUseId: 'q-use-1' }) as any, ctx() as any)
+      handleMessage({ type: 'history_replay_end', sessionId: 's1' }, ctx() as any)
+      // ...and one in the TAIL, after end#1, while replay #2 is still
+      // streaming. The tail racer is the one the pre-#7455 Set lost.
+      handleMessage(question({ toolUseId: 'q-use-2' }) as any, ctx() as any)
+      handleMessage({ type: 'history_replay_end', sessionId: 's1' }, ctx() as any)
+
+      // A racer arriving BEFORE the second start is deliberately not covered
+      // here: `_rebuildBaseline` has the same non-refcount shape and the second
+      // start overwrites it, so end#1's atomic swap slices that racer out of
+      // `messages` entirely. That is a separate defect in the same file, filed
+      // as #7477 — the ledger protects the message, the swap then drops it.
+      //
+      // Positive control: both questions really are in the store, so the
+      // `undefined` assertions are about the sweep, not a missing fixture.
+      expect((store.getState() as any).sessionStates.s1.messages).toHaveLength(2)
+      expect(answeredOf(0)).toBeUndefined()
+      expect(answeredOf(1)).toBeUndefined()
+      expect(getReplayWindowDepth('s1')).toBe(0)
+    })
+
+    // #7456 — the store drops a session's messages wholesale on prune and on
+    // timeout; module state here used to survive both with nothing left to
+    // correspond to.
+    it('session_timeout drops the session live-arrival ledger (#7456)', () => {
+      seedOne()
+      handleMessage({ type: 'history_replay_start', sessionId: 's1', fullHistory: false }, ctx() as any)
+      handleMessage(question() as any, ctx() as any)
+      const liveId = (store.getState() as any).sessionStates.s1.messages[0].id
+      expect(wasPromptLiveDuringReplay('s1', liveId)).toBe(true)
+
+      handleMessage(
+        { type: 'session_timeout', sessionId: 's1', name: 'S1', idleMs: 600000 } as any,
+        ctx() as any,
+      )
+
+      expect(wasPromptLiveDuringReplay('s1', liveId)).toBe(false)
+      expect(getReplayWindowDepth('s1')).toBe(0)
+      expect(getLiveReplayLedgerSessionIds()).not.toContain('s1')
+    })
+
+    it('a session_list prune drops the pruned session live-arrival ledger (#7456)', () => {
+      store = createMockStore(
+        baseState({
+          activeSessionId: 's1',
+          sessions: [{ sessionId: 's1', name: 'S1' } as any, { sessionId: 's2', name: 'S2' } as any],
+          sessionStates: { s1: createEmptySessionState(), s2: createEmptySessionState() },
+          // The prune path also walks the Control Room activity tree (#5163),
+          // which `baseState` leaves undefined because no other session_list
+          // test in this file removes a session.
+          activity: createEmptyActivityState(),
+        }),
+      )
+      setStore(store)
+
+      handleMessage({ type: 'history_replay_start', sessionId: 's1', fullHistory: false }, ctx() as any)
+      handleMessage(question() as any, ctx() as any)
+      const liveId = (store.getState() as any).sessionStates.s1.messages[0].id
+      expect(wasPromptLiveDuringReplay('s1', liveId)).toBe(true)
+
+      // s1 dropped out of the authoritative list.
+      handleMessage({ type: 'session_list', sessions: [{ sessionId: 's2', name: 'S2' }] } as any, ctx() as any)
+
+      expect((store.getState() as any).sessionStates).not.toHaveProperty('s1')
+      expect(wasPromptLiveDuringReplay('s1', liveId)).toBe(false)
+      expect(getReplayWindowDepth('s1')).toBe(0)
+      expect(getLiveReplayLedgerSessionIds()).not.toContain('s1')
     })
   })
 

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -3961,6 +3961,26 @@ describe('dashboard message-handler dispatch', () => {
       expect(getReplayWindowDepth('s1')).toBe(0)
     })
 
+    // The 0→1-only ledger clear, pinned at the integration level. Two DELTA
+    // starts, so `_rebuildBaseline` is never set and nothing is swapped — which
+    // is why this shape works where the full-rebuild one cannot: with two full
+    // starts, end#1 slices a racer that pre-dates start#2 out of `messages`
+    // entirely (#7477), so the assertion could never be reached. Overlapping
+    // pure-delta replays are not the common wire shape (the connect handshake
+    // replays the active session with a cursor; `subscribe_sessions`,
+    // `switch_session` and `request_full_history` all force full), so this
+    // guards the logic rather than reproducing a production sequence.
+    it('a racer before the second DELTA start stays protected', () => {
+      seedOne()
+      handleMessage({ type: 'history_replay_start', sessionId: 's1', fullHistory: false }, ctx() as any)
+      handleMessage(question({ toolUseId: 'q-use-0' }) as any, ctx() as any)
+      handleMessage({ type: 'history_replay_start', sessionId: 's1', fullHistory: false }, ctx() as any)
+      handleMessage({ type: 'history_replay_end', sessionId: 's1' }, ctx() as any)
+      handleMessage({ type: 'history_replay_end', sessionId: 's1' }, ctx() as any)
+      expect((store.getState() as any).sessionStates.s1.messages).toHaveLength(1)
+      expect(answeredOf(0)).toBeUndefined()
+    })
+
     // #7456 — the store drops a session's messages wholesale on prune and on
     // timeout; module state here used to survive both with nothing left to
     // correspond to.

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -59,6 +59,10 @@ import {
   recordHistorySeq,
   reconcileReplayStart,
   reconcileReplayEnd,
+  // #7456 — per-session teardown for the two paths that drop a session's store
+  // state wholesale; without it this module's per-session entries outlive
+  // everything they correspond to.
+  dropReplaySessionState,
   // #7420 — the shared `history_replay_end` unanswered-prompt sweep. Both
   // clients carried byte-identical copies of the predicate through #7410/#7419;
   // it now has one implementation, which is also where the live-arrival ledger
@@ -4700,6 +4704,11 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       // GC persisted messages for sessions that dropped out of the list
       for (const prevId of removedIds) {
         void clearPersistedSession(prevId);
+        // #7456 — and the store-core replay state keyed to the same id. The
+        // prune drops `sessionStates[prevId]` and its persisted messages just
+        // below, so a retained replay window / live-arrival ledger would refer
+        // to nothing at all.
+        dropReplaySessionState(prevId);
       }
       // Batch in-memory cleanup into a single state update
       if (removedIds.length > 0) {
@@ -6234,6 +6243,8 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         set(patch);
         // Garbage-collect persisted messages for the deleted session (#797)
         void clearPersistedSession(timeoutSessionId);
+        // #7456 — same for the store-core replay window / live-arrival ledger.
+        dropReplaySessionState(timeoutSessionId);
       }
       break;
     }

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -78,6 +78,13 @@ export {
   wasPromptLiveDuringReplay,
   sweepUnansweredPromptsAtReplayEnd,
   REPLAY_RESOLVED_PLACEHOLDER,
+  // #7455 — the replay window is a REFCOUNT so two overlapping replays of one
+  // session compose; #7456 — per-session teardown for the `session_list` prune
+  // and `session_timeout` paths, plus the diagnostics both are asserted on.
+  getReplayWindowDepth,
+  getLiveReplayLedgerSessionIds,
+  dropReplaySessionState,
+  MAX_LIVE_REPLAY_LEDGERS,
 } from './replay-reconcile'
 
 export type {

--- a/packages/store-core/src/replay-reconcile.test.ts
+++ b/packages/store-core/src/replay-reconcile.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import {
   resetReplayReconcile,
   recordHistorySeq,
@@ -12,6 +12,10 @@ import {
   wasPromptLiveDuringReplay,
   sweepUnansweredPromptsAtReplayEnd,
   REPLAY_RESOLVED_PLACEHOLDER,
+  getReplayWindowDepth,
+  getLiveReplayLedgerSessionIds,
+  dropReplaySessionState,
+  MAX_LIVE_REPLAY_LEDGERS,
 } from './replay-reconcile'
 
 type Msg = { id: string }
@@ -353,5 +357,251 @@ describe('replay-end unanswered-prompt sweep (#7380 / #7410 / #7420)', () => {
       noteLivePromptDuringReplay('s1', 'q2')
       expect(wasPromptLiveDuringReplay('s1', 'q2')).toBe(false)
     })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// #7455 — overlapping replays of ONE session
+// ---------------------------------------------------------------------------
+//
+// The server can have two replays of the same session in flight at once, and
+// neither caller checks: `subscribe_sessions` replays every newly-subscribed
+// background session (session-handlers.js), and `switch_session` calls
+// `replayHistory(ws, targetId, { forceFull: true })` UNCONDITIONALLY — including
+// for a session the client already subscribed to. `replayHistory` chunks 20
+// entries at a time over `setImmediate` with back-pressure pauses, so replay #1
+// is still streaming when the user taps into the session and starts replay #2.
+// Wire order: start(X) … start(X) … end(X) … end(X).
+//
+// With membership (a Set) rather than a refcount that sequence loses the #7420
+// protection in the tail: start#2 discards start#1's evidence, and end#1 closes
+// the window while replay #2 is still streaming, so every live question between
+// end#1 and end#2 falls through the `noteLivePromptDuringReplay` gate and is
+// stamped '(resolved)' by end#2's sweep — the exact bug #7420 fixed.
+describe('overlapping replays of one session (#7455)', () => {
+  it('keeps the window open until the LAST end — a racer after end#1 is still protected', () => {
+    // The reviewer's reproduction, verbatim: start, start, note, end, note, end.
+    reconcileReplayStart('s1', true, 0) // subscribe_sessions (forceFull)
+    reconcileReplayStart('s1', true, 0) // switch_session (forceFull), replay #1 still streaming
+    noteLivePromptDuringReplay('s1', 'q1')
+    reconcileReplayEnd('s1', [])
+    noteLivePromptDuringReplay('s1', 'q2')
+    reconcileReplayEnd('s1', [])
+
+    // Positive controls: both fixtures took effect, so the "unstamped" below is
+    // about the ledger and not about a note that never landed.
+    expect(wasPromptLiveDuringReplay('s1', 'q1')).toBe(true)
+    expect(wasPromptLiveDuringReplay('s1', 'q2')).toBe(true)
+
+    // A genuinely replayed prompt is still stamped, so this is not a vacuous
+    // "the sweep did nothing" pass.
+    expect(
+      sweepUnansweredPromptsAtReplayEnd('s1', [prompt('replayed-q'), prompt('q1'), prompt('q2')]),
+    ).toEqual([
+      { id: 'replayed-q', type: 'prompt', answered: REPLAY_RESOLVED_PLACEHOLDER },
+      { id: 'q1', type: 'prompt' },
+      { id: 'q2', type: 'prompt' },
+    ])
+  })
+
+  it('a nested start does NOT discard the still-open outer window ledger', () => {
+    reconcileReplayStart('s1', false, 0)
+    noteLivePromptDuringReplay('s1', 'q0')
+    expect(wasPromptLiveDuringReplay('s1', 'q0')).toBe(true)
+    // Replay #2 starts while #1 is in flight: the outer window is still
+    // protecting q0, so its evidence must survive.
+    reconcileReplayStart('s1', true, 0)
+    expect(wasPromptLiveDuringReplay('s1', 'q0')).toBe(true)
+  })
+
+  it('refcounts the window: depth climbs per start and returns to 0 on balanced ends', () => {
+    expect(getReplayWindowDepth('s1')).toBe(0)
+    reconcileReplayStart('s1', false, 0)
+    expect(getReplayWindowDepth('s1')).toBe(1)
+    reconcileReplayStart('s1', false, 0)
+    expect(getReplayWindowDepth('s1')).toBe(2)
+    reconcileReplayEnd('s1', [])
+    expect(getReplayWindowDepth('s1')).toBe(1)
+    reconcileReplayEnd('s1', [])
+    expect(getReplayWindowDepth('s1')).toBe(0)
+  })
+
+  it('is per-session — s2 starting a replay does not hold s1 window open', () => {
+    reconcileReplayStart('s1', false, 0)
+    reconcileReplayStart('s2', false, 0)
+    reconcileReplayEnd('s1', [])
+    expect(getReplayWindowDepth('s1')).toBe(0)
+    expect(getReplayWindowDepth('s2')).toBe(1)
+    noteLivePromptDuringReplay('s1', 'after-q')
+    expect(wasPromptLiveDuringReplay('s1', 'after-q')).toBe(false)
+  })
+
+  it('an unmatched end cannot drive the depth negative (a later start still opens once)', () => {
+    reconcileReplayEnd('s1', [])
+    expect(getReplayWindowDepth('s1')).toBe(0)
+    reconcileReplayStart('s1', false, 0)
+    expect(getReplayWindowDepth('s1')).toBe(1)
+    reconcileReplayEnd('s1', [])
+    expect(getReplayWindowDepth('s1')).toBe(0)
+    noteLivePromptDuringReplay('s1', 'q1')
+    expect(wasPromptLiveDuringReplay('s1', 'q1')).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// #7456 — ledger lifetime: release at replay end, teardown, and a loud cap
+// ---------------------------------------------------------------------------
+describe('live-arrival ledger lifetime (#7456)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('releases the per-session ledger when the LAST window closes, while the sweep can still read it', () => {
+    reconcileReplayStart('s1', false, 0)
+    noteLivePromptDuringReplay('s1', 'q1')
+    expect(getLiveReplayLedgerSessionIds()).toEqual(['s1'])
+
+    reconcileReplayEnd('s1', [])
+    // The caller runs the sweep immediately after `reconcileReplayEnd` returns,
+    // so the evidence must still be readable...
+    expect(wasPromptLiveDuringReplay('s1', 'q1')).toBe(true)
+    expect(sweepUnansweredPromptsAtReplayEnd('s1', [prompt('q1')])).toBeNull()
+    // ...but it is no longer RETAINED per-session: nothing accumulates for a
+    // session that is replayed once and then pruned.
+    expect(getLiveReplayLedgerSessionIds()).toEqual([])
+  })
+
+  it('does not release while an overlapping replay is still open (#7455 interaction)', () => {
+    reconcileReplayStart('s1', false, 0)
+    reconcileReplayStart('s1', false, 0)
+    noteLivePromptDuringReplay('s1', 'q1')
+    reconcileReplayEnd('s1', [])
+    expect(getLiveReplayLedgerSessionIds()).toEqual(['s1'])
+    reconcileReplayEnd('s1', [])
+    expect(getLiveReplayLedgerSessionIds()).toEqual([])
+  })
+
+  it('dropReplaySessionState forgets one session entirely and leaves the others alone', () => {
+    reconcileReplayStart('s1', true, 3)
+    noteLivePromptDuringReplay('s1', 'q1')
+    recordHistorySeq('s1', 11)
+    reconcileReplayStart('s2', true, 0)
+    noteLivePromptDuringReplay('s2', 'q2')
+    recordHistorySeq('s2', 22)
+
+    dropReplaySessionState('s1')
+
+    expect(getReplayWindowDepth('s1')).toBe(0)
+    expect(getLiveReplayLedgerSessionIds()).toEqual(['s2'])
+    expect(wasPromptLiveDuringReplay('s1', 'q1')).toBe(false)
+    expect(isRebuildInProgress('s1')).toBe(false)
+    expect(getHistoryCursor('s1')).toBeUndefined()
+    // s2 untouched.
+    expect(getReplayWindowDepth('s2')).toBe(1)
+    expect(wasPromptLiveDuringReplay('s2', 'q2')).toBe(true)
+    expect(isRebuildInProgress('s2')).toBe(true)
+    expect(getHistoryCursor('s2')).toBe(22)
+  })
+
+  it('dropReplaySessionState also drops a ledger already released to the sweep', () => {
+    reconcileReplayStart('s1', false, 0)
+    noteLivePromptDuringReplay('s1', 'q1')
+    reconcileReplayEnd('s1', [])
+    expect(wasPromptLiveDuringReplay('s1', 'q1')).toBe(true)
+    dropReplaySessionState('s1')
+    expect(wasPromptLiveDuringReplay('s1', 'q1')).toBe(false)
+  })
+
+  it('ignores a null/empty session id', () => {
+    reconcileReplayStart('s1', false, 0)
+    noteLivePromptDuringReplay('s1', 'q1')
+    dropReplaySessionState(null)
+    dropReplaySessionState('')
+    dropReplaySessionState(undefined)
+    expect(wasPromptLiveDuringReplay('s1', 'q1')).toBe(true)
+  })
+
+  // The socket-drop leak. A drop mid-replay means `history_replay_end` never
+  // arrives, so with a refcounted window the stranded +1 would keep the session
+  // permanently "in replay": its ledger would never be released and every later
+  // prompt would be protected forever. Both clients now call
+  // `resetReplayReconcile()` from `socket.onclose`/`socket.onerror`.
+  it('a drop mid-replay strands nothing once the transport teardown runs', () => {
+    reconcileReplayStart('s1', true, 0)
+    noteLivePromptDuringReplay('s1', 'q1')
+    recordHistorySeq('s1', 5)
+
+    resetReplayReconcile() // socket.onclose / socket.onerror
+
+    expect(getReplayWindowDepth('s1')).toBe(0)
+    expect(getLiveReplayLedgerSessionIds()).toEqual([])
+    expect(wasPromptLiveDuringReplay('s1', 'q1')).toBe(false)
+    expect(isRebuildInProgress('s1')).toBe(false)
+    // Cursors are NOT transport state — they are what makes the reconnect a
+    // delta replay instead of a full rebuild.
+    expect(getHistoryCursor('s1')).toBe(5)
+
+    // ...and the #7420 protection still works on the NEXT replay.
+    reconcileReplayStart('s1', false, 0)
+    noteLivePromptDuringReplay('s1', 'q2')
+    reconcileReplayEnd('s1', [])
+    expect(
+      sweepUnansweredPromptsAtReplayEnd('s1', [prompt('q1'), prompt('q2')]),
+    ).toEqual([
+      { id: 'q1', type: 'prompt', answered: REPLAY_RESOLVED_PLACEHOLDER },
+      { id: 'q2', type: 'prompt' },
+    ])
+  })
+
+  it('caps the ledger map and says so LOUDLY — never a silent truncation', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    // One open window with one live question per session, one past the cap.
+    for (let i = 0; i < MAX_LIVE_REPLAY_LEDGERS + 1; i++) {
+      const sid = `s${i}`
+      reconcileReplayStart(sid, false, 0)
+      noteLivePromptDuringReplay(sid, `q-${i}`)
+    }
+    expect(getLiveReplayLedgerSessionIds()).toHaveLength(MAX_LIVE_REPLAY_LEDGERS)
+    // LRU: the least-recently-noted session is the one evicted, never the
+    // just-touched one.
+    expect(getLiveReplayLedgerSessionIds()).not.toContain('s0')
+    expect(getLiveReplayLedgerSessionIds()).toContain(`s${MAX_LIVE_REPLAY_LEDGERS}`)
+    expect(wasPromptLiveDuringReplay('s0', 'q-0')).toBe(false)
+
+    // The log names the module, the cap, the evicted session AND the
+    // consequence — an evicted ledger un-protects a racing AskUserQuestion.
+    expect(warn).toHaveBeenCalledTimes(1)
+    const line = String(warn.mock.calls[0]?.[0])
+    expect(line).toContain('[replay-reconcile]')
+    expect(line).toContain(String(MAX_LIVE_REPLAY_LEDGERS))
+    expect(line).toContain('s0')
+    expect(line).toContain('#7456')
+    expect(line).toContain(REPLAY_RESOLVED_PLACEHOLDER)
+  })
+
+  it('re-noting an existing session refreshes its recency so it is not the one evicted', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    for (let i = 0; i < MAX_LIVE_REPLAY_LEDGERS; i++) {
+      reconcileReplayStart(`s${i}`, false, 0)
+      noteLivePromptDuringReplay(`s${i}`, `q-${i}`)
+    }
+    // Touch the oldest so it moves to the tail...
+    noteLivePromptDuringReplay('s0', 'q-0-again')
+    // ...then overflow by one: s1 (now the oldest) goes, s0 stays.
+    reconcileReplayStart('overflow', false, 0)
+    noteLivePromptDuringReplay('overflow', 'q-overflow')
+
+    expect(getLiveReplayLedgerSessionIds()).toContain('s0')
+    expect(getLiveReplayLedgerSessionIds()).not.toContain('s1')
+    expect(wasPromptLiveDuringReplay('s0', 'q-0')).toBe(true)
+  })
+
+  it('the cap does not fire in the normal case (no warn for a single session)', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    reconcileReplayStart('s1', false, 0)
+    noteLivePromptDuringReplay('s1', 'q1')
+    noteLivePromptDuringReplay('s1', 'q2')
+    reconcileReplayEnd('s1', [])
+    expect(warn).not.toHaveBeenCalled()
   })
 })

--- a/packages/store-core/src/replay-reconcile.test.ts
+++ b/packages/store-core/src/replay-reconcile.test.ts
@@ -567,6 +567,12 @@ describe('live-arrival ledger lifetime (#7456)', () => {
     expect(getLiveReplayLedgerSessionIds()).not.toContain('s0')
     expect(getLiveReplayLedgerSessionIds()).toContain(`s${MAX_LIVE_REPLAY_LEDGERS}`)
     expect(wasPromptLiveDuringReplay('s0', 'q-0')).toBe(false)
+    // ...and the consequence the warn text claims, demonstrated rather than
+    // implied: the evicted session's question is now stampable again.
+    reconcileReplayEnd('s0', [])
+    expect(sweepUnansweredPromptsAtReplayEnd('s0', [prompt('q-0')])).toEqual([
+      { id: 'q-0', type: 'prompt', answered: REPLAY_RESOLVED_PLACEHOLDER },
+    ])
 
     // The log names the module, the cap, the evicted session AND the
     // consequence — an evicted ledger un-protects a racing AskUserQuestion.

--- a/packages/store-core/src/replay-reconcile.ts
+++ b/packages/store-core/src/replay-reconcile.ts
@@ -169,16 +169,20 @@ let _sweepableLedger: { sessionId: string; ids: Set<string> } | null = null
 const MAX_CLIENT_HISTORY_CURSORS = 64
 
 /**
- * Defensive cap on the number of sessions holding an OPEN-window live-arrival
- * ledger (#7456), in the same shape as the cursor cap above.
+ * Defensive cap on `_liveDuringReplay`, in the same shape as the cursor cap
+ * above (#7456).
  *
- * Reaching it needs this many replay windows open at once, each having taken a
- * live `user_question` — `subscribe_sessions` does replay every background
- * session, so it is reachable, but it is not a shape the product produces on
- * purpose. Eviction therefore logs LOUDLY: dropping a ledger un-protects the
- * questions it held, so the next sweep stamps them '(resolved)' and destroys
- * those answer paths. A silent truncation here would be indistinguishable from
- * the #7420 bug itself.
+ * It is ONE-DIMENSIONAL, and deliberately so: it bounds the number of SESSION
+ * KEYS — how many sessions may hold an open-window ledger at once — and puts no
+ * bound on the `Set<string>` of ids inside any one of them. The unbounded axis
+ * is the negligible one: a session blocks on one `AskUserQuestion` at a time,
+ * so a realistic window holds 0–1 ids, whereas `subscribe_sessions` replays
+ * every background session and so can open many windows at once. Read this as
+ * a cap on the key count, not as a complete bound on the map's size.
+ *
+ * Eviction logs LOUDLY: dropping a ledger un-protects the questions it held, so
+ * the next sweep stamps them '(resolved)' and destroys those answer paths. A
+ * silent truncation here would be indistinguishable from the #7420 bug itself.
  */
 export const MAX_LIVE_REPLAY_LEDGERS = 64
 

--- a/packages/store-core/src/replay-reconcile.ts
+++ b/packages/store-core/src/replay-reconcile.ts
@@ -73,15 +73,36 @@ const _rebuildBaseline = new Map<string, number>()
 const _historyCursors = new Map<string, number>()
 
 /**
- * Per-session "a replay window is open right now" marker (#7420).
+ * Per-session replay-window REFCOUNT — how many replays are in flight for that
+ * session right now (#7420, refcounted by #7455). Absent key ⇒ 0 ⇒ no window.
  *
  * Deliberately NOT `_rebuildBaseline`: that map only holds FULL rebuilds, and a
  * live prompt can race a DELTA replay just as easily (the server chunks both
  * over `setImmediate`, with back-pressure pauses of up to 30s — ws-history.js).
- * Added at `reconcileReplayStart` for either kind, removed at
+ * Incremented at `reconcileReplayStart` for either kind, decremented at
  * `reconcileReplayEnd`.
+ *
+ * A COUNT and not membership, because the server can have two replays of ONE
+ * session in flight at once and neither caller checks (#7455):
+ * `subscribe_sessions` replays every newly-subscribed background session, and
+ * `switch_session` calls `replayHistory(ws, id, { forceFull: true })`
+ * unconditionally — including for a session the client is already subscribed
+ * to. `replayHistory` chunks 20 entries at a time over `setImmediate` with
+ * back-pressure pauses, so the wire order is `start(X) start(X) end(X) end(X)`.
+ * With a Set the FIRST end closed the window while replay #2 was still
+ * streaming, and every live `user_question` in that tail fell through the gate
+ * in {@link noteLivePromptDuringReplay} and was stamped '(resolved)' by the
+ * second end's sweep — #7420 again, in the one case the gate exists for.
+ *
+ * (`_rebuildBaseline` has the same non-refcount shape, pre-existing since
+ * #5555.4, and is left alone here to keep this change to the window. It is NOT
+ * benign: #7455 assumed overlapping full rebuilds only mis-slice the deferred
+ * swap, but the second start overwrites the baseline and the first end then
+ * slices a message appended BETWEEN the two starts straight out of the store.
+ * Filed with a reproduction as #7477 — the ledger protects that racer and the
+ * swap then drops it, so the two fixes compose rather than overlap.)
  */
-const _replayWindowOpen = new Set<string>()
+const _replayWindowOpen = new Map<string, number>()
 
 /**
  * Per-session ids of `prompt` ChatMessages that arrived LIVE — i.e. were NOT
@@ -101,15 +122,41 @@ const _replayWindowOpen = new Set<string>()
  * (ws-history.js) and a live broadcast never carries one. So the call site
  * records the id here as the message is appended, and the sweep skips it.
  *
- * Lifetime is exactly one replay window: the set is dropped at the NEXT
- * `reconcileReplayStart` for that session (anything already on screen when a
- * window opens pre-dates it and stays stampable) and by `resetReplayReconcile`.
- * That also bounds it — the entries are a subset of the ChatMessages the store
- * is already holding for the same window — so it needs no cap of its own, and
- * it leaves {@link sweepUnansweredPromptsAtReplayEnd} a pure read, with no
- * ordering hazard against the caller that consumes it.
+ * Lifetime is exactly one replay window, and this map holds a session only
+ * while that window is OPEN (#7456): the ledger is created on the first live
+ * arrival, dropped at the NEXT `reconcileReplayStart` for that session
+ * (anything already on screen when a window opens pre-dates it and stays
+ * stampable), and RELEASED when the last window closes — handed to
+ * {@link _sweepableLedger} so the caller's
+ * {@link sweepUnansweredPromptsAtReplayEnd}, which runs on the next statement
+ * after `reconcileReplayEnd` returns, can still read it. Both stay a pure read,
+ * with no ordering hazard against that caller.
+ *
+ * The claim this comment used to carry — that the store's own message retention
+ * bounds the map, so it needs no cap — was wrong (#7456). The store drops a
+ * session's `messages` wholesale on prune (`session_list` reconcile) and on
+ * `session_timeout`, and neither path touches module state here; and
+ * `dispatchUserQuestion` records into the ledger BEFORE its
+ * `adapter.hasSession` check, so a session the store holds nothing for can
+ * still open a key. What actually bounds it: the release above, the per-session
+ * {@link dropReplaySessionState} both clients call from those two prune paths,
+ * `resetReplayReconcile` on transport teardown and fresh auth — and,
+ * defensively and loudly, {@link MAX_LIVE_REPLAY_LEDGERS}.
  */
 const _liveDuringReplay = new Map<string, Set<string>>()
+
+/**
+ * The ONE just-closed window's ledger, released out of `_liveDuringReplay` at
+ * `reconcileReplayEnd` and held only until its caller's sweep reads it (#7456).
+ *
+ * A single slot, not a map: the sweep runs synchronously on the statement after
+ * `reconcileReplayEnd` in both clients, so at most one closed window is ever
+ * awaiting one. It is overwritten by the next replay end for ANY session,
+ * cleared by a fresh start for the same session, by `dropReplaySessionState`
+ * and by `resetReplayReconcile` — bounded to one entry by construction, with
+ * nothing to cap.
+ */
+let _sweepableLedger: { sessionId: string; ids: Set<string> } | null = null
 
 /**
  * Client-side cap on the per-session cursor map. Mirrors the server's
@@ -120,6 +167,20 @@ const _liveDuringReplay = new Map<string, Set<string>>()
  * always within the honoured window.
  */
 const MAX_CLIENT_HISTORY_CURSORS = 64
+
+/**
+ * Defensive cap on the number of sessions holding an OPEN-window live-arrival
+ * ledger (#7456), in the same shape as the cursor cap above.
+ *
+ * Reaching it needs this many replay windows open at once, each having taken a
+ * live `user_question` — `subscribe_sessions` does replay every background
+ * session, so it is reachable, but it is not a shape the product produces on
+ * purpose. Eviction therefore logs LOUDLY: dropping a ledger un-protects the
+ * questions it held, so the next sweep stamps them '(resolved)' and destroys
+ * those answer paths. A silent truncation here would be indistinguishable from
+ * the #7420 bug itself.
+ */
+export const MAX_LIVE_REPLAY_LEDGERS = 64
 
 /**
  * Reset all replay-reconcile state. Called on fresh auth / hard reset so a new
@@ -133,6 +194,7 @@ export function resetReplayReconcile(opts: { clearCursors?: boolean } = {}): voi
   // like the baseline, never a cursor: a fresh auth must not inherit either.
   _replayWindowOpen.clear()
   _liveDuringReplay.clear()
+  _sweepableLedger = null
   if (opts.clearCursors) _historyCursors.clear()
 }
 
@@ -201,11 +263,20 @@ export function reconcileReplayStart(
   _latestSeq?: unknown,
 ): { rebuildInProgress: boolean } {
   if (!sessionId) return { rebuildInProgress: false }
-  // #7420 — open the window for BOTH replay kinds, and drop the previous
-  // window's live-arrival ids: every prompt already on screen pre-dates this
-  // replay, so nothing about it is vouched for by this window.
-  _replayWindowOpen.add(sessionId)
-  _liveDuringReplay.delete(sessionId)
+  // #7420 — open the window for BOTH replay kinds. #7455 — as a REFCOUNT, so
+  // two overlapping replays of one session compose instead of the first `end`
+  // closing the window out from under the second.
+  const depth = (_replayWindowOpen.get(sessionId) ?? 0) + 1
+  _replayWindowOpen.set(sessionId, depth)
+  if (depth === 1) {
+    // 0→1 ONLY — a genuinely new window. Drop the previous window's
+    // live-arrival ids: every prompt already on screen pre-dates this replay,
+    // so nothing about it is vouched for by this window. A NESTED start
+    // (depth > 1) must NOT do this — the outer window is still open and still
+    // protecting what it recorded (#7455).
+    _liveDuringReplay.delete(sessionId)
+    if (_sweepableLedger?.sessionId === sessionId) _sweepableLedger = null
+  }
   if (fullHistory) {
     _rebuildBaseline.set(sessionId, Math.max(0, currentLen | 0))
     return { rebuildInProgress: true }
@@ -256,10 +327,10 @@ export function reconcileReplayEnd(
     recordHistorySeq(sessionId, latestSeq)
   }
   // #7420 — close the window BEFORE the delta-replay early return below, so a
-  // delta replay's window closes too. The live-arrival ids themselves are left
-  // in place for `sweepUnansweredPromptsAtReplayEnd`, which the caller runs
-  // after this; they are dropped at the next start / on reset.
-  if (sessionId) _replayWindowOpen.delete(sessionId)
+  // delta replay's window closes too. The live-arrival ids themselves stay
+  // readable for `sweepUnansweredPromptsAtReplayEnd`, which the caller runs
+  // after this — see `closeReplayWindow`.
+  if (sessionId) closeReplayWindow(sessionId)
   if (!sessionId || !_rebuildBaseline.has(sessionId)) {
     return { swappedMessages: null }
   }
@@ -309,13 +380,105 @@ export function noteLivePromptDuringReplay(
   messageId: string | null | undefined,
 ): void {
   if (!sessionId || !messageId) return
-  if (!_replayWindowOpen.has(sessionId)) return
-  let ids = _liveDuringReplay.get(sessionId)
-  if (!ids) {
-    ids = new Set<string>()
-    _liveDuringReplay.set(sessionId, ids)
-  }
+  if (!isReplayWindowOpen(sessionId)) return
+  const existing = _liveDuringReplay.get(sessionId)
+  const ids = existing ?? new Set<string>()
+  // LRU-by-update, like `_historyCursors`: delete-then-set so the touched
+  // session moves to the Map tail and is never the key the cap evicts. A plain
+  // `.set` on an existing key keeps its old slot.
+  if (existing) _liveDuringReplay.delete(sessionId)
+  _liveDuringReplay.set(sessionId, ids)
   ids.add(messageId)
+  while (_liveDuringReplay.size > MAX_LIVE_REPLAY_LEDGERS) {
+    const oldest = _liveDuringReplay.keys().next().value
+    if (oldest === undefined) break
+    _liveDuringReplay.delete(oldest)
+    // LOUD, never silent (#7456). An evicted ledger un-protects every question
+    // it held, so the next `history_replay_end` sweep stamps them and destroys
+    // those answer paths. If this ever fires in the wild, the cap is wrong.
+    console.warn(
+      `[replay-reconcile] live-question ledger cap of ${MAX_LIVE_REPLAY_LEDGERS} exceeded — ` +
+        `evicted session "${oldest}" (#7456). A live AskUserQuestion that raced that ` +
+        `session's replay may now be stamped '${REPLAY_RESOLVED_PLACEHOLDER}'.`,
+    )
+  }
+}
+
+/** Is a replay window open for this session (refcount > 0)? */
+function isReplayWindowOpen(sessionId: string): boolean {
+  return (_replayWindowOpen.get(sessionId) ?? 0) > 0
+}
+
+/**
+ * Decrement the window refcount and, when the LAST window closes, release the
+ * session's live-arrival ledger out of `_liveDuringReplay` (#7455 / #7456).
+ *
+ * The released ids move to the single-slot `_sweepableLedger` rather than being
+ * dropped, because the caller runs `sweepUnansweredPromptsAtReplayEnd` for this
+ * same session on the very next statement — the sweep stays a pure, repeatable
+ * read, and nothing is retained per-session for a session that is replayed once
+ * and then pruned.
+ */
+function closeReplayWindow(sessionId: string): void {
+  const depth = _replayWindowOpen.get(sessionId) ?? 0
+  if (depth > 1) {
+    _replayWindowOpen.set(sessionId, depth - 1)
+    return
+  }
+  _replayWindowOpen.delete(sessionId)
+  const ids = _liveDuringReplay.get(sessionId)
+  _liveDuringReplay.delete(sessionId)
+  _sweepableLedger = ids && ids.size > 0 ? { sessionId, ids } : null
+}
+
+/**
+ * The live-arrival ids in force for this session: the open window's ledger, or
+ * the just-closed window's released one while its sweep is still pending.
+ */
+function ledgerFor(sessionId: string): ReadonlySet<string> | undefined {
+  const open = _liveDuringReplay.get(sessionId)
+  if (open) return open
+  return _sweepableLedger?.sessionId === sessionId ? _sweepableLedger.ids : undefined
+}
+
+/**
+ * How many replays are in flight for this session (0 ⇒ no window open).
+ * Testing / diagnostics — the refcount is what #7455 turned the window into,
+ * and a leaked non-zero depth is the failure that teardown must prevent.
+ */
+export function getReplayWindowDepth(sessionId: string | null | undefined): number {
+  if (!sessionId) return 0
+  return _replayWindowOpen.get(sessionId) ?? 0
+}
+
+/**
+ * Session ids currently RETAINED in the live-arrival ledger map, in LRU order
+ * (oldest first). Testing / diagnostics: the leak in #7456 is precisely an
+ * entry that stays here after its session's last replay.
+ */
+export function getLiveReplayLedgerSessionIds(): string[] {
+  return [..._liveDuringReplay.keys()]
+}
+
+/**
+ * Forget ALL replay-reconcile state for one session (#7456).
+ *
+ * Called by both clients wherever the store itself drops a session wholesale —
+ * the `session_list` prune and `session_timeout` — because those paths already
+ * clear `sessionStates` and the persisted messages, and used to leave this
+ * module's per-session entries behind with nothing left to correspond to.
+ *
+ * Unlike `resetReplayReconcile`, this DOES drop the session's history cursor:
+ * the session is gone server-side, so a cursor for it can only ever be dead
+ * weight in the next `auth` payload.
+ */
+export function dropReplaySessionState(sessionId: string | null | undefined): void {
+  if (!sessionId) return
+  _rebuildBaseline.delete(sessionId)
+  _replayWindowOpen.delete(sessionId)
+  _liveDuringReplay.delete(sessionId)
+  _historyCursors.delete(sessionId)
+  if (_sweepableLedger?.sessionId === sessionId) _sweepableLedger = null
 }
 
 /** Was this prompt recorded as a live arrival during the current window? */
@@ -324,7 +487,7 @@ export function wasPromptLiveDuringReplay(
   messageId: string | null | undefined,
 ): boolean {
   if (!sessionId || !messageId) return false
-  return _liveDuringReplay.get(sessionId)?.has(messageId) === true
+  return ledgerFor(sessionId)?.has(messageId) === true
 }
 
 /**
@@ -362,7 +525,7 @@ export function sweepUnansweredPromptsAtReplayEnd<T extends SweepablePrompt>(
   messages: readonly T[],
 ): T[] | null {
   if (!sessionId) return null
-  const live = _liveDuringReplay.get(sessionId)
+  const live = ledgerFor(sessionId)
   const isStampable = (m: T): boolean =>
     m.type === 'prompt' && !m.answered && !m.requestId && !(live?.has(m.id) === true)
   if (!messages.some(isStampable)) return null


### PR DESCRIPTION
Two lifecycle defects in `packages/store-core/src/replay-reconcile.ts`, both filed from the same review of PR #7453 (the #7420 live-vs-replayed AskUserQuestion discriminator). They live in the same collections and are fixed together.

Closes #7455

Closes #7456

---

## Defect 1 (#7455) — overlapping replays of one session re-open #7420 in the tail

`_replayWindowOpen` was a `Set`: membership, not a count. The server can have **two replays of one session in flight at once** and neither caller checks — `subscribe_sessions` replays every newly-subscribed background session (`session-handlers.js:469`) and `switch_session` calls `replayHistory(ws, id, { forceFull: true })` unconditionally (`:78`) — while `replayHistory` chunks 20 entries at a time over `setImmediate` with back-pressure pauses. Wire order: `start(X) start(X) end(X) end(X)`.

With a Set:

1. `start#2` ran `_liveDuringReplay.delete(X)`, destroying the still-open outer window's evidence.
2. `end#1` closed the window while replay #2 was still streaming.
3. Every live `user_question` between `end#1` and `end#2` fell through the `if (!_replayWindowOpen.has(id)) return` gate.
4. `end#2` swept with an empty ledger and stamped `answered: '(resolved)'` on them — **the exact bug #7420 fixed**, in the one case the gate exists for.

**Fix shape.** The window is a `Map<sessionId, number>` refcount: `+1` at `reconcileReplayStart`, `-1` at `reconcileReplayEnd`, open while `> 0`. The ledger is dropped on the **0→1 transition only**, so a second *sequential* replay still forgets the previous window (unchanged, still tested) while a *nested* start leaves the outer window's ids alone.

## Defect 2 (#7456) — the ledger had no release, no cap and no teardown

Three of the module's four per-session collections were released; `_liveDuringReplay` was not. It was dropped only by the *next* `reconcileReplayStart` for the same id, or by a whole-module `resetReplayReconcile` — and `resetReplayReconcile` had exactly one production caller on each client, `auth_ok`. Neither `socket.onclose` nor `socket.onerror` called it.

The comment's bounding argument was also wrong: it claimed the store's own message retention bounds the map, but the store drops a session's `messages` wholesale on the `session_list` prune and on `session_timeout` without touching module state, and `dispatchUserQuestion` records into the ledger *before* its `adapter.hasSession` check.

**Fix shape**, all three parts:

- **Release at replay end.** The map now holds a session only while its window is OPEN. When the last window closes, the ids move to a single-slot handoff (`_sweepableLedger`) that `sweepUnansweredPromptsAtReplayEnd` reads on the very next statement — the sweep stays a pure, repeatable read (no consuming read, no ordering hazard) and nothing is retained per-session afterwards. One slot, overwritten by the next replay end anywhere: bounded by construction.
- **Teardown.** New `dropReplaySessionState(sessionId)` export, called from the `session_list` prune and `session_timeout` handlers in **both** clients beside the `clearPersistedSession(id)` they already ran; it also drops the history cursor, since `removedIds` means the session is gone server-side. And `resetReplayReconcile()` now runs from `socket.onclose` / `socket.onerror` on both clients, after the stale-socket guard. Cursors are deliberately kept — they are what makes the reconnect a delta replay (#5555.3).
- **A cap that is never silent.** `MAX_LIVE_REPLAY_LEDGERS = 64`, LRU-evicting like the cursor map, with a `console.warn` naming the module, the cap, the evicted session and the consequence (an evicted ledger un-protects its questions, so the next sweep stamps them). The log text is pinned by a test.

The refcount makes the transport teardown load-bearing rather than tidy: a `history_replay_start` with no matching `_end` strands a `+1`, so every later end decrements from a too-high base and the window never closes again for that session.

## Red-first evidence

Every behaviour was proven failing before its fix.

| Behaviour | Red evidence |
|---|---|
| #7455 interleave (`start start note end note end`) | `AssertionError: expected false to be true` in `replay-reconcile.test.ts` — `q2` (the tail racer) was never recorded |
| #7455 nested start wipes the outer ledger | `AssertionError: expected false to be true` — `q0` gone after `start#2` |
| #7456 `session_timeout` leaks the ledger (app) | `expected true to be false` at `wasPromptLiveDuringReplay` |
| #7456 `session_list` prune leaks the ledger (app) | `expected true to be false` |
| #7456 `session_timeout` / prune leak the ledger (dashboard) | `expected true to be false` (×2) |
| #7456 `socket.onclose` / `onerror` leak the window (app) | `expected 1 to be +0` at `getReplayWindowDepth` (×2) |
| #7456 `socket.onclose` / `onerror` leak the window (dashboard) | `expected 1 to be +0` (×2) |

Each connection-teardown suite also carries a **negative control** — a stale socket's close must NOT tear down the current attempt's state — which passed before and after, so the fix is the guarded reset and not a blunt one.

## Mutation evidence

Every mutant was applied to the fixed tree, grep-verified as landed, and restored from a byte backup.

| # | Mutation | Killed by |
|---|---|---|
| M1 | window back to membership (`depth = 1`, unconditional delete at end) | store-core ×4, app ×1, dashboard ×1 |
| M2 | ledger destroyed on every start (`depth >= 1`) | store-core ×1 (the nested-start test), dashboard ×1 |
| M3a | `dropReplaySessionState` calls removed from the app | app ×2 |
| M3b | `dropReplaySessionState` calls removed from the dashboard | dashboard ×2 |
| M4 | `resetReplayReconcile()` removed from `onclose`/`onerror`, both clients | app ×2, dashboard ×2 |
| M5 | cap truncates silently (`console.warn` deleted) | store-core ×1 |
| M6 | no release at replay end (ledger left in the per-session map) | store-core ×2 |
| M7 | release at end but no handoff to the sweep | store-core ×6 **including two pre-existing #7420 tests**, app ×4 — this is the proof the release does not break the sweep's read |

M2's client row was added on review. The client suites as first written could not catch it, but the reason is narrower than "by design": the obvious variant (racer *before* `start#2`) cannot be written with two **full** starts, because end#1 slices that racer out of `messages` entirely — that is #7477, not the ledger. With two **delta** starts `_rebuildBaseline` is never set, nothing is swapped, and the test works. It is green clean and red under M2 with `AssertionError: expected '(resolved)' to be undefined`. Overlapping pure-delta replays are not the common wire shape (the connect handshake replays the active session with a cursor; `subscribe_sessions`, `switch_session` and `request_full_history` all force full), so it guards the logic rather than reproducing a production sequence.

## Suite table (bare exit codes, log-redirected)

| Suite | Command | Exit | Result |
|---|---|---|---|
| store-core | `npx vitest run` | `0` | 60 files, 2203 tests |
| store-core typecheck | `npm run typecheck` | `0` | clean |
| app store | `npx jest src/__tests__/store --coverage=false` | `0` | 35 suites, 737 tests |
| app typecheck | `npx tsc --noEmit` | `0` | clean |
| dashboard store | `npx vitest run src/store/` | `0` | 84 files, 1199 tests |
| dashboard typecheck | `npx tsc --noEmit` | `0` | clean |

Existing #7420 / #5555.3 / #5555.4 / #5588 assertions are untouched and green — none was wrong, and the "forgets the previous window at the next start" test in particular still pins that a second *sequential* replay drops the previous ledger.

## Follow-on filed

**#7477** — the new interleave test surfaced a third defect in the same file. `_rebuildBaseline` has the identical non-refcount shape, and #7455 assumed its overlap is "a cosmetic mis-swap". It is not: `start#2` overwrites the baseline and `end#1` then slices a message appended **between the two starts** straight out of `sessionStates[id].messages`. Reproduced standalone (no client, no ledger) and filed rather than folded in, so this PR stays on the window; the module comment and both client tests point at it.
